### PR TITLE
improve API path validation

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -187,7 +188,7 @@ func (c *Client) ReadPolicy(name string) (*Policy, error) {
 }
 
 func (c *Client) ListPolicies(pattern string) ([]string, error) {
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/v1/policy/list/%s", c.addr, pattern))
+	resp, err := c.httpClient.Get(fmt.Sprintf("%s/v1/policy/list/%s", c.addr, url.PathEscape(pattern)))
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (c *Client) AssignIdentity(policy string, id Identity) error {
 }
 
 func (c *Client) ListIdentities(pattern string) (map[Identity]string, error) {
-	resp, err := c.httpClient.Get(fmt.Sprintf("%s/v1/identity/list/%s", c.addr, pattern))
+	resp, err := c.httpClient.Get(fmt.Sprintf("%s/v1/identity/list/%s", c.addr, url.PathEscape(pattern)))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -229,19 +229,19 @@ func server(args []string) error {
 
 	const maxBody = 1 << 20
 	mux := http.NewServeMux()
-	mux.Handle("/v1/key/create/", kes.RequireMethod(http.MethodPost, kes.LimitPathSegments(4, kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleCreateKey(store))))))
-	mux.Handle("/v1/key/delete/", kes.RequireMethod(http.MethodDelete, kes.LimitPathSegments(4, kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleDeleteKey(store))))))
-	mux.Handle("/v1/key/generate/", kes.RequireMethod(http.MethodPost, kes.LimitPathSegments(4, kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleGenerateKey(store))))))
-	mux.Handle("/v1/key/decrypt/", kes.RequireMethod(http.MethodPost, kes.LimitPathSegments(4, kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleDecryptKey(store))))))
+	mux.Handle("/v1/key/create/", kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/create/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleCreateKey(store))))))
+	mux.Handle("/v1/key/delete/", kes.RequireMethod(http.MethodDelete, kes.ValidatePath("/v1/key/delete/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleDeleteKey(store))))))
+	mux.Handle("/v1/key/generate/", kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/generate/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleGenerateKey(store))))))
+	mux.Handle("/v1/key/decrypt/", kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/decrypt/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleDecryptKey(store))))))
 
-	mux.Handle("/v1/policy/write/", kes.RequireMethod(http.MethodPost, kes.LimitPathSegments(4, kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleWritePolicy(roles))))))
-	mux.Handle("/v1/policy/read/", kes.RequireMethod(http.MethodGet, kes.LimitPathSegments(4, kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleReadPolicy(roles))))))
-	mux.Handle("/v1/policy/list/", kes.RequireMethod(http.MethodGet, kes.LimitPathSegments(4, kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleListPolicies(roles))))))
-	mux.Handle("/v1/policy/delete/", kes.RequireMethod(http.MethodDelete, kes.LimitPathSegments(4, kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleDeletePolicy(roles))))))
+	mux.Handle("/v1/policy/write/", kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/policy/write/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleWritePolicy(roles))))))
+	mux.Handle("/v1/policy/read/", kes.RequireMethod(http.MethodGet, kes.ValidatePath("/v1/policy/read/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleReadPolicy(roles))))))
+	mux.Handle("/v1/policy/list/", kes.RequireMethod(http.MethodGet, kes.ValidatePath("/v1/policy/list/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleListPolicies(roles))))))
+	mux.Handle("/v1/policy/delete/", kes.RequireMethod(http.MethodDelete, kes.ValidatePath("/v1/policy/delete/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleDeletePolicy(roles))))))
 
-	mux.Handle("/v1/identity/assign/", kes.RequireMethod(http.MethodPost, kes.LimitPathSegments(5, kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleAssignIdentity(roles))))))
-	mux.Handle("/v1/identity/list/", kes.RequireMethod(http.MethodGet, kes.LimitPathSegments(4, kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleListIdentities(roles))))))
-	mux.Handle("/v1/identity/forget/", kes.RequireMethod(http.MethodDelete, kes.LimitPathSegments(4, kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleForgetIdentity(roles))))))
+	mux.Handle("/v1/identity/assign/", kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/identity/assign/*/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleAssignIdentity(roles))))))
+	mux.Handle("/v1/identity/list/", kes.RequireMethod(http.MethodGet, kes.ValidatePath("/v1/identity/list/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleListIdentities(roles))))))
+	mux.Handle("/v1/identity/forget/", kes.RequireMethod(http.MethodDelete, kes.ValidatePath("/v1/identity/forget/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleForgetIdentity(roles))))))
 
 	server := http.Server{
 		Addr:    addr,

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+var validatePathHandlerTests = []struct {
+	Pattern     string
+	Path        string
+	ShouldMatch bool
+}{
+	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key", ShouldMatch: true},                      // 0
+	{Pattern: "/v1/key/delete/*", Path: "/v1/key/delete/my-key", ShouldMatch: true},                      // 1
+	{Pattern: "/v1/key/generate/*", Path: "/v1/key/generate/my-key", ShouldMatch: true},                  // 2
+	{Pattern: "/v1/key/decrypt/*", Path: "/v1/key/decrypt/my-key", ShouldMatch: true},                    // 3
+	{Pattern: "/v1/policy/write/*", Path: "/v1/policy/write/my-policy", ShouldMatch: true},               // 4
+	{Pattern: "/v1/policy/read/*", Path: "/v1/policy/read/my-policy", ShouldMatch: true},                 // 5
+	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/my-policy", ShouldMatch: true},                 // 6
+	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/*", ShouldMatch: true},                         // 7
+	{Pattern: "/v1/policy/delete/*", Path: "/v1/policy/delete/my-policy", ShouldMatch: true},             // 8
+	{Pattern: "/v1/identity/assign/*/*", Path: "/v1/identity/assign/af43c/my-policy", ShouldMatch: true}, // 9
+	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/af43c", ShouldMatch: true},                 // 10
+	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/*", ShouldMatch: true},                     // 11
+	{Pattern: "/v1/identity/forget/*", Path: "/v1/identity/forget/af43c", ShouldMatch: true},             // 12
+
+	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key/..", ShouldMatch: false},   // 13
+	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/../my-key", ShouldMatch: false},   // 14
+	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/my-key", ShouldMatch: false},      // 15
+	{Pattern: "/v1/key/generate/*", Path: "/v1/key/create/my-key/x", ShouldMatch: false},  // 16
+	{Pattern: "/v1/key/create/[a-z]", Path: "/v1/key/create/my-key0", ShouldMatch: false}, // 17
+	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/./*/../a", ShouldMatch: false},    // 18
+}
+
+func TestValidatePathHandler(t *testing.T) {
+	const baseURL = "https://localhost:7373"
+	var f = func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusOK) }
+
+	for i, test := range validatePathHandlerTests {
+		req, err := http.NewRequest(http.MethodGet, baseURL+test.Path, nil)
+		if err != nil {
+			t.Fatalf("Test %d: failed to create request URL: %v", i, err)
+		}
+
+		var resp dummyResponseWriter
+		ValidatePath(test.Pattern, f)(&resp, req)
+		if test.ShouldMatch && resp.StatusCode != http.StatusOK {
+			t.Fatalf("Test %d: path should have matched pattern: got %d - want %d", i, resp.StatusCode, http.StatusOK)
+		}
+		if !test.ShouldMatch && resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("Test %d: path should not have matched pattern: got %d - want %d", i, resp.StatusCode, http.StatusBadRequest)
+		}
+	}
+}
+
+var (
+	_ http.ResponseWriter = (*dummyResponseWriter)(nil)
+	_ http.Flusher        = (*dummyResponseWriter)(nil)
+)
+
+// dummyResponseWriter is a helper type to test
+// HTTP handler functions.
+type dummyResponseWriter struct {
+	Headers    http.Header
+	StatusCode int
+	Body       bytes.Buffer
+
+	written bool
+}
+
+func (d *dummyResponseWriter) Header() http.Header {
+	if d.Headers == nil {
+		d.Headers = make(http.Header)
+	}
+	return d.Headers
+}
+
+func (d *dummyResponseWriter) WriteHeader(statusCode int) {
+	if !d.written {
+		d.StatusCode = statusCode
+		d.written = true
+	}
+}
+
+func (d *dummyResponseWriter) Write(p []byte) (int, error) {
+	if !d.written {
+		d.WriteHeader(http.StatusOK)
+	}
+	return d.Body.Write(p)
+}
+func (d *dummyResponseWriter) Flush() {}


### PR DESCRIPTION
This commit improves the validation of
the request URL path. Now, the `ValidatePath`
handler function accepts a API path pattern
and tries to match the request URL path against
this pattern.
Only if the URL path matches that pattern the
request gets handled. Otherwise, we return 400
(bad request) to the client.

This simplifies adding new (more complex) APIs and
makes it easier to think about security implications
(See: directory traversal a.o.).