### PR TITLE
build a versioned KES binary in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV GOPROXY https://proxy.golang.org
 
 RUN  \
      apk add --no-cache git && \
-     go install -v -ldflags "-s -w" github.com/minio/kes/cmd/kes
+     go install -v -ldflags "-s -w" github.com/minio/kes/cmd/release && \
+     go install -v -ldflags "-s -w -X main.version=$(release)" github.com/minio/kes/cmd/kes
 
 FROM alpine:3.10
 


### PR DESCRIPTION
This commit uses the `release` command added by
08be13b to build a binary with release information
when building the docker image.

This can be verified by running:
```
docker build - < Dockerfile
```
and then
```
docker run <container-id> -v
```