### PR TITLE
update cache expiry default values

### DIFF
--- a/server-config.toml
+++ b/server-config.toml
@@ -65,11 +65,11 @@ identities = [ "7ec8095a5308a535b72b35c7ccd4ce1d7c14af713acd22e2935a9d6e4fe18127
 # Period after which all cache entries are discarded.
 # It determines how often the kes server has to fetch
 # a secret key from the key storage.
-all    = "1h" 
+all    = "5m" 
 # Period after which all unused cache entries are discarded.
 # It determines how often "not frequently" used secret keys
 # must be fetched from the key storage.
-unused = "30s" 
+unused = "20s" 
 
 # Log configuration. In general, the server distinguishes
 # between (operational) errors and audit events. Therefore,

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -71,11 +71,11 @@ cache:
     # Period after which all cache entries are discarded.
     # It determines how often the kes server has to fetch
     # a secret key from the key storage.
-    all: 1h0m0s
+    all: 5m0s
     # Period after which all unused cache entries are discarded.
     # It determines how often "not frequently" used secret keys
     # must be fetched from the key storage.
-    unused: 30s
+    unused: 20s
 
 # Log configuration. In general, the server distinguishes
 # between (operational) errors and audit events. Therefore,


### PR DESCRIPTION
This commit adjusts the cache expiry
default values to:
 - discard all entries after `5 min`
 - discard entries that haven't been
   used for more then `20 sec`

The value for `all` is reduced significantly
since:
```
1 Month / 5 min = 30 * 24 * 60 / 5 = 8640
```
So, by discarding all cache entries we make 8640
requests to the key store. For ref: AWS charges
per 10,000 requests (e.g. 10,000 req = 0.03 ct).
This means that the KES server has to authenticate
itself to the key store and request access to the
master/secret key every 5 min - which is quite
conservative.

Further, if an application is not using the
master/secret key for more 20 sec the KES
server will discard it as well. This is again
a conservative choice. However, for high-performance
applications 10 sec or less may also be appropriate.

Now, the expiry values are quite conservative and
should provide a reasonable security level.