### PR TITLE
implement audit log tracing

### DIFF
--- a/client.go
+++ b/client.go
@@ -287,6 +287,21 @@ func (c *Client) ForgetIdentity(id Identity) error {
 	return nil
 }
 
+func (c *Client) TraceAuditLog() (io.ReadCloser, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/log/audit/trace", c.addr), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseErrorResponse(resp)
+	}
+	return resp.Body, nil
+}
+
 func (c *Client) parseErrorResponse(resp *http.Response) error {
 	if resp.Body == nil {
 		return nil

--- a/cmd/kes/audit.go
+++ b/cmd/kes/audit.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/minio/kes"
+)
+
+const auditCmdUsage = `usage: %s <command>
+
+    trace              Trace the audit log output.
+
+  -h, --help           Show list of command-line options.
+`
+
+func audit(args []string) error {
+	cli := flag.NewFlagSet(args[0], flag.ExitOnError)
+	cli.Usage = func() {
+		fmt.Fprintf(cli.Output(), auditCmdUsage, cli.Name())
+	}
+
+	cli.Parse(args[1:])
+	if args = cli.Args(); len(args) == 0 {
+		cli.Usage()
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "trace":
+		return auditTrace(args)
+	default:
+		cli.Usage()
+		os.Exit(2)
+		return nil // for the compiler
+	}
+}
+
+const auditTraceCmdUsage = `Trace and print audit log events.
+
+Connects to a KES server as audit log device and print an audit
+log event for each request/response pair processed by the server.
+It will print the audit log events as readable text representation
+when writing to a tty. Otherwise it will print events as
+line-separated JSON (nd-json)
+
+usage: %s [flags]
+
+  --json               Print audit log events as JSON.
+
+  -k, --insecure       Skip X.509 certificate validation during TLS handshake.
+
+  -h, --help           Show list of command-line options.
+`
+
+func auditTrace(args []string) error {
+	cli := flag.NewFlagSet(args[0], flag.ExitOnError)
+	cli.Usage = func() {
+		fmt.Fprintf(cli.Output(), auditTraceCmdUsage, cli.Name())
+	}
+
+	var jsonOutput bool
+	var insecureSkipVerify bool
+	cli.BoolVar(&jsonOutput, "json", false, "Print audit log events as JSON")
+	cli.BoolVar(&insecureSkipVerify, "k", false, "Skip X.509 certificate validation during TLS handshake")
+	cli.BoolVar(&insecureSkipVerify, "insecure", false, "Skip X.509 certificate validation during TLS handshake")
+	if args = parseCommandFlags(cli, args[1:]); len(args) != 0 {
+		cli.Usage()
+		os.Exit(2)
+	}
+
+	certificates, err := loadClientCertificates()
+	if err != nil {
+		return err
+	}
+	client := kes.NewClient(serverAddr(), &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+		Certificates:       certificates,
+	})
+
+	reader, err := client.TraceAuditLog()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	sigCh := make(chan os.Signal)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		if err := reader.Close(); err != nil {
+			fmt.Fprintln(cli.Output(), err)
+		}
+	}()
+
+	type AuditEntry struct {
+		Time    time.Time `json:"time"`
+		Request struct {
+			Path     string       `json:"path"`
+			Identity kes.Identity `json:"identity"`
+		} `json:"request"`
+		Response struct {
+			Code int           `json:"code"`
+			Time time.Duration `json:"time"`
+		} `json:"response"`
+	}
+
+	isTerminal := isTerm(os.Stdout)
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		if err = scanner.Err(); err != nil {
+			return err
+		}
+		if isTerminal && !jsonOutput {
+			var entry AuditEntry
+			if err = json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+				return err
+			}
+			if len(entry.Request.Identity) > 7 { // only show a short identity - similar to git commits
+				entry.Request.Identity = entry.Request.Identity[:7]
+			}
+
+			var status string
+			var identity string
+			if runtime.GOOS == "windows" { // don't colorize on windows
+				status = fmt.Sprintf("[%d %s]", entry.Response.Code, http.StatusText(entry.Response.Code))
+				identity = entry.Request.Identity.String()
+			} else {
+				if entry.Response.Code == http.StatusOK {
+					status = color.GreenString("[%d %s]", entry.Response.Code, http.StatusText(entry.Response.Code))
+				} else {
+					status = color.RedString("[%d %s]", entry.Response.Code, http.StatusText(entry.Response.Code))
+				}
+				identity = color.YellowString(entry.Request.Identity.String())
+			}
+
+			const format = "%s %s %-25s %10s\n"
+			fmt.Printf(format, identity, status, entry.Request.Path, entry.Response.Time.Truncate(1*time.Microsecond))
+		} else {
+			fmt.Println(scanner.Text())
+		}
+	}
+	return nil
+
+}

--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -22,6 +22,7 @@ const usage = `usage: %s <command>
     key                  Manage secret keys.
     policy               Manage the kes server policies.
     identity             Assign policies to identities.
+    audit                Manage the kes server audit logs.                  
 
     tool                 Run specific key and identity management tools.
 
@@ -51,6 +52,8 @@ func main() {
 		err = identity(args)
 	case "policy":
 		err = policy(args)
+	case "audit":
+		err = audit(args)
 	case "tool":
 		err = tool(args)
 	default:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.26.3
+	github.com/fatih/color v1.7.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/pelletier/go-toml v1.6.0
 	github.com/secure-io/sio-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
@@ -53,7 +54,9 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=


### PR DESCRIPTION
This commit adds support for tracing
audit log events.

Therefore, this commit removes the global
HTTP write timeout. The problem with server-wide
timeouts is that as a HTTP handler you cannot
adjust/opt-out of the timeout. This makes it
impossible to implement long-running server tasks
like tracing logs.

Instead, this commit implements a custom timeout
handler - similar to https://golang.org/pkg/net/http#TimeoutHandler
The custom timeout handler and Go's TimeoutHandler
differ in implementation details. See documentation.

Now, each HTTP handler that requires a (write) timeout
must be wrapped by a timeout handler. The server-wide
write-timeout is explicitly set to 0.

Further, this commit implements a audit log tracing CLI
that prints a human-readable text output to a TTY and JSON
otherwise.