### PR TITLE
split /v1/key/create API into create and import

### DIFF
--- a/cmd/kes/create.go
+++ b/cmd/kes/create.go
@@ -56,8 +56,14 @@ func createKey(args []string) error {
 		Certificates:       certificates,
 	})
 
-	if err := client.CreateKey(name, bytes); err != nil {
-		return fmt.Errorf("Failed to create %s: %v", name, err)
+	if len(bytes) > 0 {
+		if err = client.ImportKey(name, bytes); err != nil {
+			return fmt.Errorf("Failed to import %s: %v", name, err)
+		}
+	} else {
+		if err = client.CreateKey(name); err != nil {
+			return fmt.Errorf("Failed to create %s: %v", name, err)
+		}
 	}
 	return nil
 }

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -252,7 +252,8 @@ func server(args []string) error {
 
 	const maxBody = 1 << 20
 	mux := http.NewServeMux()
-	mux.Handle("/v1/key/create/", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/create/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleCreateKey(store)))))))
+	mux.Handle("/v1/key/create/", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/create/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleCreateKey(store)))))))
+	mux.Handle("/v1/key/import/", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/import/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleImportKey(store)))))))
 	mux.Handle("/v1/key/delete/", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodDelete, kes.ValidatePath("/v1/key/delete/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleDeleteKey(store)))))))
 	mux.Handle("/v1/key/generate/", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/generate/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleGenerateKey(store)))))))
 	mux.Handle("/v1/key/decrypt/", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodPost, kes.ValidatePath("/v1/key/decrypt/*", kes.LimitRequestBody(maxBody, kes.EnforcePolicies(roles, kes.HandleDecryptKey(store)))))))

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,25 +16,26 @@ var validatePathHandlerTests = []struct {
 	ShouldMatch bool
 }{
 	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key", ShouldMatch: true},                      // 0
-	{Pattern: "/v1/key/delete/*", Path: "/v1/key/delete/my-key", ShouldMatch: true},                      // 1
-	{Pattern: "/v1/key/generate/*", Path: "/v1/key/generate/my-key", ShouldMatch: true},                  // 2
-	{Pattern: "/v1/key/decrypt/*", Path: "/v1/key/decrypt/my-key", ShouldMatch: true},                    // 3
-	{Pattern: "/v1/policy/write/*", Path: "/v1/policy/write/my-policy", ShouldMatch: true},               // 4
-	{Pattern: "/v1/policy/read/*", Path: "/v1/policy/read/my-policy", ShouldMatch: true},                 // 5
-	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/my-policy", ShouldMatch: true},                 // 6
-	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/*", ShouldMatch: true},                         // 7
-	{Pattern: "/v1/policy/delete/*", Path: "/v1/policy/delete/my-policy", ShouldMatch: true},             // 8
-	{Pattern: "/v1/identity/assign/*/*", Path: "/v1/identity/assign/af43c/my-policy", ShouldMatch: true}, // 9
-	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/af43c", ShouldMatch: true},                 // 10
-	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/*", ShouldMatch: true},                     // 11
-	{Pattern: "/v1/identity/forget/*", Path: "/v1/identity/forget/af43c", ShouldMatch: true},             // 12
+	{Pattern: "/v1/key/import/*", Path: "/v1/key/import/my-key", ShouldMatch: true},                      // 1
+	{Pattern: "/v1/key/delete/*", Path: "/v1/key/delete/my-key", ShouldMatch: true},                      // 2
+	{Pattern: "/v1/key/generate/*", Path: "/v1/key/generate/my-key", ShouldMatch: true},                  // 3
+	{Pattern: "/v1/key/decrypt/*", Path: "/v1/key/decrypt/my-key", ShouldMatch: true},                    // 4
+	{Pattern: "/v1/policy/write/*", Path: "/v1/policy/write/my-policy", ShouldMatch: true},               // 5
+	{Pattern: "/v1/policy/read/*", Path: "/v1/policy/read/my-policy", ShouldMatch: true},                 // 6
+	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/my-policy", ShouldMatch: true},                 // 7
+	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/*", ShouldMatch: true},                         // 8
+	{Pattern: "/v1/policy/delete/*", Path: "/v1/policy/delete/my-policy", ShouldMatch: true},             // 9
+	{Pattern: "/v1/identity/assign/*/*", Path: "/v1/identity/assign/af43c/my-policy", ShouldMatch: true}, // 10
+	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/af43c", ShouldMatch: true},                 // 11
+	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/*", ShouldMatch: true},                     // 12
+	{Pattern: "/v1/identity/forget/*", Path: "/v1/identity/forget/af43c", ShouldMatch: true},             // 13
 
-	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key/..", ShouldMatch: false},   // 13
-	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/../my-key", ShouldMatch: false},   // 14
-	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/my-key", ShouldMatch: false},      // 15
-	{Pattern: "/v1/key/generate/*", Path: "/v1/key/create/my-key/x", ShouldMatch: false},  // 16
-	{Pattern: "/v1/key/create/[a-z]", Path: "/v1/key/create/my-key0", ShouldMatch: false}, // 17
-	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/./*/../a", ShouldMatch: false},    // 18
+	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key/..", ShouldMatch: false},   // 14
+	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/../my-key", ShouldMatch: false},   // 15
+	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/my-key", ShouldMatch: false},      // 16
+	{Pattern: "/v1/key/generate/*", Path: "/v1/key/create/my-key/x", ShouldMatch: false},  // 17
+	{Pattern: "/v1/key/create/[a-z]", Path: "/v1/key/create/my-key0", ShouldMatch: false}, // 18
+	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/./*/../a", ShouldMatch: false},    // 19
 }
 
 func TestValidatePathHandler(t *testing.T) {


### PR DESCRIPTION
This commit splits the `/v1/key/create` API into
two separate APIs:
 - `/v1/key/create`
 - `/v1/key/import`

The reason for this API separation is that some
applications may be allowed to create keys - e.g.
a new secret key on their first startup. However,
this applications should probably not be allowed
to specify the secret key itself.

An application that can specify the secret key itself
may be a security issue since it does not necessarily
need the KES server to perform cryptographic operations
with this key.

Therefore, applications should only have the `v1/key/create`
permission (if required) but not the `/v1/key/import` permission.

However, the `/v1/key/import` API may be useful when migrating
from one backend store to another (e.g. from Vault to AWS and vice
versa).

**This is an API-breaking change** - However:
 - We have not committed to a stable API, yet.
 - Most applications that use the `/v1/key/create`
   API will not send any request body (secret key)
   since they don't want to create the key themself.
 - I'm not aware of any client using this API in a way
   such that this change would break them at the moment.
 - The CLI interface will handle the server API separation
   transparently.