### PR TITLE
aws-kms: honor error log configuration

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -183,6 +183,7 @@ func server(args []string) error {
 				SecretKey:    config.KMS.AWS.Login.SecretKey,
 				SessionToken: config.KMS.AWS.Login.SessionToken,
 			},
+			ErrorLog: errorLog.Log(),
 		}
 		if err = kms.Authenticate(); err != nil {
 			return fmt.Errorf("Failed to connect to AWS-KMS: %v", err)


### PR DESCRIPTION
This commit fixes a bug when initializing AWS-KMS.
Before, the error log was not passed to the AWS-KMS
client such that if the client would log a error message
it would always be written to the STDOUT/STDERR - regardless
what was specified in the config file.

However, this bug does not affect any (official) release
because it has been introduced by 817a824.