### PR TITLE
add basic support for audit logging

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -1,0 +1,121 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// SystemLog groups a set of logging targets.
+// It holds a reference to a *log.Logger which
+// gets updated whenever a log target gets added
+// or removed.
+// Since this can happen concurrently, it is not
+// recommended to set the log output of SystemLog.Logger()
+// manually. Instead, modify the *log.Logger output
+// through the SystemLog API.
+type SystemLog struct {
+	lock   sync.Mutex
+	output []io.Writer
+	logger *log.Logger
+}
+
+// NewLogger creates a new SystemLog. The out variable sets the
+// destination to which log data will be written. The prefix
+// appears at the beginning of each generated log line. The
+// flag argument defines the logging properties.
+func NewLogger(out io.Writer, prefix string, flags int) *SystemLog {
+	logger := &SystemLog{
+		output: []io.Writer{out},
+	}
+	logger.logger = log.New(io.MultiWriter(logger.output...), prefix, flags)
+	return logger
+}
+
+// SetOutput sets the output destination for the logger.
+func (l *SystemLog) SetOutput(out ...io.Writer) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.output = make([]io.Writer, len(out))
+	copy(l.output, out)
+	l.logger.SetOutput(io.MultiWriter(l.output...))
+}
+
+// AddOutput adds an output destination to the logger.
+func (l *SystemLog) AddOutput(out io.Writer) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.output = append(l.output, out)
+	l.logger.SetOutput(io.MultiWriter(l.output...))
+}
+
+// RemoveOutput removes the output destination from the
+// logger, if it exists.
+func (l *SystemLog) RemoveOutput(out io.Writer) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	var output = make([]io.Writer, 0, len(l.output))
+	for i := range l.output {
+		if out != l.output[i] {
+			output = append(output, l.output[i])
+		}
+	}
+	l.output = output
+	l.logger.SetOutput(io.MultiWriter(output...))
+}
+
+// Log returns the actual logger that writes everything
+// to the currently specified output destination.
+func (l *SystemLog) Log() *log.Logger { return l.logger }
+
+var _ http.ResponseWriter = (*auditResponseWriter)(nil)
+var _ http.Flusher = (*auditResponseWriter)(nil)
+
+// auditResponseWriter is an http.ResponseWriter implementation
+// that logs (parts of) the request and response before sending
+// the status code back to the client.
+type auditResponseWriter struct {
+	http.ResponseWriter
+
+	URL           url.URL     // The request URL
+	Identity      Identity    // The request X.509 identity
+	RequestHeader http.Header // The request headers
+
+	logger  *log.Logger
+	written bool // Set to true on first write
+}
+
+func (w *auditResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+func (w *auditResponseWriter) WriteHeader(statusCode int) {
+	const format = `{"time":"%s","request":{"path":"%s","identity":"%s"},"response":{"code":%d}}`
+	w.logger.Printf(format, time.Now().Format(time.RFC3339), w.URL.Path, w.Identity, statusCode)
+
+	w.ResponseWriter.WriteHeader(statusCode)
+	w.written = true
+}
+
+func (w *auditResponseWriter) Write(b []byte) (int, error) {
+	if !w.written {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *auditResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -40,6 +40,9 @@ type serverConfig struct {
 		Error struct {
 			Files []string `toml:"file" yaml:"file"`
 		} `toml:"error" yaml:"error"`
+		Audit struct {
+			Files []string `toml:"file" yaml:"file"`
+		} `toml:"audit" yaml:"audit"`
 	} `toml:"log" yaml:"log"`
 
 	KeyStore struct {

--- a/server-config.toml
+++ b/server-config.toml
@@ -74,15 +74,35 @@ unused = "30s"
 # Log configuration. In general, the server distinguishes
 # between (operational) errors and audit events. Therefore,
 # there are separate error and audit logs.
-#
-# Errors:
-# The server can log error events to files and you can specify
-# multiple log files. The server will write each error event to
-# each log file. 
-# If no log file (path) is specified the server will log errors
-# to stderr.
 [log]
-error.file = [ ] # Add one or more log file paths here.
+
+# Error log. The server can log error events to one or multiple
+# log files. If one or multiple log files already exist, the 
+# server will truncate them. If no log file (path) is specified
+# the server will log errors to stderr.
+[error]
+file = [ "" ] # Add one or more log file paths here.
+
+# Audit log. The server can log audit events to one or multiple
+# log files. Each audit event is a JSON object representing a
+# request-response pair that contains the time, client identity, the
+# API path, HTTP response status code etc.
+# {
+#   "time": "2006-01-02T15:04:05Z07:00",
+#   "request": {
+#     "path":     "/v1/key/create/my-app-key",
+#     "identity": "4067503933d4a78358f908a2df7ec14e554c612acf8a9d1aa29b7da4aa018ec9",
+#   },
+#   "response": {
+#     "status": 200
+#   }
+# }
+# The server will write such an audit log entry for every HTTP
+# request-response pair - including invalid requests. If no audit
+# file (path) is specifed the server will not log audit events.
+# In contrast to error log, audit logging has to be enabled explicitly.
+[audit]
+file = [ "" ] # Add one or more log file paths here
 
 # Key stores configuration. A key store holds secret keys.
 # A server can only be configured to use one key store at

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -80,16 +80,35 @@ cache:
 # Log configuration. In general, the server distinguishes
 # between (operational) errors and audit events. Therefore,
 # there are separate error and audit logs.
-#
-# Errors:
-# The server can log error events to files and you can specify
-# multiple log files. The server will write each error event to
-# each log file. 
-# If no log file (path) is specified the server will log errors
-# to stderr.
 log:
+  # Error log. The server can log error events to one or multiple
+  # log files. If one or multiple log files already exist, the
+  # server will truncate them. If no log file (path) is specified
+  # the server will log errors to stderr.
   error:
     file:
+    - ""  # Add one or more log file paths here.
+  
+  # Audit log. The server can log audit events to one or multiple
+  # log files. Each audit event is a JSON object representing a
+  # request-response pair that contains the time, client identity, the
+  # API path, HTTP response status code etc.
+  # {
+  #   "time": "2006-01-02T15:04:05Z07:00",
+  #   "request": {
+  #     "path":     "/v1/key/create/my-app-key",
+  #     "identity": "4067503933d4a78358f908a2df7ec14e554c612acf8a9d1aa29b7da4aa018ec9",
+  #   },
+  #   "response": {
+  #     "status": 200
+  #   }
+  # }
+  # The server will write such an audit log entry for every HTTP
+  # request-response pair - including invalid requests. If no audit
+  # file (path) is specifed the server will not log audit events.
+  # In contrast to error log, audit logging has to be enabled explicitly.
+  audit:
+    file:  
     - ""  # Add one or more log file paths here.
 
 # Key stores configuration. A key store holds secret keys.


### PR DESCRIPTION
This commit adds basic support for logging
audit events to files.

Therefore, it adds a new `SystemLog` type
that allows attaching and detaching log targets
(files, sockets, http connections, etc.) to
a `log.Logger`.

Now, we can dynamically add and remove log targets
to the currently configured logger. This is in service
for dynamically inspecting and at/detaching to logging -
which will be added in the future. This commit paves
the path for this.

The audit log itself is just a `http.HandlerFunc`
that extracts some "interesting" request parameters
(API path, X.509 identity, ...) and logs them together
with the response before writing back to the client.

At the moment the log contains the current time,
request API path, client identity and response status
code. However, this can be extended in the future.
So, the current audit log implementation is just a MVP.

For testing this just set the audit log file to `/dev/stdout` (on linux - mac may work as well?!)
and start a server. You should see a JSON object printed whenever you make a request
(that reaches the server's HTTP stack).