### PR TITLE
do not use broken key derivation for AES-GCM

### DIFF
--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -190,7 +190,7 @@ func TestSecrectUnwrap(t *testing.T) {
 	}
 }
 
-var aesDeriveKeyTests = []struct {
+var insecureAESDeriveKeyTests = []struct {
 	Key        []byte
 	IV         []byte
 	DerivedKey []byte
@@ -228,9 +228,9 @@ var aesDeriveKeyTests = []struct {
 	},
 }
 
-func TestAESDeriveKey(t *testing.T) {
-	for i, test := range aesDeriveKeyTests {
-		key, err := aesDeriveKey(test.Key, test.IV)
+func TestInsecureAESDeriveKey(t *testing.T) {
+	for i, test := range insecureAESDeriveKeyTests {
+		key, err := insecureAESDeriveKey(test.Key, test.IV)
 		if err != nil && !test.ShouldFail {
 			t.Fatalf("Test %d: Failed to derive key: %v", i, err)
 		}


### PR DESCRIPTION
This commit fixes a cryptographic security issue
w.r.t. wrapping data encryption keys.

The key derivation function (KDF) used when a
data encryption key is sealed is not a PRF.

One way to show that a function is not a PRF is
to proof that there is a relation between different
output values of the function.

In particular, the AES key derivation function used
before has the following property:
```
Let v0, v1, v2 and v3 be 128 bit values (HEX) as following:
 v0 = 00000000000000000000000000000000
 v1 = 01000000000000000000000000000000
 v2 = 00000000000000000000000000000001
 v3 = 01000000000000000000000000000001

Further let K be an arbitrary 256 bit key and f the AES key
derivation function. Then invoking f with K and the iv values
returns 4 output values
 k0 = f(K, v0)
 k1 = f(K, v1)
 k2 = f(K, v2)
 k3 = f(K, v3)

Now, the following statement is true:
 k0 ^ k1 ^ k2 == k3  // ^ is XOR

So, from deriving k0, k1, k2 you can infer k3. This clearly
violates the definition of a PRF.
```

This commit fixes this by replacing the KDF with `HMAC-SHA-256`.
Since, HMAC has been proven to a PRF if the used hash function is
collision-resistant this is an adequate fix.

However, switching to HMAC-SHA-256 is not ideal in the sense
that we now rely on 2 primitives (AES and SHA-256) instead of one.
However, this can be addressed in the future when more research has
been done.