### PR TITLE
stabilize `kes.Client` and `New*` functions

### DIFF
--- a/cmd/kes/create.go
+++ b/cmd/kes/create.go
@@ -5,13 +5,10 @@
 package main
 
 import (
-	"crypto/tls"
 	"encoding/base64"
 	"flag"
 	"fmt"
 	"os"
-
-	"github.com/minio/kes"
 )
 
 const createCmdUsage = `usage: %s name [key]
@@ -47,15 +44,10 @@ func createKey(args []string) error {
 		bytes = b
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	if len(bytes) > 0 {
 		if err = client.ImportKey(name, bytes); err != nil {
 			return fmt.Errorf("Failed to import %s: %v", name, err)

--- a/cmd/kes/decrypt.go
+++ b/cmd/kes/decrypt.go
@@ -5,13 +5,10 @@
 package main
 
 import (
-	"crypto/tls"
 	"encoding/base64"
 	"flag"
 	"fmt"
 	"os"
-
-	"github.com/minio/kes"
 )
 
 const decryptCmdUsage = `usage: %s <name> <ciphertext> [<context>]
@@ -52,15 +49,10 @@ func decryptKey(args []string) error {
 		}
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	plaintext, err := client.DecryptDataKey(name, ciphertext, context)
 	if err != nil {
 		return fmt.Errorf("Failed to decrypt data key: %v", err)

--- a/cmd/kes/delete.go
+++ b/cmd/kes/delete.go
@@ -5,12 +5,9 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
-
-	"github.com/minio/kes"
 )
 
 const deleteCmdUsage = `usage: %s name
@@ -35,14 +32,10 @@ func deleteKey(args []string) error {
 	}
 
 	name := args[0]
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
 	if err := client.DeleteKey(name); err != nil {
 		return fmt.Errorf("Failed to delete %s: %v", name, err)
 	}

--- a/cmd/kes/generate.go
+++ b/cmd/kes/generate.go
@@ -5,13 +5,10 @@
 package main
 
 import (
-	"crypto/tls"
 	"encoding/base64"
 	"flag"
 	"fmt"
 	"os"
-
-	"github.com/minio/kes"
 )
 
 const generateCmdUsage = `usage: %s name [context]
@@ -47,14 +44,10 @@ func deriveKey(args []string) error {
 		context = b
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
 	plaintext, ciphertext, err := client.GenerateDataKey(name, context)
 	if err != nil {
 		return fmt.Errorf("Failed to generate data key: %v", err)

--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -71,14 +70,10 @@ func assignIdentity(args []string) error {
 		os.Exit(2)
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
 	if err := client.AssignIdentity(args[1], kes.Identity(args[0])); err != nil {
 		return fmt.Errorf("Failed to assign policy '%s' to '%s': %v", args[1], args[0], err)
 	}
@@ -110,14 +105,10 @@ func listIdentity(args []string) error {
 		pattern = args[0]
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
 	identityRoles, err := client.ListIdentities(pattern)
 	if err != nil {
 		return fmt.Errorf("Cannot list identities: %v", err)
@@ -169,14 +160,10 @@ func forgetIdentity(args []string) error {
 		os.Exit(2)
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
 	if err := client.ForgetIdentity(kes.Identity(args[0])); err != nil {
 		return fmt.Errorf("Cannot forget '%s': %v", args[0], err)
 	}

--- a/cmd/kes/log.go
+++ b/cmd/kes/log.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -16,7 +15,6 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/minio/kes"
 )
 
 const logCmdUsage = `usage: %s <command>
@@ -77,15 +75,10 @@ func logTrace(args []string) error {
 		os.Exit(2)
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	stream, err := client.TraceAuditLog()
 	if err != nil {
 		return err

--- a/cmd/kes/policy.go
+++ b/cmd/kes/policy.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -82,15 +81,10 @@ func addPolicy(args []string) error {
 		os.Exit(2)
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	data, err := ioutil.ReadFile(args[1])
 	if err != nil {
 		return fmt.Errorf("Cannot read policy file '%s': %v", args[1], err)
@@ -149,15 +143,10 @@ func showPolicy(args []string) error {
 		}
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	policy, err := client.ReadPolicy(name)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch policy '%s': %v", args[0], err)
@@ -208,15 +197,10 @@ func listPolicies(args []string) error {
 		policy = args[0]
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	policies, err := client.ListPolicies(policy)
 	if err != nil {
 		return fmt.Errorf("Failed to list policies: %v", err)
@@ -258,15 +242,10 @@ func deletePolicy(args []string) error {
 		os.Exit(2)
 	}
 
-	certificates, err := loadClientCertificates()
+	client, err := newClient(insecureSkipVerify)
 	if err != nil {
 		return err
 	}
-	client := kes.NewClient(serverAddr(), &tls.Config{
-		InsecureSkipVerify: insecureSkipVerify,
-		Certificates:       certificates,
-	})
-
 	if err := client.DeletePolicy(args[0]); err != nil {
 		return fmt.Errorf("Failed to delete policy '%s': %v", args[0], err)
 	}


### PR DESCRIPTION
This commit stabilizes the KES client API.
The `Client` type now exports the KES server
endpoint and the HTTP client.

This is a very flexible API in the sense that
a user can configure any custom transport
configuration (timeouts etc.) or implementation
(TCP-TLS, QUIC, ...).
So, this way the `Client` type can be used even
if the underlying protocol layers will change.

Further, there are two convenience functions:
 - `NewClient`
 - `NewClientWithConfig`

which will be sufficient for most scenarios
where the user just provides a client certificate
or a TLS configuration.