### PR TITLE
add initial KMS support for sealed secrets

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -51,6 +51,21 @@ type serverConfig struct {
 		} `toml:"audit" yaml:"audit"`
 	} `toml:"log" yaml:"log"`
 
+	KMS struct {
+		AWS struct {
+			Addr   string `toml:"address" yaml:"address"`
+			Region string `toml:"region" yaml:"region"`
+
+			Key string `toml:"key" yaml:"key"`
+
+			Login struct {
+				AccessKey    string `toml:"access_key" yaml:"access_key"`
+				SecretKey    string `toml:"secret_key" yaml:"secret_key"`
+				SessionToken string `toml:"session_token" yaml:"session_token"`
+			} `toml:"credentials" yaml:"credentials"`
+		} `toml:"aws" yaml:"aws"`
+	} `toml:"kms" yaml:"kms"`
+
 	KeyStore struct {
 		Fs struct {
 			Dir string `toml:"path" yaml:"path"`

--- a/error.go
+++ b/error.go
@@ -14,6 +14,7 @@ import (
 var (
 	ErrKeyNotFound Error = NewError(http.StatusNotFound, "key does not exist")
 	ErrKeyExists   Error = NewError(http.StatusBadRequest, "key does already exist")
+	ErrKeySealed   Error = NewError(http.StatusForbidden, "key is sealed")
 	ErrNotAllowed  Error = NewError(http.StatusForbidden, "prohibited by policy")
 )
 
@@ -34,7 +35,7 @@ var (
 //       case ErrNotAllowed:
 //          // We don't have the permission to create this key.
 //       default:
-//          // Something else when wrong.
+//          // Something else went wrong.
 //   }
 type Error struct {
 	code    int

--- a/internal/aws/kms.go
+++ b/internal/aws/kms.go
@@ -1,0 +1,163 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package aws
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awskms "github.com/aws/aws-sdk-go/service/kms"
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/secret"
+)
+
+// KMS is an AWS-KMS client that implements
+// the secret.KMS interface.
+//
+// It can be used to encrypt secrets before
+// storing them at a key store resp. decrypt
+// them after fetching them from such a store.
+type KMS struct {
+	// Addr is the HTTP address of the AWS KMS.
+	// In general, the address has the following
+	// form:
+	//  kms.<region>.amazonaws.com
+	Addr string
+
+	// Region is the AWS region. Even though the Addr
+	// endpoint contains that information already, this
+	// field is mandatory.
+	Region string
+
+	// Login contains the AWS credentials (access/secret key).
+	Login Credentials
+
+	// ErrorLog specifies an optional logger for errors
+	// when files cannot be opened, deleted or contain
+	// invalid content.
+	// If nil, logging is done via the log package's
+	// standard logger.
+	ErrorLog *log.Logger
+
+	client *awskms.KMS
+}
+
+var _ secret.KMS = (*KMS)(nil)
+
+// Authenticate tries to establish a connection to
+// the AWS KMS using the login credentials.
+func (kms *KMS) Authenticate() error {
+	credentials := credentials.NewStaticCredentials(
+		kms.Login.AccessKey,
+		kms.Login.SecretKey,
+		kms.Login.SessionToken,
+	)
+	if kms.Login.AccessKey == "" && kms.Login.SecretKey == "" && kms.Login.SessionToken == "" {
+		// If all login credentials (access key, secret key and session token) are empty
+		// we pass no (not empty) credentials to the AWS SDK. The SDK will try to fetch
+		// the credentials from:
+		//  - Environment Variables
+		//  - Shared Credentials file
+		//  - EC2 Instance Metadata
+		// In particular, when running a kes server on an EC2 instance, the SDK will
+		// automatically fetch the temp. credentials from the EC2 metadata service.
+		// See: AWS IAM roles for EC2 instances.
+		credentials = nil
+	}
+
+	session, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Endpoint:    aws.String(kms.Addr),
+			Region:      aws.String(kms.Region),
+			Credentials: credentials,
+		},
+		SharedConfigState: session.SharedConfigDisable,
+	})
+	if err != nil {
+		return err
+	}
+	kms.client = awskms.New(session)
+	return nil
+}
+
+// Encrypt tries to encrypt the given plaintext with the specified
+// CMK at the AWS-KMS instance. It returns the encrypted plaintext
+// as ciphertext.
+func (kms *KMS) Encrypt(key string, plaintext []byte) ([]byte, error) {
+	ciphertext, err := kms.client.Encrypt(&awskms.EncryptInput{
+		KeyId:     aws.String(key),
+		Plaintext: plaintext,
+	})
+	if err != nil {
+		if err, ok := err.(awserr.Error); ok {
+			switch err.Code() {
+			case awskms.ErrCodeNotFoundException:
+				kms.logf("aws: the CMK '%s' does not exist: %v", key, err)
+			case awskms.ErrCodeDisabledException:
+				kms.logf("aws: the CMK '%s' is disabled: %v", key, err)
+			case awskms.ErrCodeKeyUnavailableException:
+				kms.logf("aws: the CMK '%s' is not available: %v", key, err)
+			case awskms.ErrCodeInvalidKeyUsageException:
+				kms.logf("aws: the CMK '%s' cannot be used for encryption: %v", key, err)
+			case awskms.ErrCodeInvalidStateException:
+				kms.logf("aws: the CMK '%s' is in an invalid state: %v", key, err)
+			default:
+				kms.logf("aws: %v", err)
+			}
+		} else {
+			kms.logf("aws: %v", err)
+		}
+		return nil, kes.NewError(http.StatusInternalServerError, "cannot encrypt key")
+	}
+	return ciphertext.CiphertextBlob, nil
+}
+
+// Decrypt tries to decrypt the given ciphertext with the the given key
+// using the AWS-KMS. It returns the decrypted ciphertexts as plaintext
+// on success.
+func (kms *KMS) Decrypt(key string, ciphertext []byte) ([]byte, error) {
+	plaintext, err := kms.client.Decrypt(&awskms.DecryptInput{
+		KeyId:          aws.String(key),
+		CiphertextBlob: ciphertext,
+	})
+	if err != nil {
+		if err, ok := err.(awserr.Error); ok {
+			switch err.Code() {
+			case awskms.ErrCodeNotFoundException:
+				kms.logf("aws: the CMK '%s' does not exist", key)
+			case awskms.ErrCodeDisabledException:
+				kms.logf("aws: the CMK '%s' is disabled", key)
+			case awskms.ErrCodeInvalidCiphertextException:
+				kms.logf("aws: secret is not authentic: %v", err)
+			case awskms.ErrCodeIncorrectKeyException:
+				kms.logf("aws: secret was not encrypted with '%s'", key)
+			case awskms.ErrCodeKeyUnavailableException:
+				kms.logf("aws: the CMK '%s' is not available", key)
+			case awskms.ErrCodeInvalidKeyUsageException:
+				kms.logf("aws: the CMK '%s' cannot be used for decryption", key)
+			case awskms.ErrCodeInvalidStateException:
+				kms.logf("aws: the CMK '%s' is in an invalid state", key)
+			default:
+				kms.logf("aws: %v", err)
+			}
+		} else {
+			kms.logf("aws: %v", err)
+		}
+		return nil, kes.ErrKeySealed
+	}
+	return plaintext.Plaintext, nil
+}
+
+func (kms *KMS) logf(format string, v ...interface{}) {
+	if kms.ErrorLog == nil {
+		log.Printf(format, v...)
+	} else {
+		kms.ErrorLog.Printf(format, v...)
+	}
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2,42 +2,29 @@
 // Use of this source code is governed by the AGPLv3
 // license that can be found in the LICENSE file.
 
-// Package fs implements a secret key store that
-// stores secret keys as files on the file system.
+// Package fs implements a key-value store that
+// stores keys as file names and values as file
+// content.
 package fs
 
 import (
-	"context"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"sync/atomic"
-	"time"
+	"strings"
 
 	"github.com/minio/kes"
-	"github.com/minio/kes/internal/cache"
 	"github.com/minio/kes/internal/secret"
 )
 
-// KeyStore is a file system secret key store
-// that stores secret keys as files in a directory.
-type KeyStore struct {
-	// Dir is the directory where secret key files
-	// are located. The key store will read / write
-	// secrets from / to files in this directory.
+// Store is a file system key-value store that stores
+// keys as file names in a directory.
+type Store struct {
+	// Dir is the directory where key-value entries
+	// are located. The store will read / write
+	// values from / to files in this directory.
 	Dir string
-
-	// CacheExpireAfter is the duration after which
-	// cache entries expire such that they have to
-	// be loaded from the backend storage again.
-	CacheExpireAfter time.Duration
-
-	// CacheExpireUnusedAfter is the duration after
-	// which not recently used cache entries expire
-	// such that they have to be loaded from the
-	// backend storage again.
-	// Not recently is defined as: CacheExpireUnusedAfter / 2
-	CacheExpireUnusedAfter time.Duration
 
 	// ErrorLog specifies an optional logger for errors
 	// when files cannot be opened, deleted or contain
@@ -45,50 +32,59 @@ type KeyStore struct {
 	// If nil, logging is done via the log package's
 	// standard logger.
 	ErrorLog *log.Logger
-
-	cache cache.Cache
-	once  uint32
 }
 
-// Create adds the given secret key to the store if and only
-// if no entry for name exists. If an entry already exists
-// it returns kes.ErrKeyExists.
-//
-// In particular, Create creates a new file in KeyStore.Dir
-// and writes the secret key to it.
-func (store *KeyStore) Create(name string, secret secret.Secret) error {
-	store.initialize()
-	if _, ok := store.cache.Get(name); ok {
-		return kes.ErrKeyExists
-	}
+var _ secret.Remote = (*Store)(nil)
 
-	path := filepath.Join(store.Dir, name)
+// Create creates a new file in the directory if no file
+// with the name 'key' does not exists and writes value
+// to it.
+// If such a file already exists it returns kes.ErrKeyExists.
+func (s *Store) Create(key, value string) error {
+	// We use os.O_CREATE and os.O_EXCL to enforce that the
+	// file must not have existed before.
+	path := filepath.Join(s.Dir, key)
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil && os.IsExist(err) {
 		return kes.ErrKeyExists
 	}
 	if err != nil {
-		store.logf("fs: cannot open %s: %v", path, err)
+		s.logf("fs: cannot open %s: %v", path, err)
 		return err
 	}
 	defer file.Close()
 
-	if _, err = secret.WriteTo(file); err != nil {
-		store.logf("fs: failed to write to %s: %v", path, err)
+	if _, err = file.WriteString(value); err != nil {
+		s.logf("fs: failed to write to %s: %v", path, err)
 		if rmErr := os.Remove(path); rmErr != nil {
-			store.logf("fs: cannot remove %s: %v", path, err)
+			s.logf("fs: cannot remove %s: %v", path, rmErr)
 		}
 		return err
 	}
-	if err = file.Sync(); err != nil { // Ensure that we wrote the secret key to disk
-		store.logf("fs: cannot to flush and sync %s: %v", path, err)
+
+	if err = file.Sync(); err != nil { // Ensure that we wrote the value to disk
+		s.logf("fs: cannot to flush and sync %s: %v", path, err)
 		if rmErr := os.Remove(path); rmErr != nil {
-			store.logf("fs: cannot remove %s: %v", path, err)
+			s.logf("fs: cannot remove %s: %v", path, rmErr)
 		}
 		return err
 	}
-	store.cache.Set(name, secret)
 	return nil
+}
+
+// Delete removes a the secret key with the given name
+// from the key store and deletes the associated file,
+// if it exists.
+func (s *Store) Delete(key string) error {
+	path := filepath.Join(s.Dir, key)
+	err := os.Remove(path)
+	if err != nil && os.IsNotExist(err) {
+		err = nil // Ignore the error if the file does not exist
+	}
+	if err != nil {
+		s.logf("fs: failed to delete '%s': %v", path, err)
+	}
+	return err
 }
 
 // Get returns the secret key associated with the given name.
@@ -96,61 +92,30 @@ func (store *KeyStore) Create(name string, secret secret.Secret) error {
 //
 // In particular, Get reads the secret key from the associated
 // file in KeyStore.Dir.
-func (store *KeyStore) Get(name string) (secret.Secret, error) {
-	store.initialize()
-	if secret, ok := store.cache.Get(name); ok {
-		return secret, nil
-	}
-
-	// Since we haven't found the requested secret key in the cache
-	// we reach out to the disk to fetch it from there.
-	path := filepath.Join(store.Dir, name)
+func (s *Store) Get(key string) (string, error) {
+	path := filepath.Join(s.Dir, key)
 	file, err := os.Open(path)
 	if err != nil && os.IsNotExist(err) {
-		return secret.Secret{}, kes.ErrKeyNotFound
+		return "", kes.ErrKeyNotFound
 	}
 	if err != nil {
-		store.logf("fs: cannot open '%s': %v", path, err)
-		return secret.Secret{}, err
+		s.logf("fs: cannot open '%s': %v", path, err)
+		return "", err
 	}
 	defer file.Close()
 
-	var secret secret.Secret
-	if _, err := secret.ReadFrom(file); err != nil {
-		store.logf("fs: failed to read secret from '%s': %v", path, err)
-		return secret, err
+	var value strings.Builder
+	if _, err := io.Copy(&value, io.LimitReader(file, secret.MaxSize)); err != nil {
+		s.logf("fs: failed to read from '%s': %v", path, err)
+		return "", err
 	}
-	secret, _ = store.cache.Add(name, secret)
-	return secret, nil
+	return value.String(), nil
 }
 
-// Delete removes a the secret key with the given name
-// from the key store and deletes the associated file,
-// if it exists.
-func (store *KeyStore) Delete(name string) error {
-	path := filepath.Join(store.Dir, name)
-	err := os.Remove(path)
-	if err != nil && os.IsNotExist(err) {
-		err = nil // Ignore the error if the file does not exist
-	}
-	store.cache.Delete(name)
-	if err != nil {
-		store.logf("fs: failed to delete '%s': %v", path, err)
-	}
-	return err
-}
-
-func (store *KeyStore) initialize() {
-	if atomic.CompareAndSwapUint32(&store.once, 0, 1) {
-		store.cache.StartGC(context.Background(), store.CacheExpireAfter)
-		store.cache.StartUnusedGC(context.Background(), store.CacheExpireUnusedAfter/2)
-	}
-}
-
-func (store *KeyStore) logf(format string, v ...interface{}) {
-	if store.ErrorLog == nil {
+func (s *Store) logf(format string, v ...interface{}) {
+	if s.ErrorLog == nil {
 		log.Printf(format, v...)
 	} else {
-		store.ErrorLog.Printf(format, v...)
+		s.ErrorLog.Printf(format, v...)
 	}
 }

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -108,7 +108,7 @@ func HandleVersion(version string) http.HandlerFunc {
 // It infers the name of the new Secret from the request URL - in
 // particular from the URL's path base.
 // See: https://golang.org/pkg/path/#Base
-func HandleCreateKey(store secret.Store) http.HandlerFunc {
+func HandleCreateKey(store *secret.Store) http.HandlerFunc {
 	var ErrInvalidKeyName = kes.NewError(http.StatusBadRequest, "invalid key name")
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -140,7 +140,7 @@ func HandleCreateKey(store secret.Store) http.HandlerFunc {
 // It infers the name of the new Secret from the request URL - in
 // particular from the URL's path base.
 // See: https://golang.org/pkg/path/#Base
-func HandleImportKey(store secret.Store) http.HandlerFunc {
+func HandleImportKey(store *secret.Store) http.HandlerFunc {
 	var (
 		ErrInvalidKeyName = kes.NewError(http.StatusBadRequest, "invalid key name")
 		ErrInvalidJSON    = kes.NewError(http.StatusBadRequest, "invalid json")
@@ -178,7 +178,7 @@ func HandleImportKey(store secret.Store) http.HandlerFunc {
 	}
 }
 
-func HandleDeleteKey(store secret.Store) http.HandlerFunc {
+func HandleDeleteKey(store *secret.Store) http.HandlerFunc {
 	var ErrInvalidKeyName = kes.NewError(http.StatusBadRequest, "invalid key name")
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -195,7 +195,7 @@ func HandleDeleteKey(store secret.Store) http.HandlerFunc {
 	}
 }
 
-func HandleGenerateKey(store secret.Store) http.HandlerFunc {
+func HandleGenerateKey(store *secret.Store) http.HandlerFunc {
 	var (
 		ErrInvalidJSON    = kes.NewError(http.StatusBadRequest, "invalid json")
 		ErrInvalidKeyName = kes.NewError(http.StatusBadRequest, "invalid key name")
@@ -243,7 +243,7 @@ func HandleGenerateKey(store secret.Store) http.HandlerFunc {
 	}
 }
 
-func HandleDecryptKey(store secret.Store) http.HandlerFunc {
+func HandleDecryptKey(store *secret.Store) http.HandlerFunc {
 	var (
 		ErrInvalidJSON    = kes.NewError(http.StatusBadRequest, "invalid json")
 		ErrInvalidKeyName = kes.NewError(http.StatusBadRequest, "invalid key name")

--- a/internal/secret/cache_test.go
+++ b/internal/secret/cache_test.go
@@ -2,19 +2,17 @@
 // Use of this source code is governed by the AGPLv3
 // license that can be found in the LICENSE file.
 
-package cache
+package secret
 
 import (
 	"testing"
-
-	"github.com/minio/kes/internal/secret"
 )
 
 func TestCacheSet(t *testing.T) {
-	var secret secret.Secret
+	var secret Secret
 	secret[0] = 0xff
 
-	var c Cache
+	var c cache
 	c.Set("0", secret)
 	if s, ok := c.Get("0"); !ok || s != secret {
 		t.Fatalf("Expected to find cache entry: got: %x - want: %x", s, secret)
@@ -28,12 +26,12 @@ func TestCacheSet(t *testing.T) {
 	}
 }
 
-func TestCacheAdd(t *testing.T) {
-	var secret secret.Secret
+func TestCacheSetOrGet(t *testing.T) {
+	var secret Secret
 	secret[0] = 0xff
 
-	var c Cache
-	if s, ok := c.Add("0", secret); !ok || s != secret {
+	var c cache
+	if s := c.SetOrGet("0", secret); s != secret {
 		t.Fatalf("Expected to be able to add an entry: got: %x - want: %x", s, secret)
 	}
 	if s, ok := c.Get("0"); !ok || s != secret {
@@ -41,16 +39,16 @@ func TestCacheAdd(t *testing.T) {
 	}
 
 	secret[0] = 0x11
-	if s, ok := c.Add("0", secret); ok || s == secret {
+	if s := c.SetOrGet("0", secret); s == secret {
 		t.Fatal("Cache entry should already exist")
 	}
 }
 
 func TestCacheGet(t *testing.T) {
-	var secret secret.Secret
+	var secret Secret
 	secret[0] = 0xff
 
-	var c Cache
+	var c cache
 	c.Set("0", secret)
 	if s, ok := c.Get("0"); !ok || s != secret {
 		t.Fatalf("Expected to find cache entry: got: %x - want: %x", s, secret)
@@ -61,10 +59,10 @@ func TestCacheGet(t *testing.T) {
 }
 
 func TestCacheDelete(t *testing.T) {
-	var secret secret.Secret
+	var secret Secret
 	secret[0] = 0xff
 
-	var c Cache
+	var c cache
 	c.Set("0", secret)
 	if s, ok := c.Get("0"); !ok || s != secret {
 		t.Fatalf("Expected to find cache entry: got: %x - want: %x", s, secret)
@@ -74,30 +72,6 @@ func TestCacheDelete(t *testing.T) {
 	c.Delete("1")
 
 	if s, ok := c.Get("0"); ok || s == secret {
-		t.Fatal("Cache entry should not exist")
-	}
-}
-
-func TestCacheClear(t *testing.T) {
-	var secret secret.Secret
-	secret[0] = 0xff
-
-	var c Cache
-	c.Set("0", secret)
-	c.Set("1", secret)
-	if s, ok := c.Get("0"); !ok || s != secret {
-		t.Fatalf("Expected to find cache entry: got: %x - want: %x", s, secret)
-	}
-	if s, ok := c.Get("1"); !ok || s != secret {
-		t.Fatalf("Expected to find cache entry: got: %x - want: %x", s, secret)
-	}
-
-	c.Clear()
-
-	if s, ok := c.Get("0"); ok || s == secret {
-		t.Fatal("Cache entry should not exist")
-	}
-	if s, ok := c.Get("1"); ok || s == secret {
 		t.Fatal("Cache entry should not exist")
 	}
 }

--- a/internal/secret/ciphertext_test.go
+++ b/internal/secret/ciphertext_test.go
@@ -1,0 +1,127 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package secret
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+var marshalCiphertextTests = []struct {
+	LocalKey Secret
+	KMSKey   string
+	Bytes    []byte
+
+	Output string
+}{
+	{ // 0
+		LocalKey: Secret{},
+		KMSKey:   "",
+		Bytes:    nil,
+		Output:   `{"local_key":{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"kms_key":"","ciphertext":null}`,
+	},
+	{ // 1
+		LocalKey: mustDecodeSecret("e01218424a659aeb575a4320dfc7a7ada78f9ec6106ae210921cc1843ef1b3e5"),
+		KMSKey:   "5f91e7d9-a376-47cd-ad6f-3485abf9122c",
+		Bytes:    mustDecodeHex("0102020078056328069c2aa385a68a7d5010dd7e46f9a3175602d8446a91c53628164e7cf301c06112f393a2449acca50f3b1f5f2774000001233082011f06092a864886f70d010706a08201103082010c0201003082010506092a864886f70d010701301e060960864801650304012e3011040c29e53e22e65a8b36c9ab37aa0201108081d71da1a4c2d2f99738df327c81915b3e2c3983b5ec8d6985a11f06e50d89ac139b3cfd3556c78d9d5033d232826d9608ee038b1c52a947b7f08f0161268c0a3ddd4f3ecb9549e7617dd019d76c0666f33807a9ec6e5f276a22ec3f77a7e48aa17c81771e3605c9c595c1f3538981dec5808f4dde22a60374abef2b07dd19422528e5743da9e6bc92a61140f6d2efdbae16478f992fae600e12e087fb3482f90d3ad1ccdba90839d08affa536aabf987b5f621bc61280dac809a94fcae8413b6437deb62bb84373f78a4d95bb6ddf7e4d8b270735c89372f8"),
+		Output:   `{"local_key":{"bytes":"4BIYQkplmutXWkMg38enraePnsYQauIQkhzBhD7xs+U="},"kms_key":"5f91e7d9-a376-47cd-ad6f-3485abf9122c","ciphertext":"AQICAHgFYygGnCqjhaaKfVAQ3X5G+aMXVgLYRGqRxTYoFk588wHAYRLzk6JEmsylDzsfXyd0AAABIzCCAR8GCSqGSIb3DQEHBqCCARAwggEMAgEAMIIBBQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwp5T4i5lqLNsmrN6oCARCAgdcdoaTC0vmXON8yfIGRWz4sOYO17I1phaEfBuUNiawTmzz9NVbHjZ1QM9Iygm2WCO4DixxSqUe38I8BYSaMCj3dTz7LlUnnYX3QGddsBmbzOAep7G5fJ2oi7D93p+SKoXyBdx42BcnFlcHzU4mB3sWAj03eIqYDdKvvKwfdGUIlKOV0PanmvJKmEUD20u/brhZHj5kvrmAOEuCH+zSC+Q060czbqQg50Ir/pTaqv5h7X2IbxhKA2sgJqU/K6EE7ZDfetiu4Q3P3ik2Vu23ffk2LJwc1yJNy+A=="}`,
+	},
+}
+
+func TestMarshalCiphertext(t *testing.T) {
+	type Ciphertext struct {
+		LocalKey Secret `json:"local_key"`
+		Key      string `json:"kms_key"`
+		Bytes    []byte `json:"ciphertext"`
+	}
+	for i, test := range marshalCiphertextTests {
+		output, err := json.Marshal(Ciphertext{
+			LocalKey: test.LocalKey,
+			Key:      test.KMSKey,
+			Bytes:    test.Bytes,
+		})
+		if err != nil {
+			t.Fatalf("Test %d: Failed to marshal ciphertext: %v", i, err)
+		}
+		if string(output) != test.Output {
+			t.Fatalf("Test %d: marshal output mismatch: \ngot  '%s'\nwant '%s'", i, string(output), test.Output)
+		}
+	}
+}
+
+var unmarshalCiphertextTests = []struct {
+	Input string
+
+	LocalKey Secret
+	KMSKey   string
+	Bytes    []byte
+}{
+	{ // 0
+		Input: `{"local_key":{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"kms_key":"","ciphertext":null}`,
+
+		LocalKey: Secret{},
+		KMSKey:   "",
+		Bytes:    nil,
+	},
+	{ // 1
+		Input: `{"local_key":{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"kms_key":"5f91e7d9-a376-47cd-ad6f-3485abf9122c","ciphertext":null}`,
+
+		LocalKey: Secret{},
+		KMSKey:   "5f91e7d9-a376-47cd-ad6f-3485abf9122c",
+		Bytes:    nil,
+	},
+	{ // 2
+		Input: `{"local_key":{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"kms_key":"","ciphertext":"u41kHS7VEy/3vJz3anJmZ9Jt2ajx4HBkcwHxmo6KiUSOzjsP3h9+0bymOosQiXvk"}`,
+
+		LocalKey: Secret{},
+		KMSKey:   "",
+		Bytes:    mustDecodeHex("bb8d641d2ed5132ff7bc9cf76a726667d26dd9a8f1e070647301f19a8e8a89448ece3b0fde1f7ed1bca63a8b10897be4"),
+	},
+	{ // 3
+		Input: `{"local_key":{"bytes":"4BIYQkplmutXWkMg38enraePnsYQauIQkhzBhD7xs+U="},"kms_key":"5f91e7d9-a376-47cd-ad6f-3485abf9122c","ciphertext":"AQICAHgFYygGnCqjhaaKfVAQ3X5G+aMXVgLYRGqRxTYoFk588wHAYRLzk6JEmsylDzsfXyd0AAABIzCCAR8GCSqGSIb3DQEHBqCCARAwggEMAgEAMIIBBQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwp5T4i5lqLNsmrN6oCARCAgdcdoaTC0vmXON8yfIGRWz4sOYO17I1phaEfBuUNiawTmzz9NVbHjZ1QM9Iygm2WCO4DixxSqUe38I8BYSaMCj3dTz7LlUnnYX3QGddsBmbzOAep7G5fJ2oi7D93p+SKoXyBdx42BcnFlcHzU4mB3sWAj03eIqYDdKvvKwfdGUIlKOV0PanmvJKmEUD20u/brhZHj5kvrmAOEuCH+zSC+Q060czbqQg50Ir/pTaqv5h7X2IbxhKA2sgJqU/K6EE7ZDfetiu4Q3P3ik2Vu23ffk2LJwc1yJNy+A=="}`,
+
+		LocalKey: mustDecodeSecret("e01218424a659aeb575a4320dfc7a7ada78f9ec6106ae210921cc1843ef1b3e5"),
+		KMSKey:   "5f91e7d9-a376-47cd-ad6f-3485abf9122c",
+		Bytes:    mustDecodeHex("0102020078056328069c2aa385a68a7d5010dd7e46f9a3175602d8446a91c53628164e7cf301c06112f393a2449acca50f3b1f5f2774000001233082011f06092a864886f70d010706a08201103082010c0201003082010506092a864886f70d010701301e060960864801650304012e3011040c29e53e22e65a8b36c9ab37aa0201108081d71da1a4c2d2f99738df327c81915b3e2c3983b5ec8d6985a11f06e50d89ac139b3cfd3556c78d9d5033d232826d9608ee038b1c52a947b7f08f0161268c0a3ddd4f3ecb9549e7617dd019d76c0666f33807a9ec6e5f276a22ec3f77a7e48aa17c81771e3605c9c595c1f3538981dec5808f4dde22a60374abef2b07dd19422528e5743da9e6bc92a61140f6d2efdbae16478f992fae600e12e087fb3482f90d3ad1ccdba90839d08affa536aabf987b5f621bc61280dac809a94fcae8413b6437deb62bb84373f78a4d95bb6ddf7e4d8b270735c89372f8"),
+	},
+}
+
+func TestUnmarshalCiphertext(t *testing.T) {
+	type Ciphertext struct {
+		LocalKey Secret `json:"local_key"`
+		Key      string `json:"kms_key"`
+		Bytes    []byte `json:"ciphertext"`
+	}
+	for i, test := range unmarshalCiphertextTests {
+		var ciphertext Ciphertext
+		err := json.Unmarshal([]byte(test.Input), &ciphertext)
+		if err != nil {
+			t.Fatalf("Test %d: Unmarshal failed: %v", i, err)
+		}
+
+		if ciphertext.LocalKey != test.LocalKey {
+			t.Fatalf("Test %d: local key mismatch: got '%x' - want '%x'", i, ciphertext.LocalKey, test.LocalKey)
+		}
+		if ciphertext.Key != test.KMSKey {
+			t.Fatalf("Test %d: KMS key mismatch: got '%s' - want '%s'", i, ciphertext.Key, test.KMSKey)
+		}
+
+		if !bytes.Equal(ciphertext.Bytes, test.Bytes) {
+			t.Fatalf("Test %d: ciphertext bytes mismatch: \ngot  '%x'\nwant '%x'", i, ciphertext.Bytes, test.Bytes)
+		}
+
+		// We also test that if we can successfully unmarshal a ciphertext
+		// then we should be able to successfully marshal it as well.
+
+		output, err := json.Marshal(ciphertext)
+		if err != nil {
+			t.Fatalf("Test %d: Failed to marshal ciphertext: %v", i, err)
+		}
+		if string(output) != test.Input {
+			t.Fatalf("Test %d: marshal output mismatch: \ngot  '%s'\nwant '%s'", i, string(output), test.Input)
+		}
+	}
+}

--- a/internal/secret/kms.go
+++ b/internal/secret/kms.go
@@ -1,0 +1,32 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package secret
+
+// KMS is a key management system that holds a set
+// of cryptographic secret keys. The KMS interface
+// specifies what operations can be performed with
+// these secret keys.
+//
+// In particularly, a KMS can encrypt a value, i.e.
+// a secret, with one of its cryptographic keys and
+// returns the encrypted value as ciphertext.
+// The ciphertext can then be passed to the KMS
+// again - together with the same key name - which
+// then tries to decrypt it and returns the plaintext
+// on success.
+type KMS interface {
+	// Encrypt encrypts the given plaintext with the
+	// cryptographic key referenced by the given key name.
+	// It returns the encrypted plaintext as ciphertext.
+	// If the encryption fails Encrypt returns a non-nil
+	// error.
+	Encrypt(key string, plaintext []byte) (ciphertext []byte, err error)
+
+	// Decrypt tries to decrypt the given ciphertext
+	// and returns the secret plaintext on success.
+	// If the decryption fails Decrypt returns a non-nil
+	// error.
+	Decrypt(key string, ciphertext []byte) (plaintext []byte, err error)
+}

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/secure-io/sio-go/sioutil"
@@ -31,12 +30,16 @@ func TestSecretString(t *testing.T) {
 	}
 }
 
-func TestSecretWriteTo(t *testing.T) {
-	for i, test := range secretStringTests {
-		var sb strings.Builder
-		test.Secret.WriteTo(&sb)
-		if s := sb.String(); s != test.String {
-			t.Fatalf("Test %d: got %s - want %s", i, s, test.String)
+var secretMarshalJSONTests = secretStringTests
+
+func TestSecretMarshalJSON(t *testing.T) {
+	for i, test := range secretMarshalJSONTests {
+		s, err := test.Secret.MarshalJSON()
+		if err != nil {
+			t.Fatalf("Test %d: Failed to marshal secret: %v", i, err)
+		}
+		if string(s) != test.String {
+			t.Fatalf("Test %d: got %s - want %s", i, string(s), test.String)
 		}
 	}
 }
@@ -71,15 +74,17 @@ func TestSecretParseString(t *testing.T) {
 	}
 }
 
-func TestSecretReadFrom(t *testing.T) {
-	for i, test := range secretParseStringTests {
+var secretUnmarshalJSONTests = secretParseStringTests
+
+func TestSecretUnmarshalJSON(t *testing.T) {
+	for i, test := range secretUnmarshalJSONTests {
 		var secret Secret
-		_, err := secret.ReadFrom(strings.NewReader(test.String))
+		err := secret.UnmarshalJSON([]byte(test.String))
 		if err != nil && !test.ShouldFail {
-			t.Fatalf("Test %d: Failed to parse string: %v", i, err)
+			t.Fatalf("Test %d: Failed to unmarshal JSON: %v", i, err)
 		}
 		if err == nil && test.ShouldFail {
-			t.Fatalf("Test %d: Parsing should have failed but it succeeded", i)
+			t.Fatalf("Test %d: Unmarshaling should have failed but it succeeded", i)
 		}
 		if err == nil && secret != test.Secret {
 			t.Fatalf("Test %d: got %x - want %x", i, secret, test.Secret)

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -4,10 +4,287 @@
 
 package secret
 
-type Store interface {
-	Create(string, Secret) error
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
 
-	Delete(string) error
+	"github.com/secure-io/sio-go/sioutil"
+)
 
-	Get(string) (Secret, error)
+// MaxSize is the max. size of a (encrypted) secret.
+//
+// Neither a secret nor an encrypted secret should
+// be larger than 1 MiB.
+//
+// Implementions of Remote should use this to limit
+// the amount of data they read from the key-value
+// store.
+const MaxSize = 1 << 20 // 1 MiB
+
+// Remote is a key-value store for plain or
+// encrypted secrets. Therefore, it stores
+// keys and values as strings.
+//
+// Remote is the interface that must be
+// implemented by secret store backends,
+// like Vault or AWS SecretsManager.
+type Remote interface {
+	// Create adds the given key-value pair to
+	// the remote store if and only if no entry
+	// for the given key exists already.
+	//
+	// If key already exists at the remote store
+	// it does not replace the secret and returns
+	// kes.ErrKeyExists.
+	//
+	// Create returns the first error it encounters
+	// while trying to add the given key-value pair
+	// to the store, if any.
+	Create(key string, value string) error
+
+	// Delete deletes the given key and the associated
+	// value from the remote store. It does not return
+	// an non-nil error if the key does not exist.
+	//
+	// Delete returns the first error it encounters
+	// while trying to delete the given key from the
+	// store, if any.
+	Delete(key string) error
+
+	// Get returns the value associated with the given
+	// key. If no value is associated with key then Get
+	// returns kes.ErrKeyNotFound.
+	//
+	// Get returns the first error it encounters while
+	// trying to add the given key-value pair to the
+	// store, if any.
+	Get(key string) (value string, err error)
+}
+
+// Store is the local secret store connected
+// to a remote key-value store.
+//
+// It is responsible for en/decrypting secrets
+// if a KMS is present and for caching secrets
+// fetched from the remote key value store.
+type Store struct {
+	// Key is the name of the cryptographic key
+	// at the KMS used to encrypt newly created
+	// secrets before sending them to the remote
+	// key-value store.
+	//
+	// If KMS is nil it will be ignored.
+	// It must not be modified once the Store
+	// has been used to fetch or store secrets.
+	Key string
+
+	// KMS is the KMS implementation used to
+	// encrypt secrets before sending them to
+	// the remove key-value store.
+	//
+	// It uses the Store.Key as the default
+	// cryptographic key for encrypting new
+	// secrets
+	//
+	// If the KMS is nil then all newly created
+	// secrets will be stored as plaintext.
+	//
+	// If KMS is present and the remote key-value
+	// store returns a plaintext value then the
+	// Store still tries to decrypt the plaintext
+	// value - which should fail.
+	// Similarly, if no KMS is present and the
+	// remote key-value store returns an encrypted
+	// value then the Store does not try to decrypt
+	// the value.
+	// Basically, the remote store must return only
+	// plaintext values or ciphertext values - but
+	// not both.
+	//
+	// It must not be modified once the Store has been
+	// used to fetch or store secrets.
+	KMS KMS
+
+	// Remote is the remote key-value store. Secrets
+	// will be fetched from or written to this store.
+	//
+	// It must not be modified once the Store has been
+	// used to fetch or store secrets.
+	Remote Remote
+
+	cache cache
+	once  sync.Once // For the cache garbage collection
+}
+
+// Create adds the given secret with the given name to
+// the secret store. If there is already a secret with
+// this name then it does not replacce the secret and
+// returns kes.ErrKeyExists.
+func (s *Store) Create(name string, secret Secret) (err error) {
+	var value string
+	if s.KMS != nil {
+		value, err = s.encrypt(secret)
+		if err != nil {
+			return err
+		}
+	} else {
+		value = secret.String()
+	}
+
+	if err = s.Remote.Create(name, value); err != nil {
+		return err
+	}
+	s.cache.SetOrGet(name, secret)
+	return nil
+}
+
+// Delete deletes the secret associated with the given
+// name, if one exists.
+func (s *Store) Delete(name string) error {
+	// We can always remove a secret from the cache.
+	// If the delete operation on the remote store
+	// fails we will fetch it again on the next Get.
+	s.cache.Delete(name)
+	return s.Remote.Delete(name)
+}
+
+// Get returns the secret associated with the given name,
+// if any. If no such secret exists it returns
+// kes.ErrKeyNotFound.
+func (s *Store) Get(name string) (Secret, error) {
+	if secret, ok := s.cache.Get(name); ok {
+		return secret, nil
+	}
+
+	value, err := s.Remote.Get(name)
+	if err != nil {
+		return Secret{}, err
+	}
+
+	var secret Secret
+	if s.KMS != nil {
+		secret, err = s.decrypt(value)
+		if err != nil {
+			return Secret{}, err
+		}
+	} else {
+		if err = secret.ParseString(value); err != nil {
+			return Secret{}, err
+		}
+	}
+	return s.cache.SetOrGet(name, secret), nil
+}
+
+// StartGC starts the cache garbage collection background process.
+// The GC will discard all cached secrets after expiry. Further,
+// it will discard all entries that havn't been used for unusedExpiry.
+//
+// If expiry is 0 the GC will not discard any secrets. Similarly, if
+// the unusedExpiry is 0 then the GC will not discard unused secrets.
+//
+// There is only one garbage collection background process. Calling
+// StartGC more than once has no effect.
+func (s *Store) StartGC(ctx context.Context, expiry, unusedExpiry time.Duration) {
+	s.once.Do(func() {
+		s.cache.StartGC(ctx, expiry)
+
+		// Actually, we also don't run the unused GC if unusedExpiry/2 == 0,
+		// not if unusedExpiry == 0.
+		// However, that can only happen if unusedExpiry is 1ns - which is
+		// anyway an unreasonable value for the expiry.
+		s.cache.StartUnusedGC(ctx, unusedExpiry/2)
+	})
+}
+
+// encrypt encrypts the given secret with the Store.KMS
+// and returns the string representation of the ciphertext.
+//
+// More specifically, encrypt first encrypts the secret
+// with a randomly generated secret key. The result of
+// this first encryption gets then passed to the KMS -
+// which performs a second encryption with the key
+// referenced by Store.Key.
+//
+// This two-stage encryption process ensures that one the
+// one hand access to the KMS is necessary to decrypt the
+// secret again and on the other hand the KMS provider is
+// not able to learn the plaintext secrets.
+// If we would not encrypt the secret *before* sending it
+// to the KMS then whoever can observe/inspect the KMS can
+// sees our secrets in plaintext.
+//
+// The randomly generated secret key for the first encryption
+// stage is embedded into the returned ciphertext string.
+func (s *Store) encrypt(secret Secret) (string, error) {
+	var localKey Secret
+	random, err := sioutil.Random(len(localKey))
+	if err != nil {
+		return "", err
+	}
+	copy(localKey[:], random)
+
+	bytes, err := localKey.Wrap([]byte(secret.String()), []byte(s.Key))
+	if err != nil {
+		return "", err
+	}
+	bytes, err = s.KMS.Encrypt(s.Key, bytes)
+	if err != nil {
+		return "", err
+	}
+
+	type Ciphertext struct {
+		LocalKey Secret `json:"local_key"`
+
+		KeyName string `json:"kms_key"`
+		Bytes   []byte `json:"ciphertext"`
+	}
+	ciphertext, err := json.Marshal(Ciphertext{
+		LocalKey: localKey,
+		KeyName:  s.Key,
+		Bytes:    bytes,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(ciphertext), nil
+}
+
+// decrypt tries to decrypt the given string representation
+// of an encrypted secret with the Store.KMS and returns the
+// plaintext secret on success.
+//
+// Therefore, it parses the given ciphertext string, decrypts
+// the actual ciphertext bytes using the KMS and then uses the
+// local key (part of the ciphertext string) to decrypt the
+// response from the KMS.
+// See: encrypt for more details about this two-stage process.
+func (s *Store) decrypt(ciphertext string) (Secret, error) {
+	type Ciphertext struct {
+		LocalKey Secret `json:"local_key"`
+
+		KeyName string `json:"kms_key"`
+		Bytes   []byte `json:"ciphertext"`
+	}
+
+	var ctxt Ciphertext
+	if err := json.Unmarshal([]byte(ciphertext), &ctxt); err != nil {
+		return Secret{}, err
+	}
+
+	plaintext, err := s.KMS.Decrypt(ctxt.KeyName, ctxt.Bytes)
+	if err != nil {
+		return Secret{}, err
+	}
+	plaintext, err = ctxt.LocalKey.Unwrap(plaintext, []byte(ctxt.KeyName))
+	if err != nil {
+		return Secret{}, err
+	}
+
+	var secret Secret
+	if err = secret.ParseString(string(plaintext)); err != nil {
+		return Secret{}, err
+	}
+	return secret, nil
 }

--- a/server-config.toml
+++ b/server-config.toml
@@ -128,6 +128,30 @@ file = [ "" ] # Add one or more log file paths here.
 [audit]
 file = [ "" ] # Add one or more log file paths here
 
+# External KMS configuration. An external KMS holds a set
+# of cryptographic secret keys - which can be used to encrypt
+# resp. decrypt secrets.
+# The kes server will try to encrypt resp. decrypt secrets
+# before storing resp. fetching them form the key store.
+# If an external KMS is set the kes server will only accept
+# encrypted secrets and no more plaintext secrets.
+#
+# The AWS key management system (AWS-KMS). If set, the kes
+# server will send all secrets to AWS to encrypt resp. decrypt
+# them before / after storing resp. fetching them from the
+# key store.
+[kms.aws]
+address = "" # The AWS-KMS endpoint - e.g.: kms.us-east-2.amazonaws.com
+region  = "" # The AWS region of the Secrets Manager - e.g.: "us-east-2"
+key     = "" # The AWS-KMS key ID (CMK ID) used to encrypt new secrets.
+
+# The AWS credentials to authenticate to AWS-KMS.
+[kms.aws.credentials]
+access_key    = "" # Your AWS Access Key
+secret_key    = "" # Your AWS Secret Key
+session_token = "" # Your AWS session token (usually optional)
+
+
 # Key stores configuration. A key store holds secret keys.
 # A server can only be configured to use one key store at
 # the same time.

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -133,6 +133,28 @@ log:
     file:  
     - ""  # Add one or more log file paths here.
 
+# External KMS configuration. An external KMS holds a set
+# of cryptographic secret keys - which can be used to encrypt
+# resp. decrypt secrets.
+# The kes server will try to encrypt resp. decrypt secrets
+# before storing resp. fetching them form the key store.
+# If an external KMS is set the kes server will only accept
+# encrypted secrets and no more plaintext secrets.
+kms:
+  # The AWS key management system (AWS-KMS). If set, the kes
+  # server will send all secrets to AWS to encrypt resp. decrypt
+  # them before / after storing resp. fetching them from the
+  # key store.
+  aws:
+    address: "" # The AWS-KMS endpoint - e.g.: kms.us-east-2.amazonaws.com
+    region: ""  # The AWS region of the Secrets Manager - e.g.: "us-east-2"
+    key: ""     # The AWS-KMS key ID (CMK ID) used to encrypt new secrets.
+    # The AWS credentials to authenticate to AWS-KMS.
+    credentials:
+      access_key: ""    # Your AWS Access Key
+      secret_key: ""    # Your AWS Secret Key
+      session_token: "" # Your AWS session token (usually optional)
+
 # Key stores configuration. A key store holds secret keys.
 # A server can only be configured to use one key store at
 # the same time.


### PR DESCRIPTION
This commit implements encrypted secrets.
Before, KES stored all secrets as plaintext at the
backend secret store. Therefore, KES assumed/required
that the secret store is a secure/trusted component.

While this assumption may be true for secret stores like
Vault or AWS SecretsManager it is not true in the general
case. Further, even if the secret store is considered trusted
it may be desirable to separate the trust between the secret
storage provider and another party.

Therefore, a KES server may want to encrypt secrets before
storing them at the secret store. In general, KES encrypts
secrets with an (external) KMS - like Vault, AWS-KMS or
Azure Vault. Therefore, KES sends a secret to the KMS before
writing it to the secret store. However, it doesn't send the
secret as plaintext to the KMS since that would reveal the
secret to the operator of the KMS / anyone who can inspect
KMS operations.

Instead, it generates a random (local) cryptographic key
when creating a secret and encrypts the secret with that key
*before* sending the secret to the KMS. So, the KMS only
sees ciphertexts (`Enc(local_key, secret)`). The local key
is then embedded into the value written to the secret store.

This construction ensures that neither the secret store provider
nor the KMS provider can decrypt an encrypted secret on their own.
So, it is possible to leverage e.g. a cloud KMS provider (AWS, Google,
MS, ...) to encrypt secrets on some local storage without sharing
these secrets with the cloud provider.

***

Therefore, this commit changes the architecture of the exiting code
quite a bit:

There is now a local store (`secret.Store`) and a remote store
(`secret.Remote`). The `secret.Store` implements en/decryption
(via the `secret.KMS` interface) and is responsible for caching
secrets.
The `secret.Remote` interface defines what operations a secret
store has to provide and must be implemented by all secret store
implementations.

Since, a secret store now can contain plaintext and encrypted
secrets the `secret.Remote` consumes strings while `secret.Store`
consumes `secret.Secret`.
However, for now we demand that the secret store returns only
plaintext secrets or encrypted secrets - but not both. When
the KES server is configured to use a KMS it will always try
to decrypt values from the secret store - including plaintext
secrets which should fail.

An encrypted secret has the following format:
```
{
  "local_key": {
    "bytes": "4BIYQkplmutXWkMg38enraePnsYQauIQkhzBhD7xs+U="
  },
  "kms_key": "5f91e7d9-a376-47cd-ad6f-3485abf9122c",
  "ciphertext":"<base64-encoded-ciphertext>"
}
```

The `local_key` is the cryptographic key used to encrypt
the plaintext secret before sending it to the KMS.
The `kms_key` is the name of the cryptographic key at
the KMS used encrypt the secret (ciphertext).
So, the result of encrypting the plaintext first with
the local key and then with the KMS is `ciphertext`.

***

Apart from this conceptual change, this commit also
adds a `secret.KMS` implementation for the AWS-KMS and
extends the KES server configuration to provide an
AWS-KMS configuration.