### PR TITLE
add version information to binary and server

### DIFF
--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -15,6 +15,10 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// Use e.g.: go build -ldflags "-X main.version=v1.0.0"
+// to set the binary version.
+var version = "0.0.0-dev"
+
 const usage = `usage: %s <command>
 
     server               Start a kes server.
@@ -26,17 +30,27 @@ const usage = `usage: %s <command>
 
     tool                 Run specific key and identity management tools.
 
+  -v, --version          Print version information
   -h, --help             Show this list of command line options.
 `
 
 func main() {
+	var showVersion bool
+
 	cli := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	cli.Usage = func() {
 		fmt.Fprintf(cli.Output(), usage, cli.Name())
 	}
+	cli.BoolVar(&showVersion, "v", false, "Print version information")
+	cli.BoolVar(&showVersion, "version", false, "Print version information")
 	cli.Parse(os.Args[1:])
-	args := cli.Args()
 
+	if showVersion {
+		fmt.Fprintln(cli.Output(), cli.Name(), version)
+		return
+	}
+
+	args := cli.Args()
 	if len(args) < 1 {
 		cli.Usage()
 		os.Exit(2)

--- a/cmd/kes/release.sh
+++ b/cmd/kes/release.sh
@@ -3,6 +3,12 @@
 binaryName="kes"
 platforms=("linux/amd64" "linux/arm"  "windows/amd64" "darwin/amd64" )
 
+version=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null)
+if [ $? -ne 0 ]; then
+    version="0.0.0-$(git rev-parse --short HEAD)"
+    echo "Warning: current HEAD has no tag. Therefore, using commit ID: $version as release version."
+fi
+
 for platform in "${platforms[@]}"
 do
     platform_split=(${platform//\// })
@@ -16,7 +22,7 @@ do
     fi  
    
     echo "Building release $release..."
-    env GOOS=$GOOS GOARCH=$GOARCH go build -o $name && zip -r -q "$release.zip" $name
+    env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-X main.version=$version" -o $name && zip -r -q "$release.zip" $name
     if [ $? -ne 0 ]; then
         echo "Failed to build $output_name. Aborting the script execution..."
         exit 1

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -269,6 +269,8 @@ func server(args []string) error {
 	mux.Handle("/v1/identity/forget/", timeout(10*time.Second, kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodDelete, kes.ValidatePath("/v1/identity/forget/*", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleForgetIdentity(roles))))))))
 
 	mux.Handle("/v1/log/audit/trace", kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodGet, kes.ValidatePath("/v1/log/audit/trace", kes.LimitRequestBody(0, kes.EnforcePolicies(roles, kes.HandleTraceAuditLog(auditLog)))))))
+
+	mux.Handle("/version", timeout(10*time.Second, kes.AuditLog(auditLog.Log(), roles, kes.RequireMethod(http.MethodGet, kes.ValidatePath("/version", kes.LimitRequestBody(0, kes.HandleVersion(version))))))) // /version is accessible to any identity
 	mux.Handle("/", timeout(10*time.Second, kes.AuditLog(auditLog.Log(), roles, http.NotFound)))
 
 	server := http.Server{

--- a/handler.go
+++ b/handler.go
@@ -83,6 +83,16 @@ func AuditLog(logger *log.Logger, roles *Roles, f http.HandlerFunc) http.Handler
 	}
 }
 
+// HandleVersion returns a handler function that returns the
+// given version as JSON. In particular, it returns a JSON
+// object:
+//  {
+//    "version": "<version>"
+//  }
+func HandleVersion(version string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) { fmt.Fprintf(w, `{"version":"%s"}`, version) }
+}
+
 // HandleCreateKey returns a handler function that generates a new
 // random Secret and stores in the Store under the request name, if
 // it doesn't exist.


### PR DESCRIPTION
This commit adds version information to the
binary and the server.

Now, when making a release the commit tag
becomes the release version. So, running
```
cd ./cmd/kes && ./release.sh
```
after tagging a new release (e.g. v1.0.0)
will include `v1.0.0` as version into the binary.
If HEAD has no tag the release script will print
a warning and use `0.0.0-<commit-ID>` as release
version.

The binary version is printed when running:
```
kes --version
```

Further, the server handles GET requests
to `/version` and respond with a JSON object
containing the version of the server.

Note that the `/version` route is available to
anyone who can authenticate (via mTLS) to the
server. There is no policy that allows/denies
access to `/version`.