### PR TITLE
stabilize server error API

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,7 +4,12 @@
 
 package kes
 
-import "net/http"
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
 
 var (
 	ErrKeyNotFound Error = NewError(http.StatusNotFound, "key does not exist")
@@ -52,3 +57,48 @@ func NewError(code int, msg string) Error {
 func (e Error) Status() int { return e.code }
 
 func (e Error) Error() string { return e.message }
+
+// parseErrorResponse returns an error containing
+// the response status code and response body
+// as error message if the response is an error
+// response - i.e. status code >= 400.
+//
+// If the response status code is < 400, e.g. 200 OK,
+// parseErrorResponse returns nil and does not attempt
+// to read or close the responde body.
+//
+// If resp is an error response, parseErrorResponse reads
+// and closes the response body.
+func parseErrorResponse(resp *http.Response) error {
+	if resp == nil || resp.StatusCode < 400 {
+		return nil
+	}
+	if resp.Body == nil {
+		return NewError(resp.StatusCode, "")
+	}
+	defer resp.Body.Close()
+
+	const MaxBodySize = 1 << 20
+	var size = resp.ContentLength
+	if size < 0 || size > MaxBodySize {
+		size = MaxBodySize
+	}
+
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if strings.HasPrefix(contentType, "application/json") {
+		type Response struct {
+			Message string `json:"message"`
+		}
+		var response Response
+		if err := json.NewDecoder(io.LimitReader(resp.Body, size)).Decode(&response); err != nil {
+			return err
+		}
+		return NewError(resp.StatusCode, response.Message)
+	}
+
+	var sb strings.Builder
+	if _, err := io.CopyN(&sb, resp.Body, size); err != nil {
+		return err
+	}
+	return NewError(resp.StatusCode, sb.String())
+}

--- a/internal/aws/secrets-manager.go
+++ b/internal/aws/secrets-manager.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -136,10 +135,7 @@ func (store *SecretsManager) Get(name string) (secret.Secret, error) {
 	})
 	if err != nil {
 		if err, ok := err.(awserr.Error); ok {
-			switch err.Code() {
-			case secretsmanager.ErrCodeDecryptionFailure:
-				return secret.Secret{}, kes.NewError(http.StatusForbidden, fmt.Sprintf("aws: cannot access secret '%s': %v", name, err))
-			case secretsmanager.ErrCodeResourceNotFoundException:
+			if err.Code() == secretsmanager.ErrCodeResourceNotFoundException {
 				return secret.Secret{}, kes.ErrKeyNotFound
 			}
 		}

--- a/internal/http/error.go
+++ b/internal/http/error.go
@@ -1,0 +1,41 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Error sends the given err as JSON error responds to w.
+//
+// If err has a 'Status() int' method then Error sets the
+// response status code to err.Status(). Otherwise, it will
+// send 500 (internal server error).
+//
+// If err is nil then Error will send the status code 500 and
+// an empty JSON response body - i.e. '{}'.
+func Error(w http.ResponseWriter, err error) error {
+	var status = http.StatusInternalServerError
+	if e, ok := err.(interface{ Status() int }); ok {
+		status = e.Status()
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+
+	const (
+		emptyMsg = `{}`
+		format   = `{"message":"%v"}`
+	)
+	if err == nil {
+		_, err = io.WriteString(w, emptyMsg)
+	} else {
+		_, err = io.WriteString(w, fmt.Sprintf(format, err))
+	}
+	return err
+}

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -35,7 +35,7 @@ func TLSProxy(proxy *auth.TLSProxy, f http.HandlerFunc) http.HandlerFunc {
 
 		aw, ok := w.(*log.AuditResponseWriter)
 		if err := proxy.Verify(r); err != nil {
-			http.Error(w, err.Error(), statusCode(err))
+			Error(w, err)
 			return
 		}
 		if ok && aw != nil {


### PR DESCRIPTION
This commit stabilizes and unifies the error interface
of the KES server. From now on the KES server returns
a error code >= 400 (bad request) and a JSON error message
as response body.

The error response has the following (simple) form:
```
{
  "message": "...",
}
```

Now, a client can rely upon the server returning an error status
code and a JSON object explaining why the error occurred.
Further, the client can now easily check whether the server
returned an expected error - e.g. `key not found`

However, this change does not finalize the errors returned by the server
themself but just the general structure of error messages.