### PR TITLE
fix incorrect identity assignment during startup

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -223,7 +223,9 @@ func server(args []string) error {
 			if roles.IsAssigned(identity) {
 				return fmt.Errorf("Cannot assign policy '%s' to identity '%s': this identity already has a policy", name, identity)
 			}
-			roles.Assign(name, identity)
+			if identity != kes.IdentityUnknown {
+				roles.Assign(name, identity)
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit fixes a bug in the identity<->policy
assignment during the server startup.

Now, the server does not assign a policy to the
unknown identity (empty string). Instead, such
policy<->identity mappings are ignored.

The previous behavior was not correct but also
not a security issue since the unknown identity
is always rejected by the server when doing a policy
lookup.