### PR TITLE
add support for Vault as KMS provider

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}

--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -52,6 +52,29 @@ type serverConfig struct {
 	} `toml:"log" yaml:"log"`
 
 	KMS struct {
+		Vault struct {
+			Addr      string `toml:"address" yaml:"address"`
+			Namespace string `toml:"namespace" yaml:"namespace"`
+
+			Key string `toml:"key" yaml:"key"`
+
+			AppRole struct {
+				ID     string        `toml:"id" yaml:"id"`
+				Secret string        `toml:"secret" yaml:"secret"`
+				Retry  time.Duration `toml:"retry" yaml:"retry"`
+			} `toml:"approle" yaml:"approle"`
+
+			TLS struct {
+				KeyPath  string `toml:"key" yaml:"key"`
+				CertPath string `toml:"cert" yaml:"cert"`
+				CAPath   string `toml:"ca" yaml:"ca"`
+			} `toml:"tls" yaml:"tls"`
+
+			Status struct {
+				Ping time.Duration `toml:"ping" yaml:"ping"`
+			} `toml:"status" yaml:"status"`
+		} `toml:"vault" yaml:"vault"`
+
 		AWS struct {
 			Addr   string `toml:"address" yaml:"address"`
 			Region string `toml:"region" yaml:"region"`

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -1,0 +1,202 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// client is a generic vault client that
+// implements common functionality for
+// the vault.Store and vault.KMS
+type client struct {
+	*vaultapi.Client
+
+	sealed uint32 // Atomic bool: sealed == 0 is false, sealed == 1 is true
+}
+
+// Sealed returns true if the most recently fetched vault
+// health status indicates that the vault server is sealed.
+//
+// Note that the most recently fetchted vault status may not
+// reflect the current status of the vault server - because it
+// may have changed in the meantime.
+//
+// If the vault health status hasn't been queried every then
+// Sealed returns false.
+func (c *client) Sealed() bool { return atomic.LoadUint32(&c.sealed) == 1 }
+
+// CheckStatus keeps fetching the vault health status every delay
+// unit of time until  <-ctx.Done() returns.
+//
+// Since CheckStatus starts an endless for-loop users should usually
+// invoke CheckStatus in a separate go routine:
+//   go client.CheckStatus(ctx, 10 * time.Second)
+//
+// If the delay == 0 CheckStatus uses a 10s delay by default.
+func (c *client) CheckStatus(ctx context.Context, delay time.Duration) {
+	if delay == 0 {
+		delay = 10 * time.Second
+	}
+	var timer *time.Timer
+	for {
+		status, err := c.Sys().Health()
+		if err == nil {
+			if status.Sealed {
+				atomic.StoreUint32(&c.sealed, 1)
+			} else {
+				atomic.StoreUint32(&c.sealed, 0)
+			}
+		}
+
+		if timer == nil {
+			timer = time.NewTimer(delay)
+		} else {
+			timer.Reset(delay)
+		}
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// Authenticate tries to fetch a auth. token with an associated TTL
+// from the vault server by using the login AppRole credentials.
+//
+// To renew the auth. token see: client.RenewToken(...).
+func (c *client) Authenticate(login AppRole) (token string, ttl time.Duration, err error) {
+	secret, err := c.Logical().Write("auth/approle/login", map[string]interface{}{
+		"role_id":   login.ID,
+		"secret_id": login.Secret,
+	})
+	if err != nil || secret == nil {
+		// The Vault SDK eventually returns no error but also no
+		// secret. In this case have to return a (not very helpful)
+		// error to signal that the authentication failed - for some
+		// (unknown) reason.
+		if err == nil {
+			err = errors.New("vault: authentication failed: SDK returned no error but also no token")
+		}
+		return token, ttl, err
+	}
+
+	token, err = secret.TokenID()
+	if err != nil {
+		return token, ttl, err
+	}
+
+	ttl, err = secret.TokenTTL()
+	if err != nil {
+		return token, ttl, err
+	}
+	return token, ttl, err
+}
+
+// RenewToken tries to authenticate with the given AppRole
+// credentials if the given ttl is 0. Further, it keeps
+// trying to renew the the client auth. token before its
+// ttl expires until <-ctx.Done() returns.
+//
+// If the vault server becomes sealed, RenewToken stops
+// and waits until it becomes unsealed again. Therefore,
+// a client should have started a client.CheckStatus(...)
+// go routine in the background.
+//
+// If the authentication fails, RenewToken tries to
+// re-authenticate with the given login credentials.
+// Once this re-authentication succeeds, RenewToken
+// starts renewing the received token before its TTL
+// expires.
+// If the re-authentication fails, RenewToken retries
+// the authentication after login.Retry.
+//
+// If login.Retry == 0, RenewToken uses 5s delay by default.
+//
+// Since RenewToken starts a endless for-loop users should
+// usually invoke CheckStatus in a separate go routine:
+//   go client.RenewToken(ctx, login, ttl)
+func (c *client) RenewToken(ctx context.Context, login AppRole, ttl time.Duration) {
+	if login.Retry == 0 {
+		login.Retry = 5 * time.Second
+	}
+	for {
+		// If Vault is sealed we have to wait
+		// until it is unsealed again.
+		//
+		// Users should start client.CheckStatus() in
+		// another go routine to unblock this for-loop
+		// once vault becomes unsealed again.
+		for c.Sealed() {
+			timer := time.NewTimer(1 * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+
+		// If the TTL is 0 we cannot renew the token.
+		// Therefore, we try to re-authenticate and
+		// get a new token. We repeat that until we
+		// successfully authenticate and got a token.
+		if ttl == 0 {
+			var (
+				token string
+				err   error
+			)
+			token, ttl, err = c.Authenticate(login)
+			if err != nil {
+				ttl = 0 // On error, set the TTL again to 0 to re-auth. again.
+				timer := time.NewTimer(login.Retry)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
+				continue
+			}
+			c.SetToken(token) // SetToken is safe to call from different go routines
+		}
+
+		// Now the client has a token with a non-zero TTL
+		// such tht we can renew it. We repeat that until
+		// the renewable process fails once. In this case
+		// we try to re-authenticate again.
+		timer := time.NewTimer(ttl / 2)
+		for {
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			secret, err := c.Auth().Token().RenewSelf(int(ttl.Seconds()))
+			if err != nil || secret == nil {
+				break
+			}
+			if ok, err := secret.TokenIsRenewable(); !ok || err != nil {
+				break
+			}
+			ttl, err := secret.TokenTTL()
+			if err != nil || ttl == 0 {
+				break
+			}
+			timer.Reset(ttl / 2)
+		}
+		// If we exit the for-loop above set the TTL to 0 to trigger
+		// a re-authentication.
+		ttl = 0
+	}
+}

--- a/internal/vault/kms.go
+++ b/internal/vault/kms.go
@@ -1,0 +1,259 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package vault
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/secret"
+)
+
+// KMS is a Vault KMS client that implements the
+// secret.KMS interface.
+//
+// It can be used to encrypt secrets before storing
+// them at a key store resp. decrypt them after
+// fetching them from such a store.
+type KMS struct {
+	// Addr is the HTTP address of the Vault server.
+	Addr string
+
+	// AppRole contains the Vault AppRole authentication
+	// credentials.
+	AppRole AppRole
+
+	// StatusPingAfter is the duration after which
+	// the KMS will check the status of the Vault
+	// server. Particularly, this status information
+	// is used to determine whether the Vault server
+	// has been sealed resp. unsealed again.
+	StatusPingAfter time.Duration
+
+	// ErrorLog specifies an optional logger for errors
+	// when an encryption or decryption request fails.
+	// If nil, logging is done via the log package's
+	// standard logger.
+	ErrorLog *log.Logger
+
+	// Path to the mTLS client private key to authenticate to
+	// the Vault server.
+	ClientKeyPath string
+
+	// Path to the mTLS client certificate to authenticate to
+	// the Vault server.
+	ClientCertPath string
+
+	// Path to the root CA certificate(s) used to verify the
+	// TLS certificate of the Vault server. If empty, the
+	// host's root CA set is used.
+	CAPath string
+
+	// The Vault namespace used to separate and isolate different
+	// organizations / tenants at the same Vault instance. If
+	// non-empty, the Vault client will send the
+	//   X-Vault-Namespace: Namespace
+	// HTTP header on each request. For more information see:
+	// https://www.vaultproject.io/docs/enterprise/namespaces/index.html
+	Namespace string
+
+	client *client
+}
+
+var _ secret.KMS = (*KMS)(nil)
+
+// Authenticate tries to establish a connection to
+// a Vault server using the approle credentials.
+// It returns an error if no connection could be
+// established - for instance because of invalid
+// authentication credentials.
+func (kms *KMS) Authenticate(context context.Context) error {
+	tlsConfig := &vaultapi.TLSConfig{
+		ClientKey:  kms.ClientKeyPath,
+		ClientCert: kms.ClientCertPath,
+	}
+	if kms.CAPath != "" {
+		stat, err := os.Stat(kms.CAPath)
+		if err != nil {
+			return fmt.Errorf("Failed to open '%s': %v", kms.CAPath, err)
+		}
+		if stat.IsDir() {
+			tlsConfig.CAPath = kms.CAPath
+		} else {
+			tlsConfig.CACert = kms.CAPath
+		}
+	}
+
+	config := vaultapi.DefaultConfig()
+	config.Address = kms.Addr
+	config.ConfigureTLS(tlsConfig)
+	vaultClient, err := vaultapi.NewClient(config)
+	if err != nil {
+		return err
+	}
+	kms.client = &client{
+		Client: vaultClient,
+	}
+	if kms.Namespace != "" {
+		// We must only set the namespace if it is not
+		// empty. If namespace == "" the vault client
+		// will send an empty namespace HTTP header -
+		// which is not what we want.
+		kms.client.SetNamespace(kms.Namespace)
+	}
+	go kms.client.CheckStatus(context, kms.StatusPingAfter)
+
+	token, ttl, err := kms.client.Authenticate(kms.AppRole)
+	if err != nil {
+		return err
+	}
+	kms.client.SetToken(token)
+	go kms.client.RenewToken(context, kms.AppRole, ttl)
+	return nil
+}
+
+var errEncryption = kes.NewError(http.StatusServiceUnavailable, "failed to encrypt key")
+
+// Encrypt tries to encrypt the given plaintext with the specified
+// key at the Vault KMS instance. It returns the encrypted plaintext
+// as ciphertext.
+func (kms *KMS) Encrypt(key string, plaintext []byte) ([]byte, error) {
+	if kms.client == nil {
+		kms.log(errNoConnection)
+		return nil, errEncryption
+	}
+	if kms.client.Sealed() {
+		kms.log("vault: server is sealed")
+		return nil, errEncryption
+	}
+
+	payload := map[string]interface{}{
+		"plaintext": base64.StdEncoding.EncodeToString(plaintext),
+	}
+	secret, err := kms.client.Logical().Write(fmt.Sprintf("/transit/encrypt/%s", key), payload)
+	if secret == nil && err == nil {
+		// Under certain conditions (e.g. Vault responds with 200 OK but does not send
+		// a response body - i.e. when Vault gets sealed) then the Vault SDK returns
+		// no secret but also no error.
+		kms.log("vault: server returned no ciphertext but also no error")
+		return nil, errEncryption
+	}
+	if err != nil {
+		if err, ok := err.(*vaultapi.ResponseError); ok {
+			switch {
+			case err.StatusCode == http.StatusForbidden:
+				kms.logf("vault: insufficient permissions to encrypt with '%s'", key)
+			case err.StatusCode == http.StatusNotFound:
+				kms.logf("vault: the key '%s' does not exist", key)
+			case len(err.Errors) > 0:
+				kms.logf("vault: %d %s: %v", err.StatusCode, http.StatusText(err.StatusCode), err.Errors[0])
+			default:
+				kms.logf("vault: %d %s: server has not sent any error message", err.StatusCode, http.StatusText(err.StatusCode))
+			}
+		} else {
+			kms.logf("vault: %v", err)
+		}
+		return nil, errEncryption
+	}
+
+	// If we receive a response from Vault we check whether
+	// it is well-formed.
+	v, ok := secret.Data["ciphertext"]
+	if !ok {
+		kms.log("vault: response does not contain any ciphertext")
+		return nil, errEncryption
+	}
+	ciphertext, ok := v.(string)
+	if !ok {
+		kms.log("vault: server has sent invalid ciphertext")
+		return nil, errEncryption
+	}
+	return []byte(ciphertext), nil
+}
+
+// Decrypt tries to decrypt the given ciphertext with the the given key
+// using the AWS-KMS. It returns the decrypted ciphertexts as plaintext
+// on success.
+func (kms *KMS) Decrypt(key string, ciphertext []byte) ([]byte, error) {
+	if kms.client == nil {
+		kms.log(errNoConnection)
+		return nil, kes.ErrKeySealed
+	}
+	if kms.client.Sealed() {
+		kms.log("vault: server is sealed")
+		return nil, kes.ErrKeySealed
+	}
+
+	// A vault ciphertext has the form: 'vault:<verion>:<base64-ciphertext>'
+	// Therefore, we pass the ciphertext as string directly to Vault.
+	payload := map[string]interface{}{
+		"ciphertext": string(ciphertext),
+	}
+	secret, err := kms.client.Logical().Write(fmt.Sprintf("/transit/decrypt/%s", key), payload)
+	if secret == nil && err == nil {
+		// Under certain conditions (e.g. Vault responds with 200 OK but does not send
+		// a response body - i.e. when Vault gets sealed) then the Vault SDK returns
+		// no secret but also no error.
+		kms.log("vault: server returned no plaintext but also no error")
+		return nil, kes.ErrKeySealed
+	}
+	if err != nil {
+		if err, ok := err.(*vaultapi.ResponseError); ok {
+			switch {
+			case err.StatusCode == http.StatusForbidden:
+				kms.logf("vault: insufficient permissions to decrypt with '%s'", key)
+			case len(err.Errors) > 0:
+				kms.logf("vault: %d %s: %v", err.StatusCode, http.StatusText(err.StatusCode), err.Errors[0])
+			default:
+				kms.logf("vault: %d %s: server has not sent any error message", err.StatusCode, http.StatusText(err.StatusCode))
+			}
+		} else {
+			kms.logf("vault: %v", err)
+		}
+		return nil, kes.ErrKeySealed
+	}
+
+	// If we receive a response from Vault we check whether
+	// it is well-formed.
+	v, ok := secret.Data["plaintext"]
+	if !ok {
+		kms.log("vault: response does not contain any plaintext")
+		return nil, kes.ErrKeySealed
+	}
+	plaintext, ok := v.(string)
+	if !ok {
+		kms.log("vault: server has sent invalid plaintext")
+		return nil, kes.ErrKeySealed
+	}
+	bytes, err := base64.StdEncoding.DecodeString(plaintext)
+	if err != nil {
+		kms.logf("vault: server has sent invalid plaintext: %v", err)
+		return nil, kes.ErrKeySealed
+	}
+	return bytes, nil
+}
+
+func (kms *KMS) log(v ...interface{}) {
+	if kms.ErrorLog == nil {
+		log.Println(v...)
+	} else {
+		kms.ErrorLog.Println(v...)
+	}
+}
+
+func (kms *KMS) logf(format string, v ...interface{}) {
+	if kms.ErrorLog == nil {
+		log.Printf(format, v...)
+	} else {
+		kms.ErrorLog.Printf(format, v...)
+	}
+}

--- a/server-config.toml
+++ b/server-config.toml
@@ -128,6 +128,7 @@ file = [ "" ] # Add one or more log file paths here.
 [audit]
 file = [ "" ] # Add one or more log file paths here
 
+
 # External KMS configuration. An external KMS holds a set
 # of cryptographic secret keys - which can be used to encrypt
 # resp. decrypt secrets.
@@ -136,6 +137,37 @@ file = [ "" ] # Add one or more log file paths here
 # If an external KMS is set the kes server will only accept
 # encrypted secrets and no more plaintext secrets.
 #
+# The Vault KMS configuration. If set, the kes server will
+# send all secrets to Vault to encrypt resp. decrypt them
+# before / after storing resp. fetching them from the key
+# store.
+[kms.vault]
+address   = "" # The Vault endpoint - e.g. https://127.0.0.1:8200
+key       = "" # The master key at Vault used to en/decrypt secrets - e.g. my-key
+namespace = "" # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
+
+# Vault AppRole access credentials.
+# See: https://www.vaultproject.io/docs/auth/approle.html 
+[kms.vault.approle]
+id     = ""    # Your AppRole Role ID 
+secret = ""    # Your AppRole Secret ID
+retry  = "15s" # Duration until the server tries to re-authenticate after connection loss.
+
+# Vault client TLS configuration.
+# The server will use the private key and certificate to
+# to authenticate to Vault via mTLS and use the Root CAs
+# found at the ca path to verify the Vault server TLS
+# certificate.
+[kms.vault.tls]
+key  = "" # Path to the TLS client private key for mTLS authentication to Vault
+cert = "" # Path to the TLS client certificate for mTLS authentication to Vailt
+ca   = "" # Path to one or multiple PEM Root CA certificates
+
+# Vault status configuration. The kes server will periodically
+# reach out to Vault to check its status. 
+[kms.vault.status]
+ping = "10s" # Duration until the server checks Vault's status again.
+
 # The AWS key management system (AWS-KMS). If set, the kes
 # server will send all secrets to AWS to encrypt resp. decrypt
 # them before / after storing resp. fetching them from the
@@ -151,7 +183,7 @@ access_key    = "" # Your AWS Access Key
 secret_key    = "" # Your AWS Secret Key
 session_token = "" # Your AWS session token (usually optional)
 
-
+    
 # Key stores configuration. A key store holds secret keys.
 # A server can only be configured to use one key store at
 # the same time.

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -141,6 +141,24 @@ log:
 # If an external KMS is set the kes server will only accept
 # encrypted secrets and no more plaintext secrets.
 kms:
+  # The Vault KMS configuration. If set, the kes server will
+  # send all secrets to Vault to encrypt resp. decrypt them
+  # before / after storing resp. fetching them from the key
+  # store.
+  vault:
+    address: ""   # The Vault endpoint - e.g. https://127.0.0.1:8200
+    namespace: "" # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
+    key: ""       # The master key at Vault used to en/decrypt secrets - e.g. my-key
+    approle:    # AppRole credentials. See: https://www.vaultproject.io/docs/auth/approle.html:
+      id: ""      # Your AppRole Role ID
+      secret: ""  # Your AppRole Secret ID
+      retry: 15s  # Duration until the server tries to re-authenticate after connection loss.
+    tls:        # The Vault client TLS configuration for mTLS authentication and certificate verification  
+      key: ""     # Path to the TLS client private key for mTLS authentication to Vault
+      cert: ""    # Path to the TLS client certificate for mTLS authentication to Vailt
+      ca: ""      # Path to one or multiple PEM Root CA certificates 
+    status:     # Vault status configuration. The kes server will periodically reach out to Vault to check its status. 
+      ping: 10s   # Duration until the server checks Vault's status again.
   # The AWS key management system (AWS-KMS). If set, the kes
   # server will send all secrets to AWS to encrypt resp. decrypt
   # them before / after storing resp. fetching them from the
@@ -179,10 +197,10 @@ keystore:
       secret: ""  # Your AppRole Secret ID
       retry: 15s  # Duration until the server tries to re-authenticate after connection loss.
     tls:        # The Vault client TLS configuration for mTLS authentication and certificate verification  
-      key: ""   # Path to the TLS client private key for mTLS authentication to Vault
-      cert: ""  # Path to the TLS client certificate for mTLS authentication to Vailt
-      ca: ""    # Path to one or multiple PEM Root CA certificates 
-    status:       # Vault status configuration. The kes server will periodically reach out to Vault to check its status. 
+      key: ""     # Path to the TLS client private key for mTLS authentication to Vault
+      cert: ""    # Path to the TLS client certificate for mTLS authentication to Vailt
+      ca: ""      # Path to one or multiple PEM Root CA certificates 
+    status:     # Vault status configuration. The kes server will periodically reach out to Vault to check its status. 
       ping: 10s   # Duration until the server checks Vault's status again.
   aws:
     # The AWS Secrets Manager key store. The server will store


### PR DESCRIPTION
This commit adds Vault as KMS provider
to encrypt secrets at the secret store
backend.

Therefore, this commit adds a section
for configuring Vault as KMS provider.

Overall, this commit adds Vault as a
second KMS provider similar to AWS-KMS.