### PR TITLE
proxy: fix invalid check to enable authentication

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -221,7 +221,7 @@ func server(args []string) error {
 		proxy = &auth.TLSProxy{
 			CertHeader: http.CanonicalHeaderKey(config.TLS.Proxy.Header.ClientCert),
 		}
-		if mtlsAuth == "verify" {
+		if strings.ToLower(mtlsAuth) != "off" {
 			proxy.VerifyOptions = new(x509.VerifyOptions)
 		}
 		for _, identity := range config.TLS.Proxy.Identities {


### PR DESCRIPTION
This commit fixes a bug in the server initialization
w.r.t. requiring TLS certificate verification of TLS proxies.

Currently, the certificate of the TLS proxy is not validated
by default / when `--auth` is not set to `off`.

However, this has no direct security impact since a TLS proxy
has to be explicitly configured and its public key has to be pinned.

This commit fixes this by always enabling TLS certificate validation
for TLS proxies unless `--auth=off` has been specified.