### PR TITLE
client: use io.LimitReader instead of io.CopyN for raw error messages

### DIFF
--- a/error.go
+++ b/error.go
@@ -98,7 +98,7 @@ func parseErrorResponse(resp *http.Response) error {
 	}
 
 	var sb strings.Builder
-	if _, err := io.CopyN(&sb, resp.Body, size); err != nil {
+	if _, err := io.Copy(&sb, io.LimitReader(resp.Body, size)); err != nil {
 		return err
 	}
 	return NewError(resp.StatusCode, sb.String())


### PR DESCRIPTION
This commit fixes an incorrect usage of `io.CopyN`
in the error parsing code of the client.

When a (misbehaving) KES server does not send a
`application/json` content type and e.g. no content
length then the KES client would try to read at
most `MaxBodySize = 1<<20` bytes from the body.

However, when the server response is smaller then
`1<<20` then the client would return `io.EOF`.

This commit fixes this by using an `io.LimitReader`.
The semantics of `io.LimitReader` and `io.CopyN`
are slightly different:
 - `io.LimitReader` limits a `io.Reader` to
   **at most** `N` bytes.
 - `io.CopyN` tries to copy **exactly** `N`
    bytes from a `io.Reader`.

See also: minio/minio#9790