### PR TITLE
rename the KES client env. variables for the client key and cert

### DIFF
--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -104,13 +104,13 @@ func isFlagPresent(set *flag.FlagSet, name string) bool {
 }
 
 func newClient(insecureSkipVerify bool) (*kes.Client, error) {
-	certPath := os.Getenv("KES_CLIENT_TLS_CERT_FILE")
-	keyPath := os.Getenv("KES_CLIENT_TLS_KEY_FILE")
+	certPath := os.Getenv("KES_CLIENT_CERT")
+	keyPath := os.Getenv("KES_CLIENT_KEY")
 	if certPath == "" {
-		return nil, errors.New("No client TLS certificate: env KES_CLIENT_TLS_CERT_FILE is not set or empty")
+		return nil, errors.New("No client TLS certificate: env KES_CLIENT_CERT is not set or empty")
 	}
 	if keyPath == "" {
-		return nil, errors.New("No client TLS private key: env KES_CLIENT_TLS_KEY_FILE is not set or empty")
+		return nil, errors.New("No client TLS private key: env KES_CLIENT_KEY is not set or empty")
 	}
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {


### PR DESCRIPTION
This commit renames the client env. variables used to specify
the client certificate and private key.

Before, the CLI client expected:
```
export KES_CLIENT_TLS_CERT_FILE=<cert>
export KES_CLIENT_TLS_KEY_FILE=<key>
```

Now, the CLI client expects:
```
export KES_CLIENT_CERT=<cert>
export KES_CLIENT_KEY=<key>
```

The reason for this change is that the previous env. variables
are quite verbose and look odd compared to the `KES_SERVER`
variable.

The new variables are more compact and don't require boilerplate
typing.

It has been considered to have a fallback - like if `KES_CLIENT_CERT`
is not present look for `KES_CLIENT_TLS_CERT_FILE`. However, it
seems worse to have a deprecated fallback that gets removed at some
point in time. A clean cut seems better here.