### PR TITLE
implement request retry mechanism for KES client

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,174 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// retryBody takes an io.ReadSeeker and converts it
+// into an io.ReadCloser that can be used as request
+// body for retryable requests.
+//
+// The body must implement io.Seeker to ensure that
+// the entire body is sent again when retrying a request.
+//
+// If body is nil, retryBody returns nil.
+func retryBody(body io.ReadSeeker) io.ReadCloser {
+	if body == nil {
+		return nil
+	}
+
+	var closer io.Closer
+	if c, ok := body.(io.Closer); ok {
+		closer = c
+	} else {
+		closer = ioutil.NopCloser(body)
+	}
+
+	type ReadSeekCloser struct {
+		io.ReadSeeker
+		io.Closer
+	}
+	return ReadSeekCloser{
+		ReadSeeker: body,
+		Closer:     closer,
+	}
+}
+
+// retry is an http.Client that implements
+// a retry mechanism for requests that fail
+// due to a temporary network error.
+//
+// It provides a similar interface as the http.Client
+// but requires that the request body implements io.Seeker.
+// Otherwise, it cannot guarantee that the entire request
+// body gets sent when retrying a request.
+type retry http.Client
+
+// Get issues a GET to the specified URL.
+// It is a wrapper around retry.Do.
+func (r *retry) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, retryBody(nil))
+	if err != nil {
+		return nil, err
+	}
+	return r.Do(req)
+}
+
+// Post issues a POST to the specified URL.
+// It is a wrapper around retry.Do.
+func (r *retry) Post(url, contentType string, body io.ReadSeeker) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, retryBody(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return r.Do(req)
+}
+
+// Do sends an HTTP request and returns an HTTP response using
+// the underlying http.Client. If the request fails b/c of a
+// temporary error Do retries the request a few times. If the
+// request keeps failing, Do will give up and return a descriptive
+// error.
+func (r *retry) Do(req *http.Request) (*http.Response, error) {
+	type RetryReader interface {
+		io.Reader
+		io.Seeker
+		io.Closer
+	}
+
+	// If the request body is not a RetryReader it cannot
+	// be retried. The caller has to ensure that the actual
+	// body content is an io.ReadCloser + io.Seeker.
+	// The retry.NewRequest method does that.
+	//
+	// A request can only be retried if we can seek to the
+	// start of the request body. Otherwise, we may send a
+	// parial response body when we retry the request.
+	var body RetryReader
+	if req.Body != nil {
+		var ok bool
+		body, ok = req.Body.(RetryReader)
+		if !ok {
+			// We cannot convert the req.Body to an io.Seeker.
+			// If we would proceed we may introduce hard to find
+			// bugs. Also, there is no point in returning an
+			// error since the caller has specified a wrong type.
+			panic("kes: request cannot be retried")
+		}
+	}
+
+	const (
+		MinRetryDelay     = 200 * time.Millisecond
+		MaxRandRetryDelay = 800
+	)
+	var (
+		retry  = 2 // For now, we retry 2 times before we give up
+		client = (*http.Client)(r)
+	)
+	resp, err := client.Do(req)
+	for retry > 0 && (isTemporary(err) || (resp != nil && resp.StatusCode == http.StatusServiceUnavailable)) {
+		randomRetryDelay := time.Duration(rand.Intn(MaxRandRetryDelay)) * time.Millisecond
+		time.Sleep(MinRetryDelay + randomRetryDelay)
+		retry--
+
+		// If there is a body we have to reset it. Otherwise, we may send
+		// only partial data to the server when we retry the request.
+		if body != nil {
+			if _, err = body.Seek(0, io.SeekStart); err != nil {
+				return nil, err
+			}
+			req.Body = body
+		}
+
+		resp, err = client.Do(req) // Now, retry.
+	}
+	if isTemporary(err) {
+		// If the request still fails with a temporary error
+		// we wrap the error to provide more information to the
+		// caller.
+		return nil, &url.Error{
+			Op:  req.Method,
+			URL: req.URL.String(),
+			Err: fmt.Errorf("Temporary network error: %v", err),
+		}
+	}
+	return resp, err
+}
+
+// isTemporary returns true if the given error is
+// temporary - e.g. a temporary *url.Error or an
+// net.Error that indicates that a request got
+// timed-out.
+//
+// A nil error is not temporary.
+func isTemporary(err error) bool {
+	if err == nil { // fast path
+		return false
+	}
+	if netErr, ok := err.(net.Error); ok { // *url.Error implements net.Error
+		if netErr.Timeout() || netErr.Temporary() {
+			return true
+		}
+
+		// If a connection drops (e.g. server dies) while sending the request
+		// http.Do returns either io.EOF or io.ErrUnexpected. We treat that as
+		// temp. since the server may get restared such that the retry may succeed.
+		if errors.Is(netErr, io.EOF) || errors.Is(netErr, io.ErrUnexpectedEOF) {
+			return true
+		}
+	}
+	return false
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/url"
+	"testing"
+)
+
+var retryBodyTests = []struct {
+	Body io.ReadSeeker
+}{
+	{Body: nil},
+	{Body: bytes.NewReader(nil)},
+}
+
+func TestRetryBody(t *testing.T) {
+	for i, test := range retryBodyTests {
+		body := retryBody(test.Body)
+		if test.Body == nil && body != nil {
+			t.Fatalf("Test %d: invalid retry body: got %v - want %v", i, body, test.Body)
+		}
+		if test.Body != nil {
+			if _, ok := body.(io.Seeker); !ok {
+				t.Fatalf("Test %d: retry body does not implement io.Seeker", i)
+			}
+		}
+	}
+}
+
+var isTemporaryTests = []struct {
+	Err         error
+	IsTemporary bool
+}{
+	{Err: nil, IsTemporary: false},
+	{Err: io.EOF, IsTemporary: false},
+	{Err: url.InvalidHostError(""), IsTemporary: false},
+	{
+		Err: &url.Error{
+			Op:  "GET",
+			URL: "http://127.0.0.1",
+			Err: net.UnknownNetworkError("unknown"),
+		},
+		IsTemporary: false,
+	},
+	{
+		Err: &url.Error{
+			Op:  "GET",
+			URL: "http://127.0.0.1",
+			Err: io.EOF,
+		},
+		IsTemporary: true,
+	},
+}
+
+func TestIsTemporary(t *testing.T) {
+	for i, test := range isTemporaryTests {
+		temp := isTemporary(test.Err)
+		switch {
+		case test.IsTemporary == true && temp == false:
+			t.Fatalf("Test %d: err should be temporary but it is not", i)
+		case test.IsTemporary == false && temp == true:
+			t.Fatalf("Test %d: err should not be temporary but it is", i)
+		}
+	}
+}


### PR DESCRIPTION
This commit implements a request retry mechanism.
Now, client automatically retries a request if
the failure seems to be temporary.

In particular, if e.g. a KES server dies for some
reason before it has sent a response then the client
fails with an `*url.Error` wrapping an `io.EOF` or
an `io.ErrUnexpected`. In this case we retry the request
hoping that the KES server gets (automatically) restarted.