### PR TITLE
vault: allow custom engine paths

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -51,15 +51,17 @@ type serverConfig struct {
 		} `yaml:"fs"`
 
 		Vault struct {
-			Endpoint  string `yaml:"endpoint"`
-			Namespace string `yaml:"namespace"`
+			Endpoint   string `yaml:"endpoint"`
+			EnginePath string `yaml:"engine"`
+			Namespace  string `yaml:"namespace"`
 
 			Prefix string `yaml:"prefix"`
 
 			AppRole struct {
-				ID     string        `yaml:"id"`
-				Secret string        `yaml:"secret"`
-				Retry  time.Duration `yaml:"retry"`
+				EnginePath string        `yaml:"engine"`
+				ID         string        `yaml:"id"`
+				Secret     string        `yaml:"secret"`
+				Retry      time.Duration `yaml:"retry"`
 			} `yaml:"approle"`
 
 			TLS struct {
@@ -125,6 +127,22 @@ func loadServerConfig(path string) (config serverConfig, err error) {
 		}
 	}
 	return config, file.Close()
+}
+
+// SetDefaults set default values for fields that may be empty b/c not specified by user.
+func (config *serverConfig) SetDefaults() {
+	if config.Log.Audit == "" {
+		config.Log.Audit = "off" // If not set, default is off.
+	}
+	if config.Log.Error == "" {
+		config.Log.Error = "on" // If not set, default is on.
+	}
+	if config.Keys.Vault.EnginePath == "" {
+		config.Keys.Vault.EnginePath = "kv" // If not set, use the Vault default engine path.
+	}
+	if config.Keys.Vault.AppRole.EnginePath == "" {
+		config.Keys.Vault.AppRole.EnginePath = "approle" // If not set, use the Vault default auth path.
+	}
 }
 
 // refersToEnvVar returns true if s has the following form:

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -7,6 +7,7 @@ package vault
 import (
 	"context"
 	"errors"
+	"path"
 	"sync/atomic"
 	"time"
 
@@ -75,7 +76,8 @@ func (c *client) CheckStatus(ctx context.Context, delay time.Duration) {
 //
 // To renew the auth. token see: client.RenewToken(...).
 func (c *client) Authenticate(login AppRole) (token string, ttl time.Duration, err error) {
-	secret, err := c.Logical().Write("auth/approle/login", map[string]interface{}{
+	location := path.Join("auth", login.Engine, "login") // /auth/<engine>/login
+	secret, err := c.Logical().Write(location, map[string]interface{}{
 		"role_id":   login.ID,
 		"secret_id": login.Secret,
 	})

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -150,9 +150,11 @@ keys:
   # https://www.vaultproject.io/api/secret/kv/kv-v1.html
   vault:
     endpoint: ""  # The Vault endpoint - e.g. https://127.0.0.1:8200
+    engine: ""    # The path of the K/V engine - e.g. secrets. If empty, defaults to: kv. (Vault default)
     namespace: "" # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
     prefix: ""    # An optional K/V prefix. The server will store keys under this prefix. 
     approle:    # AppRole credentials. See: https://www.vaultproject.io/docs/auth/approle.html
+      engine: ""  # The path of the AppRole engine - e.g. authenticate. If empty, defaults to: approle. (Vault default)
       id: ""      # Your AppRole Role ID
       secret: ""  # Your AppRole Secret ID
       retry: 15s  # Duration until the server tries to re-authenticate after connection loss.


### PR DESCRIPTION
This commit allows users to specify a custom
engine path for the K/V secret engine and
AppRole authentication method, and therefore,
fixes #55.

Vault allows engines to be mounted at arbitrary
paths. For instance, you can mount the K/V secret
engine at `/kv` or `/secrets`.
Further, Vault allows multiple instances of the same
engine to be present at the same time. Therefore,
supporting user-defined engine paths is necessary.

The same is true for authentication methods/engines,
like AppRole.

This adds two configuration options `engine: <engine-name>`.
One is for the K/V engine and the other one is for the
AppRole engine.
However, if not specified the server assumes that the
K/V engine is mounted at the "default" `/kv` path and
similarly, that the AppRole engine is mounted at the
"default" `/approle` path.