### PR TITLE
rename package `awsecret` to `aws`

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/minio/kes"
-	"github.com/minio/kes/awsecret"
+	"github.com/minio/kes/aws"
 	"github.com/minio/kes/fs"
 	"github.com/minio/kes/mem"
 	"github.com/minio/kes/vault"
@@ -211,14 +211,14 @@ func server(args []string) error {
 		}
 		store = vaultStore
 	case config.KeyStore.Aws.SecretsManager.Addr != "":
-		awsStore := &awsecret.KeyStore{
+		awsStore := &aws.SecretsManager{
 			Addr:                   config.KeyStore.Aws.SecretsManager.Addr,
 			Region:                 config.KeyStore.Aws.SecretsManager.Region,
 			KmsKeyID:               config.KeyStore.Aws.SecretsManager.KmsKeyID,
 			CacheExpireAfter:       config.Cache.Expiry.All,
 			CacheExpireUnusedAfter: config.Cache.Expiry.Unused,
 			ErrorLog:               errorLog.Log(),
-			Login: awsecret.Credentials{
+			Login: aws.Credentials{
 				AccessKey:    config.KeyStore.Aws.SecretsManager.Login.AccessKey,
 				SecretKey:    config.KeyStore.Aws.SecretsManager.Login.SecretKey,
 				SessionToken: config.KeyStore.Aws.SecretsManager.Login.SessionToken,


### PR DESCRIPTION
This commit renames the `awsecret` package
to make the API more idiomatic.

Before, `awsecret` should only contain types
and functions related to the AWS SecretsManager.
Therefore, it contained the generic `KeyStore` type.

Now, the package `aws` groups all AWS services that
can be used as key store. So, there is a `aws.SecretsManager`
type that implements a key store using the AWS SecretsManager
as storage.