### PR TITLE
add support for TLS proxies

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -22,6 +22,12 @@ type serverConfig struct {
 	TLS struct {
 		KeyPath  string `toml:"key" yaml:"key"`
 		CertPath string `toml:"cert" yaml:"cert"`
+		Proxy    struct {
+			Identities []kes.Identity `toml:"identities" yaml:"identities"`
+			Header     struct {
+				ClientCert string `toml:"cert" yaml:"cert"`
+			} `toml:"header" yaml:"header"`
+		} `toml:"proxy" yaml:"proxy"`
 	} `toml:"tls" yaml:"tls"`
 
 	Policies map[string]struct {

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -1,0 +1,200 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package auth
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/minio/kes"
+)
+
+type TLSProxy struct {
+	// Identify computes the identity from a X.509 certificate
+	// sent by the client or proxy.
+	//
+	// If it is nil a default IdentityFunc computing the
+	// SHA-256 of the certificate's public key will be used.
+	Identify IdentityFunc
+
+	// CertHeader is the HTTP header key used to extract the
+	// client certificate forwarded by a TLS proxy. The TLS
+	// proxy has to include the certificate of the actual
+	// client into the request headers as CertHeader.
+	//
+	// If the request has been sent by a proxy but the request
+	// headers do not contain an escaped and ASN.1 encoded
+	// certificate then the request will be rejected.
+	CertHeader string
+
+	// The X.509 certificate verification options used when
+	// verifiying the certificate that has been sent by the
+	// actual kes client and forwarded by the TLS proxy as
+	// part of the request headers.
+	//
+	// If it is nil the client certificate won't be verified.
+	VerifyOptions *x509.VerifyOptions
+
+	lock       sync.RWMutex
+	identities map[kes.Identity]bool
+}
+
+// Is returns true if and only if the given identity
+// is a TLS proxy.
+func (p *TLSProxy) Is(identity kes.Identity) bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	if p.identities == nil {
+		return false
+	}
+	return p.identities[identity]
+}
+
+// Add adds the given identity to the list of TLS
+// proxies if:
+//  identity != kes.IdentityUnknown
+func (p *TLSProxy) Add(identity kes.Identity) {
+	if identity.IsUnknown() {
+		return
+	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.identities == nil {
+		p.identities = map[kes.Identity]bool{}
+	}
+	p.identities[identity] = true
+}
+
+// Verify verifies the given HTTP request. If the request
+// has been made by a TLS proxy then Verify tries to extract
+// the certificate of the actual kes client from the request
+// headers and replaces the peer certificate of the TLS proxy
+// with the extracted client certificate.
+//
+// It verifies the certificate of the actual kes client, if
+// present, only if the TLSProxy.VerifyOptions are not nil.
+//
+// If the request has not been made by a TLS proxy, Verify
+// only checks whether a client certificate is present.
+func (p *TLSProxy) Verify(req *http.Request) error {
+	if req.TLS == nil {
+		// This can only happen if the server accepts non-TLS
+		// connections - which violates our fundamental security
+		// assumption. Therefore, we respond with BadRequest
+		// and log that the server is not correctly configured.
+		//
+		// Technically, it would be acceptable to allow non-TLS
+		// connections if:
+		// - The kes server and TLS proxy run on the same host
+		//   or within the same trusted (!) network (segment).
+		// - And, the kes server is ONLY reachable from the TLS
+		//   proxy.
+		// However, that would be a very fragile setup and there
+		// is no real disadvantage caused by using TLS between the
+		// proxy and the kes server. Therefore, we fail the request.
+		return kes.NewError(http.StatusBadRequest, "insecure connection: TLS required")
+	}
+
+	if len(req.TLS.PeerCertificates) != 1 {
+		if len(req.TLS.PeerCertificates) == 0 {
+			// If the request is forwarded by a TLS proxy then the
+			// proxy didn't send a client certificate to authenticate
+			// itself as proxy.
+			// However, if the request comes from an actual kes client
+			// directly (bypassing the TLS proxy) then this client didn't
+			// send a certificate.
+			// We cannot distinguish both cases because we would have to
+			// compute the identity from the certificate (which is not present)
+			// first. So, we return the same error message as if there is
+			// no TLS proxy.
+			return kes.NewError(http.StatusBadRequest, "no client certificate is present")
+		}
+
+		// For now we require that the client sends
+		// only one certificate. However, it's possible
+		// to support multiple - but we have to think
+		// about the semantics.
+		//
+		// Again, we cannot distinguish whether the request
+		// comes from a TLS proxy or an actual kes client.
+		// Therefore, we behave as if there is no TLS proxy.
+		return kes.NewError(http.StatusBadRequest, "too many client certificates are present")
+	}
+
+	identify := p.Identify
+	if identify == nil {
+		identify = defaultIdentify
+	}
+
+	identity := identify(req.TLS.PeerCertificates[0])
+	if identity.IsUnknown() {
+		return kes.ErrNotAllowed
+	}
+
+	// If identity is the/a proxy we extract the certificate
+	// of the actual kes client from the request headers and
+	// modify the TLS connection state such that for handlers
+	// further down the stack it looks like the request has
+	// been made by the kes client itself.
+	// They can consume the TLS connection state as usual without
+	// having to care about a TLS proxy.
+	if p.Is(identity) {
+		cert, err := p.getClientCertificate(req.Header)
+		if err != nil {
+			return err
+		}
+
+		req.TLS.PeerCertificates = []*x509.Certificate{cert}
+		req.TLS.VerifiedChains = nil
+
+		if p.VerifyOptions != nil { // Perform X.509 certificate validation
+			opts := *p.VerifyOptions
+			req.TLS.VerifiedChains, err = cert.Verify(opts)
+			if err != nil {
+				// TODO(aead): Decide whether we should return a error
+				// message here. For new we can just return 403 forbidden.
+				return kes.NewError(http.StatusForbidden, "")
+			}
+		}
+	}
+	return nil
+}
+
+// getClientCertificate tries to extract an URL-escaped and ANS.1-encoded
+// X.509 certificate from the given HTTP headers. It returns an error if
+// no or more then one certificate are present or when the certificate
+// cannot be decoded.
+func (p *TLSProxy) getClientCertificate(h http.Header) (*x509.Certificate, error) {
+	clientCerts, ok := h[http.CanonicalHeaderKey(p.CertHeader)]
+	if !ok {
+		return nil, kes.NewError(http.StatusBadRequest, "no client certificate is present")
+	}
+	if len(clientCerts) != 1 {
+		if len(clientCerts) == 0 {
+			return nil, kes.NewError(http.StatusBadRequest, "no client certificate is present")
+		}
+		return nil, kes.NewError(http.StatusBadRequest, "too many client certificates are present")
+	}
+
+	clientCert, err := url.QueryUnescape(clientCerts[0])
+	if err != nil {
+		return nil, kes.NewError(http.StatusBadRequest, "invalid client certificate")
+	}
+
+	block, _ := pem.Decode([]byte(clientCert))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, kes.NewError(http.StatusBadRequest, "invalid client certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, kes.NewError(http.StatusBadRequest, "invalid client certificate")
+	}
+	return cert, nil
+}

--- a/internal/auth/proxy_test.go
+++ b/internal/auth/proxy_test.go
@@ -1,0 +1,132 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package auth
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/minio/kes"
+)
+
+var tlsProxyAddTests = []struct {
+	Identites []kes.Identity
+}{
+	{
+		Identites: nil,
+	},
+	{
+		Identites: []kes.Identity{
+			"57eb2da320a48ebe2750e95c50b3d64240aef4cd5d54c28a4f25155e88c98580",
+		},
+	},
+	{
+		Identites: []kes.Identity{
+			kes.IdentityUnknown,
+			"57eb2da320a48ebe2750e95c50b3d64240aef4cd5d54c28a4f25155e88c98580",
+		},
+	},
+	{
+		Identites: []kes.Identity{
+			kes.IdentityUnknown,
+			"57eb2da320a48ebe2750e95c50b3d64240aef4cd5d54c28a4f25155e88c98580",
+			"163d766f3e88f2a02b15a46bc541cc679c4cbb0a060405f298d5fc0d9d876bb3",
+		},
+	},
+}
+
+func TestTLSProxyAdd(t *testing.T) {
+	for i, test := range tlsProxyAddTests {
+		var proxy TLSProxy
+		for j, identity := range test.Identites {
+			proxy.Add(identity)
+			if !identity.IsUnknown() && !proxy.Is(identity) {
+				t.Fatalf("Test %d: %d-th identity '%s' should be a proxy but is not", i, j, identity)
+			}
+		}
+	}
+}
+
+var tlsProxyGetClientCertificateTests = []struct {
+	Proxy  *TLSProxy
+	Header http.Header
+	Err    error
+}{
+	{
+		Proxy:  &TLSProxy{},
+		Header: http.Header{},
+		Err:    kes.NewError(http.StatusBadRequest, "no client certificate is present"),
+	},
+	{
+		Proxy: &TLSProxy{CertHeader: "X-Forwarded-Ssl-Client-Cert"},
+		Header: http.Header{
+			"X-Forwarded-Ssl-Client-Cert": []string{url.QueryEscape(clientCert)},
+		},
+		Err: nil,
+	},
+	{
+		Proxy: &TLSProxy{CertHeader: "X-Forwarded-Ssl-Client-Cert"},
+		Header: http.Header{
+			"X-Forwarded-Ssl-Client-Cert": []string{url.QueryEscape(clientCert), url.QueryEscape(clientCert)},
+		},
+		Err: kes.NewError(http.StatusBadRequest, "too many client certificates are present"),
+	},
+	{
+		Proxy: &TLSProxy{CertHeader: "X-Forwarded-Ssl-Client-Cert"},
+		Header: http.Header{
+			"X-Ssl-Cert": []string{url.QueryEscape(clientCert)},
+		},
+		Err: kes.NewError(http.StatusBadRequest, "no client certificate is present"),
+	},
+	{
+		Proxy: &TLSProxy{CertHeader: "X-Tls-Client-Cert"},
+		Header: http.Header{
+			"X-Tls-Client-Cert": []string{url.QueryEscape(noPEMTypeClientCert)},
+		},
+		Err: kes.NewError(http.StatusBadRequest, "invalid client certificate"),
+	},
+	{
+		Proxy: &TLSProxy{CertHeader: "X-Tls-Client-Cert"},
+		Header: http.Header{
+			"X-Tls-Client-Cert": []string{unescapedClientCert},
+		},
+		Err: kes.NewError(http.StatusBadRequest, "invalid client certificate"),
+	},
+}
+
+func TestTLSProxyGetClientCertificate(t *testing.T) {
+	for i, test := range tlsProxyGetClientCertificateTests {
+		_, err := test.Proxy.getClientCertificate(test.Header)
+		if err != test.Err {
+			t.Fatalf("Test %d: got error %v - want error %v", i, err, test.Err)
+		}
+	}
+}
+
+const clientCert = `-----BEGIN CERTIFICATE-----
+MIIBETCBxKADAgECAhEAwNfpyTO85V8w7ecjWU8CdDAFBgMrZXAwDzENMAsGA1UE
+AxMEcm9vdDAeFw0xOTEyMTYyMjQ2NDdaFw0yMDAxMTUyMjQ2NDdaMA8xDTALBgNV
+BAMTBHJvb3QwKjAFBgMrZXADIQDNKcY+Mv84QGUEyC/NIvJefLjt9NGGQ9kj5eEX
+e2QNGaM1MDMwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwG
+A1UdEwEB/wQCMAAwBQYDK2VwA0EAqUvabyUgcQYp+dPFZpPBycx9+2sWEwwBsybk
+JPbwv+fAB2l3rjHt2u9iWL6a2C9xzLh8ni+o2YIWLCGhMSfqBA==
+-----END CERTIFICATE-----`
+
+const noPEMTypeClientCert = `MIIBETCBxKADAgECAhEAwNfpyTO85V8w7ecjWU8CdDAFBgMrZXAwDzENMAsGA1UE
+AxMEcm9vdDAeFw0xOTEyMTYyMjQ2NDdaFw0yMDAxMTUyMjQ2NDdaMA8xDTALBgNV
+BAMTBHJvb3QwKjAFBgMrZXADIQDNKcY+Mv84QGUEyC/NIvJefLjt9NGGQ9kj5eEX
+e2QNGaM1MDMwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwG
+A1UdEwEB/wQCMAAwBQYDK2VwA0EAqUvabyUgcQYp+dPFZpPBycx9+2sWEwwBsybk
+JPbwv+fAB2l3rjHt2u9iWL6a2C9xzLh8ni+o2YIWLCGhMSfqBA==`
+
+const unescapedClientCert = `%A-----BEGIN CERTIFICATE-----
+MIIBETCBxKADAgECAhEAwNfpyTO85V8w7ecjWU8CdDAFBgMrZXAwDzENMAsGA1UE
+AxMEcm9vdDAeFw0xOTEyMTYyMjQ2NDdaFw0yMDAxMTUyMjQ2NDdaMA8xDTALBgNV
+BAMTBHJvb3QwKjAFBgMrZXADIQDNKcY+Mv84QGUEyC/NIvJefLjt9NGGQ9kj5eEX
+e2QNGaM1MDMwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwG
+A1UdEwEB/wQCMAAwBQYDK2VwA0EAqUvabyUgcQYp+dPFZpPBycx9+2sWEwwBsybk
+JPbwv+fAB2l3rjHt2u9iWL6a2C9xzLh8ni+o2YIWLCGhMSfqBA==
+-----END CERTIFICATE-----`

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -1,0 +1,49 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"net/http"
+
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/log"
+)
+
+// TLSProxy returns a handler function that checks if the
+// request has been forwarded by a TLS proxy and, if so,
+// verifies and adjusts the request such that handlers
+// further down the stack can treat it as sent by the
+// actual client.
+//
+// Therefore, it replaces the proxy certificate in the
+// TLS connection state with the client certificate
+// forwarded by the proxy as part of the request headers.
+func TLSProxy(proxy *auth.TLSProxy, f http.HandlerFunc) http.HandlerFunc {
+	if proxy == nil {
+		return f
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		// TODO(aead): At the moment updating the audit log
+		// identity via this type check is kind of a hack.
+		// However, there is no simple and clean solution
+		// that does not require some extended changes.
+		// (One option may be another http.HandlerFunc type)
+		// For now, we can keep this until we've sattled
+		// on a cleaner solution.
+
+		aw, ok := w.(*log.AuditResponseWriter)
+		if err := proxy.Verify(r); err != nil {
+			http.Error(w, err.Error(), statusCode(err))
+			return
+		}
+		if ok && aw != nil {
+			// Update the audit log identity such that
+			// the audit log shows the actual client and
+			// not the TLS proxy.
+			aw.Identity = auth.Identify(r, proxy.Identify)
+		}
+		f(w, r)
+	}
+}

--- a/server-config.toml
+++ b/server-config.toml
@@ -14,6 +14,30 @@ root = "c84cc9b91ae2399b043da7eca616048d4b4200edf2ff418d8af3835911db945d"
 key  = "./server.key" # Path to the TLS private key
 cert = "./server.cert"  # Path to the TLS certificate
 
+# The TLS proxy configuration. A TLS proxy, like nginx, sits in
+# between a kes client and the kes server and usually acts as a
+# load balancer or common API endpoint.
+# All connections from the kes client to the TLS proxy as well
+# the connections from the TLS proxy to the kes server must be
+# established over TLS.
+[tls.proxy]
+# The identities of all TLS proxies directly connected to the kes
+# server.
+#
+# Note that a TLS proxy can act as any identity (including root)
+# since it can forward arbitrary client certificates. Client certificates
+# aren't secret information and a malicious TLS proxy can fake any
+# identity it has seen before. Therefore, its critical that all TLS proxy
+# identities are secure and trusted servers.
+identities = [ ]
+
+# The HTTP header sent by the TLS proxy to forward certain data
+# about the client to the kes server.
+[tls.proxy.header]
+# The HTTP header containing the URL-escaped and PEM-encoded
+# certificate of the kes client forwarded by the TLS proxy.
+cert = "X-Tls-Client-Cert"
+
 # Policy definitions. A policy must have an unique name
 # (i.e. [policy.<name>]) and specifies which APIs can
 # be accessed (i.e. paths = [ ... ]).
@@ -33,7 +57,7 @@ cert = "./server.cert"  # Path to the TLS certificate
 # the server finds the policy assigned to the identity and then
 # checks whether the request is valid.
 
-# In general, each user/applicaton should only have the minimal
+# In general, each user/application should only have the minimal
 # set of policy permissions to accomplish whatever it needs to do.
 # Therefore, it is recommended to define policies based on workflows
 # and then assign them to the identities.
@@ -99,7 +123,7 @@ file = [ "" ] # Add one or more log file paths here.
 # }
 # The server will write such an audit log entry for every HTTP
 # request-response pair - including invalid requests. If no audit
-# file (path) is specifed the server will not log audit events.
+# file (path) is specified the server will not log audit events.
 # In contrast to error log, audit logging has to be enabled explicitly.
 [audit]
 file = [ "" ] # Add one or more log file paths here

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -13,6 +13,28 @@ root: c84cc9b91ae2399b043da7eca616048d4b4200edf2ff418d8af3835911db945d
 tls:
   key: ./server.key   # Path to the TLS private key
   cert: ./server.cert # Path to the TLS certificate
+  # The TLS proxy configuration. A TLS proxy, like nginx, sits in
+  # between a kes client and the kes server and usually acts as a
+  # load balancer or common API endpoint.
+  # All connections from the kes client to the TLS proxy as well
+  # the connections from the TLS proxy to the kes server must be
+  # established over TLS.
+  proxy:
+    # The identities of all TLS proxies directly connected to the kes
+    # server.
+    #
+    # Note that a TLS proxy can act as any identity (including root)
+    # since it can forward arbitrary client certificates. Client certificates
+    # aren't secret information and a malicious TLS proxy can fake any
+    # identity it has seen before. Therefore, its critical that all TLS proxy
+    # identities are secure and trusted servers.
+    identities: []
+    # The HTTP header sent by the TLS proxy to forward certain data
+    # about the client to the kes server.
+    header:
+      # The HTTP header containing the URL-escaped and PEM-encoded
+      # certificate of the kes client forwarded by the TLS proxy.
+      cert: X-Tls-Client-Cert
 
 # Policy definitions. A policy must have an unique name
 # (i.e. [policy.<name>]) and specifies which APIs can
@@ -33,7 +55,7 @@ tls:
 # the server finds the policy assigned to the identity and then
 # checks whether the request is valid.
 
-# In general, each user/applicaton should only have the minimal
+# In general, each user/application should only have the minimal
 # set of policy permissions to accomplish whatever it needs to do.
 # Therefore, it is recommended to define policies based on workflows
 # and then assign them to the identities.
@@ -105,7 +127,7 @@ log:
   # }
   # The server will write such an audit log entry for every HTTP
   # request-response pair - including invalid requests. If no audit
-  # file (path) is specifed the server will not log audit events.
+  # file (path) is specified the server will not log audit events.
   # In contrast to error log, audit logging has to be enabled explicitly.
   audit:
     file:  


### PR DESCRIPTION
This commit adds support for TLS proxies such that
there can be 0, 1 or multiple TLS proxies between
one (or more) kes clients and a kes server.

The identity of each proxies (direct neighbor of the kes server)
must be added to `proxy.identities`.
Further, the proxy which is a direct neighbor of the kes client
must forward the kes client certificate as part of the request
header.

So, in the most simple (and most common) case there is one TLS
proxy - e.g. a nginx load balancer - between the kes server and
kes client. This nginx has to extract and forward the client
certificate (request headers) and has to authenticate itself
via its own nginx client certificate to kes as proxy.

Optionally, the nginx may verify the kes client certificate as well.

If there would be two load balancers then the one closer to the
client has to extract the forward the client certificate while
the one closer to the kes server has to authenticate itself to the
kes server. This must be the case for any number ( >= 2) TLS proxies.

As an example, the following nginx configuration shows how to
setup a demo load balancer on your local machine:
```
http {
   server {
     listen              443 ssl;
     server_name         localhost;

     # Avoid buffering the response. Especially for audit log tracing.
     proxy_buffering off;

     # The nginx private key and certificate presented to clients
     # connecting to it.
     ssl_certificate       <nginx.crt>;
     ssl_certificate_key   <nginx.key>;

     # Require a client certificate but don't verify it.
     # See nginx docs for more details.
     ssl_verify_client   optional_no_ca;

     location / {
        # KES server endpoint
        proxy_pass                  https://localhost:7373;

        # Enforce TLSv1.3 - KES supports it.
        proxy_ssl_protocols         TLSv1.3;

        # This demo config assumes the KES server uses
        # self-signed certificates.
        proxy_ssl_verify            off;

        # The private key and client certificate used by nginx
        # to authenticate itself to the kes server
        # The output of: 'kes tool identity of <nginx-client.cert>'
        # must be added to the proxy.identities section in the
        # kes config file.
        proxy_ssl_certificate       <nginx-client.cert>;
        proxy_ssl_certificate_key   <nginx-client.key>;

        # The header used by nginx to forward the escaped and
        # encoded certificate of the KES client. This value
        # must match the entry in the tls.proxy.header section
        # in the KES config file.
        proxy_set_header X-Tls-Client-Cert $ssl_client_escaped_cert;

        # We need keep-alive for audit log tracing
        proxy_http_version 1.1;
     }
  }
}
```

Fixes #18