### PR TITLE
pretty-print audit log response time

### DIFF
--- a/cmd/kes/audit.go
+++ b/cmd/kes/audit.go
@@ -144,12 +144,23 @@ func auditTrace(args []string) error {
 				identity = color.YellowString(entry.Request.Identity.String())
 			}
 
+			// Truncate duration values such that we show reasonable
+			// time values - like 1.05s or 345.76ms.
+			respTime := entry.Response.Time
+			switch {
+			case respTime >= time.Second:
+				respTime = respTime.Truncate(10 * time.Millisecond)
+			case respTime >= time.Millisecond:
+				respTime = respTime.Truncate(10 * time.Microsecond)
+			default:
+				respTime = respTime.Truncate(time.Microsecond)
+			}
+
 			const format = "%s %s %-25s %10s\n"
-			fmt.Printf(format, identity, status, entry.Request.Path, entry.Response.Time.Truncate(1*time.Microsecond))
+			fmt.Printf(format, identity, status, entry.Request.Path, respTime)
 		} else {
 			fmt.Println(scanner.Text())
 		}
 	}
 	return nil
-
 }


### PR DESCRIPTION
This commit improves the request-response time
printing while tracing the audit log.

Before, the response time has been truncated to
microseconds. However, when a request-response
takes about 1 seconds the printed time may
be 1.123567s.

This commit fixes this by truncating the printed
time to 10s of milliseconds resp. 10 of microseconds.
This ensures that the audit log shows request-response
times like 1.15s or 256.99ms.

When dealing with times smaller than 1 millisecond we
keep the old behavior to show times like 17μs or 117μs.

I haven't observed sub-microsecond response times, yet -
not even on localhost (local network interface roundtrip).