### PR TITLE
add new `log` cmd and deprecate `audit` cmd

### DIFF
--- a/cmd/kes/log.go
+++ b/cmd/kes/log.go
@@ -1,3 +1,7 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
 package main
 
 import (
@@ -15,17 +19,17 @@ import (
 	"github.com/minio/kes"
 )
 
-const auditCmdUsage = `usage: %s <command>
+const logCmdUsage = `usage: %s <command>
 
-    trace              Trace the audit log output.
+    trace              Trace server log events.
 
   -h, --help           Show list of command-line options.
 `
 
-func audit(args []string) error {
+func log(args []string) error {
 	cli := flag.NewFlagSet(args[0], flag.ExitOnError)
 	cli.Usage = func() {
-		fmt.Fprintf(cli.Output(), auditCmdUsage, cli.Name())
+		fmt.Fprintf(cli.Output(), logCmdUsage, cli.Name())
 	}
 
 	cli.Parse(args[1:])
@@ -36,7 +40,7 @@ func audit(args []string) error {
 
 	switch args[0] {
 	case "trace":
-		return auditTrace(args)
+		return logTrace(args)
 	default:
 		cli.Usage()
 		os.Exit(2)
@@ -44,32 +48,28 @@ func audit(args []string) error {
 	}
 }
 
-const auditTraceCmdUsage = `Trace and print audit log events.
+const logTraceCmdUsage = `Trace server log events.
 
-Connects to a KES server as audit log device and print an audit
-log event for each request/response pair processed by the server.
-It will print the audit log events as readable text representation
-when writing to a tty. Otherwise it will print events as
-line-separated JSON (nd-json)
+Connects to a KES server and traces log events.
 
 usage: %s [flags]
 
-  --json               Print audit log events as JSON.
+  --json               Print log events as JSON.
 
   -k, --insecure       Skip X.509 certificate validation during TLS handshake.
 
   -h, --help           Show list of command-line options.
 `
 
-func auditTrace(args []string) error {
+func logTrace(args []string) error {
 	cli := flag.NewFlagSet(args[0], flag.ExitOnError)
 	cli.Usage = func() {
-		fmt.Fprintf(cli.Output(), auditTraceCmdUsage, cli.Name())
+		fmt.Fprintf(cli.Output(), logTraceCmdUsage, cli.Name())
 	}
 
 	var jsonOutput bool
 	var insecureSkipVerify bool
-	cli.BoolVar(&jsonOutput, "json", false, "Print audit log events as JSON")
+	cli.BoolVar(&jsonOutput, "json", false, "Print log events as JSON")
 	cli.BoolVar(&insecureSkipVerify, "k", false, "Skip X.509 certificate validation during TLS handshake")
 	cli.BoolVar(&insecureSkipVerify, "insecure", false, "Skip X.509 certificate validation during TLS handshake")
 	if args = parseCommandFlags(cli, args[1:]); len(args) != 0 {

--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -24,9 +24,9 @@ const usage = `usage: %s <command>
     server               Start a kes server.
 
     key                  Manage secret keys.
+    log                  Work with server logs.
     policy               Manage the kes server policies.
     identity             Assign policies to identities.
-    audit                Manage the kes server audit logs.                  
 
     tool                 Run specific key and identity management tools.
 
@@ -62,12 +62,12 @@ func main() {
 		err = server(args)
 	case "key":
 		err = key(args)
+	case "log":
+		err = log(args)
 	case "identity":
 		err = identity(args)
 	case "policy":
 		err = policy(args)
-	case "audit":
-		err = audit(args)
 	case "tool":
 		err = tool(args)
 	default:

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	stdlog "log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -137,7 +137,7 @@ func server(args []string) error {
 		}
 	}
 
-	errorLog := xlog.NewLogger(os.Stderr, "", log.LstdFlags)
+	errorLog := xlog.NewLogger(os.Stderr, "", stdlog.LstdFlags)
 	if len(config.Log.Error.Files) > 0 {
 		var files []io.Writer
 		for _, path := range config.Log.Error.Files {


### PR DESCRIPTION
This adds a new CLI sub-command `log` that
provides mechanisms to work with KES server
logs - e.g. trace the server log event stream.

In general, there are two types of log events
produced by a KES server:
 - audit events
 - error events

The new `log` command will be the starting point
for dealing with both event types. At the moment
the CLI only deals audit event streams. Therefore,
the new `log` command preserves the exact behavior
of `audit`.
So, there is a sub-command `trace` and
`kes log trace` behaves exactly as `kes audit trace`
did before.

In the future, we want to add more and more log
management features to `kes log` - e.g. support
for error log events.