### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.crt
 .idea
 kes
+!kes/


### PR DESCRIPTION
This commit updates the .gitignore file
to exclude the kes binary but not a kes
folder - e.g. cmd/kes/.