### PR TITLE
delete assigned identities when deleting policy

### DIFF
--- a/cmd/kes/policy.go
+++ b/cmd/kes/policy.go
@@ -93,7 +93,7 @@ func addPolicy(args []string) error {
 	if err = policy.UnmarshalJSON(data); err != nil {
 		return fmt.Errorf("Policy file is invalid JSON: %v", err)
 	}
-	if err = client.WritePolicy(args[0], &policy); err != nil {
+	if err = client.SetPolicy(args[0], &policy); err != nil {
 		return fmt.Errorf("Failed to add policy '%s': %v", args[0], err)
 	}
 	return nil
@@ -140,7 +140,7 @@ func showPolicy(args []string) error {
 	if err != nil {
 		return err
 	}
-	policy, err := client.ReadPolicy(name)
+	policy, err := client.GetPolicy(name)
 	if err != nil {
 		return fmt.Errorf("Failed to fetch policy '%s': %v", args[0], err)
 	}
@@ -181,7 +181,7 @@ func listPolicies(args []string) error {
 		cli.Usage()
 		os.Exit(2)
 	}
-	policy := "*"
+	var policy string
 	if len(args) == 1 {
 		policy = args[0]
 	}

--- a/error.go
+++ b/error.go
@@ -12,10 +12,22 @@ import (
 )
 
 var (
+	// ErrNotAllowed represents a KES server response returned when the
+	// client has not sufficient policy permissions to perform a particular
+	// operation.
+	ErrNotAllowed Error = NewError(http.StatusForbidden, "prohibited by policy")
+
+	// ErrKeyNotFound represents a KES server response returned when a client
+	// tries to access or use a cryptographic key which does not exist.
 	ErrKeyNotFound Error = NewError(http.StatusNotFound, "key does not exist")
-	ErrKeyExists   Error = NewError(http.StatusBadRequest, "key does already exist")
-	ErrKeySealed   Error = NewError(http.StatusForbidden, "key is sealed")
-	ErrNotAllowed  Error = NewError(http.StatusForbidden, "prohibited by policy")
+
+	// ErrKeyExists represents a KES server response returned when a client tries
+	// to create a cryptographic key which already exists.
+	ErrKeyExists Error = NewError(http.StatusBadRequest, "key does already exist")
+
+	// ErrPolicyNotFound represents a KES server response returned when a client
+	// tries to access a policy which does not exist.
+	ErrPolicyNotFound Error = NewError(http.StatusNotFound, "policy does not exist")
 )
 
 // Error is the type of client-server API errors.

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -415,7 +415,6 @@ func HandleWritePolicy(roles *auth.Roles) http.HandlerFunc {
 func HandleReadPolicy(roles *auth.Roles) http.HandlerFunc {
 	var (
 		ErrInvalidPolicyName = kes.NewError(http.StatusBadRequest, "invalid policy name")
-		ErrPolicyNotFound    = kes.NewError(http.StatusBadRequest, "policy does not exist")
 	)
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := pathBase(r.URL.Path)
@@ -426,7 +425,7 @@ func HandleReadPolicy(roles *auth.Roles) http.HandlerFunc {
 
 		policy, ok := roles.Get(name)
 		if !ok {
-			Error(w, ErrPolicyNotFound)
+			Error(w, kes.ErrPolicyNotFound)
 			return
 		}
 		json.NewEncoder(w).Encode(policy)
@@ -465,7 +464,6 @@ func HandleAssignIdentity(roles *auth.Roles) http.HandlerFunc {
 		ErrIdentityUnknown = kes.NewError(http.StatusBadRequest, "identity is unknown")
 		ErrIdentityRoot    = kes.NewError(http.StatusBadRequest, "identity is root")
 		ErrSelfAssign      = kes.NewError(http.StatusForbidden, "identity cannot assign policy to itself")
-		ErrPolicyNotFound  = kes.NewError(http.StatusBadRequest, "policy does not exist")
 	)
 	return func(w http.ResponseWriter, r *http.Request) {
 		identity := kes.Identity(pathBase(r.URL.Path))
@@ -484,7 +482,7 @@ func HandleAssignIdentity(roles *auth.Roles) http.HandlerFunc {
 
 		policy := pathBase(strings.TrimSuffix(r.URL.Path, identity.String()))
 		if err := roles.Assign(policy, identity); err != nil {
-			Error(w, ErrPolicyNotFound)
+			Error(w, kes.ErrPolicyNotFound)
 			return
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This commit changes the implementation of the
`/v1/policy/delete` API.

Deleting a policy used to just remove the policy with the
specified name from the policy set. When there were identities
assigned to this particular policy then identities would become
"stale"/"dangling".

If the KES server would encounter a request from an identity that
would be "assigned" to a deleted policy it would deny any access,
as it would if the identity would not be assigned to a policy.

This commit changes the behavior of `/v1/policy/delete` such that
deleting a policy also removes all assigned identities from the
KES server. This behavior is save because:
 - An identity can be assigned to (at most) one policy at one point
   in time.
 - An assigned identity is just a mapping from (external) identity
   to a policy. It does not have any state whatsoever.

It's worth noting that assigning an identity to a policy and
re-assigning an identity from one (potentially deleted) policy
to another policy are the exact same operations.

Therefore, no state gets lost when removing the assigned identities
once a policy gets deleted - except for which identities "belong"
together based on being assigned to the same policy. However, this
information would be lost anyway on e.g. KES server restart and cannot
be assumed to be persistent.

Also, it is anyway not possible to assign an identity to a non-existing
policy via the `/v1/identity/assign` API.

***

From a user perspective this change has the following implications:
 1. Now, an identity is always assigned to exactly one (existing) policy.
 2. Setting a policy and deleting a policy are not inverse operations
    anymore.

***

The difference in behavior:

**Setup:**
```
kes policy list -k
[
  my-policy
]

kes identity list -k
{
  d78fe3a92987a554bb4ef39712109f9bb492b28e5a85eca1d59ddd5f7bb18832 => my-policy
}
```

**Previous behavior:**
```
kes policy delete my-policy -k

kes identity list -k
{
  d78fe3a92987a554bb4ef39712109f9bb492b28e5a85eca1d59ddd5f7bb18832 => my-policy
}
```

**Current behavior:**
```
kes policy delete my-policy -k

kes identity list -k
{
}
```