### PR TITLE
vault: add support for namespaces

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -48,8 +48,9 @@ type serverConfig struct {
 		} `toml:"fs" yaml:"fs"`
 
 		Vault struct {
-			Addr string `toml:"address" yaml:"address"`
-			Name string `toml:"name" yaml:"name"`
+			Addr      string `toml:"address" yaml:"address"`
+			Name      string `toml:"name" yaml:"name"`
+			Namespace string `toml:"namespace" yaml:"namespace"`
 
 			AppRole struct {
 				ID     string        `toml:"id" yaml:"id"`

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -168,8 +168,9 @@ func server(args []string) error {
 		}
 	case config.KeyStore.Vault.Addr != "":
 		vaultStore := &vault.KeyStore{
-			Addr:     config.KeyStore.Vault.Addr,
-			Location: config.KeyStore.Vault.Name,
+			Addr:      config.KeyStore.Vault.Addr,
+			Location:  config.KeyStore.Vault.Name,
+			Namespace: config.KeyStore.Vault.Namespace,
 			AppRole: vault.AppRole{
 				ID:     config.KeyStore.Vault.AppRole.ID,
 				Secret: config.KeyStore.Vault.AppRole.Secret,

--- a/server-config.toml
+++ b/server-config.toml
@@ -101,8 +101,9 @@ path = "" # Path to your key store
 # at Vault's key-value backend. For more information see:
 # https://www.vaultproject.io/api/secret/kv/kv-v1.html
 [keystore.vault]
-address = "" # The Vault endpoint - e.g. https://127.0.0.1:8200
-name = ""    # An optional K/V prefix. The server will store keys under /kv/name/... 
+address   = ""  # The Vault endpoint - e.g. https://127.0.0.1:8200
+name      = ""  # An optional K/V prefix. The server will store keys under /kv/name/... 
+namespace = ""  # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
 
 # Vault AppRole access credentials.
 # See: https://www.vaultproject.io/docs/auth/approle.html 

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -108,8 +108,9 @@ keystore:
   # at Vault's key-value backend. For more information see:
   # https://www.vaultproject.io/api/secret/kv/kv-v1.html
   vault:
-    address: "" # The Vault endpoint - e.g. https://127.0.0.1:8200
-    name: ""    # An optional K/V prefix. The server will store keys under /kv/name/... 
+    address: ""   # The Vault endpoint - e.g. https://127.0.0.1:8200
+    name: ""      # An optional K/V prefix. The server will store keys under /kv/name/... 
+    namespace: "" # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
     approle:    # AppRole credentials. See: https://www.vaultproject.io/docs/auth/approle.html
       id: ""      # Your AppRole Role ID
       secret: ""  # Your AppRole Secret ID

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -96,6 +96,14 @@ type KeyStore struct {
 	// host's root CA set is used.
 	CAPath string
 
+	// The Vault namespace used to separate and isolate different
+	// organizations / tenants at the same Vault instance. If
+	// non-empty, the Vault client will send the
+	//   X-Vault-Namespace: Namespace
+	// HTTP header on each request. For more information see:
+	// https://www.vaultproject.io/docs/enterprise/namespaces/index.html
+	Namespace string
+
 	cache cache.Cache
 	once  uint32
 
@@ -132,6 +140,14 @@ func (store *KeyStore) Authenticate(context context.Context) error {
 	if err != nil {
 		return err
 	}
+	if store.Namespace != "" {
+		// We must only set the namespace if it is not
+		// empty. If namespace == "" the vault client
+		// will send an empty namespace HTTP header -
+		// which is not what we want.
+		client.SetNamespace(store.Namespace)
+	}
+
 	store.client = client
 
 	status, err := store.client.Sys().Health()


### PR DESCRIPTION
This commit adds support for Vault namespaces.
A Vault namespace allows separating / isolating
multiple tenants or organisations.

See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
for more information.