### PR TITLE
gemalto: add support for Gemalto KeySecure

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -88,6 +88,22 @@ type serverConfig struct {
 				} `yaml:"credentials"`
 			} `yaml:"secretsmanager"`
 		} `yaml:"aws"`
+
+		Gemalto struct {
+			KeySecure struct {
+				Endpoint string `yaml:"endpoint"`
+
+				Login struct {
+					Token  string        `yaml:"token"`
+					Domain string        `yaml:"domain"`
+					Retry  time.Duration `yaml:"retry"`
+				} `yaml:"credentials"`
+
+				TLS struct {
+					CAPath string `yaml:"ca"`
+				} `yaml:"tls"`
+			} `yaml:"keysecure"`
+		} `yaml:"gemalto"`
 	} `yaml:"keys"`
 }
 

--- a/internal/gemalto/client.go
+++ b/internal/gemalto/client.go
@@ -1,0 +1,173 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package gemalto
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	xhttp "github.com/minio/kes/internal/http"
+)
+
+// authToken is a KeySecure authentication token.
+// It can be used to authenticate API requests.
+type authToken struct {
+	Type   string
+	Value  string
+	Expiry time.Duration
+}
+
+// String returns the string representation of
+// the authentication token.
+func (t *authToken) String() string { return fmt.Sprintf("%s %s", t.Type, t.Value) }
+
+// client is a KeySecure REST API client
+// responsible for fetching and renewing
+// authentication tokens.
+type client struct {
+	xhttp.Retry
+	ErrorLog *log.Logger
+
+	lock  sync.Mutex
+	token authToken
+}
+
+// Authenticate tries to obtain a new authentication token
+// from the given KeySecure endpoint via the given refresh
+// token.
+//
+// Athenticate should be called to obtain the first authentication
+// token. This token can then be renewed via RenewAuthToken.
+func (c *client) Authenticate(endpoint string, login Credentials) error {
+	type Request struct {
+		Type   string `json:"grant_type"`
+		Token  string `json:"refresh_token"`
+		Domain string `json:"domain"`
+	}
+	type Response struct {
+		Type   string `json:"token_type"`
+		Token  string `json:"jwt"`
+		Expiry uint64 `json:"duration"` // KeySecure returns expiry in seconds
+	}
+
+	body, err := json.Marshal(Request{
+		Type:   "refresh_token",
+		Token:  login.Token,
+		Domain: login.Domain,
+	})
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/api/v1/auth/tokens", endpoint)
+	req, err := http.NewRequest(http.MethodPost, url, xhttp.RetryReader(bytes.NewReader(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		response, err := parseServerError(resp)
+		if err != nil {
+			return fmt.Errorf("%s: %v", resp.Status, err)
+		}
+		return fmt.Errorf("%s: %s (%d)", resp.Status, response.Message, response.Code)
+	}
+
+	const MaxSize = 1 << 20 // An auth. token response should not exceed 1 MiB
+	var response Response
+	if err = json.NewDecoder(io.LimitReader(resp.Body, MaxSize)).Decode(&response); err != nil {
+		return err
+	}
+	if response.Token == "" {
+		return errors.New("server response does not contain an auth token")
+	}
+	if response.Type != "Bearer" {
+		return fmt.Errorf("unexpected auth token type '%s'", response.Type)
+	}
+	if response.Expiry <= 0 {
+		return fmt.Errorf("invalid auth token expiry '%d'", response.Expiry)
+	}
+
+	c.lock.Lock()
+	c.token = authToken{
+		Type:   response.Type,
+		Value:  response.Token,
+		Expiry: time.Duration(response.Expiry) * time.Second,
+	}
+	c.lock.Unlock()
+	return nil
+}
+
+// RenewAuthToken tries to renew the client's authentication
+// token before it expires. It blocks until <-ctx.Done() completes.
+//
+// Before calling RenewAuthToken the client should already have a
+// authentication token. Therefore, RenewAuthToken should be called
+// only after a Authenticate.
+//
+// RenewAuthToken tries get a new authentication token from the given
+// KeySecure endpoint by presenting the given refresh token.
+// It continuesly tries to renew the authentication before it expires.
+//
+// If RenewAuthToken fails to request or renew the client's authentication
+// token then it keeps retrying and waits for the given login.Retry delay
+// between each retry attempt.
+//
+// If login.Retry is 0 then RenewAuthToken uses a reasonable default retry delay.
+func (c *client) RenewAuthToken(ctx context.Context, endpoint string, login Credentials) {
+	if login.Retry == 0 {
+		login.Retry = 5 * time.Second
+	}
+	var (
+		timer *time.Timer
+		err   error
+	)
+	for {
+		if err != nil {
+			logf(c.ErrorLog, "gemalto: failed to renew auth token: %v", err)
+			timer = time.NewTimer(login.Retry)
+		} else {
+			c.lock.Lock()
+			timer = time.NewTimer(c.token.Expiry / 2)
+			c.lock.Unlock()
+		}
+
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			err = c.Authenticate(endpoint, login)
+			timer.Stop()
+		}
+	}
+}
+
+// AuthToken returns an authentication token that can be
+// used to authenticate API requests to a KeySecure instance.
+//
+// Typically, it is a JWT token and should be used as HTTP
+// Authorization header value.
+func (c *client) AuthToken() string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.token.String()
+}

--- a/internal/gemalto/key-secure.go
+++ b/internal/gemalto/key-secure.go
@@ -1,0 +1,354 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+// Package gemalto implements a key store that fetches/stores
+// cryptographic keys on a Gemalto KeySecure instance.
+package gemalto
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/minio/kes"
+	xhttp "github.com/minio/kes/internal/http"
+)
+
+// Credentials represents a Gemalto KeySecure
+// refresh token that can be used to obtain a
+// short-lived authentication token.
+//
+// A token is valid within either the default root
+// domain (empty) or a specifc domain - e.g. my-domain.
+type Credentials struct {
+	Token  string        // The KeySecure refresh token
+	Domain string        // The KeySecure domain - similar to a Vault Namespace
+	Retry  time.Duration // The time to wait before trying to re-authenticate
+}
+
+// KeySecure is a Gemalto KeySecure client that
+// stores / fetches key-value pairs as secrets.
+//
+// It tries to connect to a KeySecure instance
+// at the given endpoint and uses the login
+// credentials to authenticate.
+type KeySecure struct {
+	// Endpoint is the KeySecure instance endpoint.
+	Endpoint string
+
+	// CAPath is a path to the root CA certificate(s)
+	// used to verify the TLS certificate of the KeySecure
+	// instance. If empty, the host's root CA set is used.
+	CAPath string
+
+	// Login credentials are used to authenticate to the
+	// KeySecure instance and obtain a short-lived authentication
+	// token.
+	Login Credentials
+
+	// ErrorLog specifies an optional logger for errors.
+	// If an unexpected error is encountered while trying
+	// to fetch, store or delete a key or when an authentication
+	// error happens then an error event is written to the error
+	// log.
+	//
+	// If nil, logging is done via the log package's standard
+	// logger.
+	ErrorLog *log.Logger
+
+	client *client
+}
+
+// Authenticate tries to establish a connection to a
+// KeySecure server using the login credentials.
+//
+// It retruns an error if no connection could be
+// established - for instance because of invalid
+// credentials.
+func (s *KeySecure) Authenticate() (err error) {
+	var rootCAs *x509.CertPool
+	if s.CAPath != "" {
+		rootCAs, err = loadCustomCAs(s.CAPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.client = &client{
+		ErrorLog: s.ErrorLog,
+		Retry: xhttp.Retry{
+			Client: http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						RootCAs: rootCAs,
+					},
+					Proxy: http.ProxyFromEnvironment,
+					DialContext: (&net.Dialer{
+						Timeout:   10 * time.Second,
+						KeepAlive: 10 * time.Second,
+						DualStack: true,
+					}).DialContext,
+					ForceAttemptHTTP2:     true,
+					MaxIdleConns:          100,
+					IdleConnTimeout:       30 * time.Second,
+					TLSHandshakeTimeout:   10 * time.Second,
+					ExpectContinueTimeout: 1 * time.Second,
+				},
+			},
+		},
+	}
+	if err = s.client.Authenticate(s.Endpoint, s.Login); err != nil {
+		return err
+	}
+	go s.client.RenewAuthToken(context.Background(), s.Endpoint, s.Login)
+	return nil
+}
+
+// Create creates the given key-value pair at Gemalto if and only
+// if the given key does not exist. If such an entry already exists
+// it returns kes.ErrKeyExists.
+func (s *KeySecure) Create(key, value string) error {
+	type Request struct {
+		Type  string `json:"dataType"`
+		Value string `json:"material"`
+		Name  string `json:"name"`
+	}
+
+	body, err := json.Marshal(Request{
+		Type:  "seed", // KeySecure supports blob, password and seed
+		Value: value,
+		Name:  key,
+	})
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/api/v1/vault/secrets", s.Endpoint)
+	req, err := http.NewRequest(http.MethodPost, url, xhttp.RetryReader(bytes.NewReader(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", s.client.AuthToken())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		if resp.StatusCode == http.StatusConflict {
+			return kes.ErrKeyExists
+		}
+		if response, err := parseServerError(resp); err != nil {
+			logf(s.ErrorLog, "gemalto: %s: failed to parse server response: %v", resp.Status, err)
+		} else {
+			logf(s.ErrorLog, "gemalto: failed to create key '%s': %s (%d)", key, response.Message, response.Code)
+		}
+		return kes.NewError(http.StatusBadGateway, "bad gateway: failed to create key")
+	}
+	return nil
+}
+
+// Get returns the value associated with the given key.
+// If no entry for the key exists it returns kes.ErrKeyNotFound.
+func (s *KeySecure) Get(key string) (string, error) {
+	type Response struct {
+		Value string `json:"material"`
+	}
+
+	url := fmt.Sprintf("%s/api/v1/vault/secrets/%s/export?type=name", s.Endpoint, key)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", s.client.AuthToken())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return "", kes.ErrKeyNotFound
+		}
+
+		if response, err := parseServerError(resp); err != nil {
+			logf(s.ErrorLog, "gemalto: %s: failed to parse server response: %v", resp.Status, err)
+		} else {
+			logf(s.ErrorLog, "gemalto: failed to access key '%s': %s (%d)", key, response.Message, response.Code)
+		}
+		return "", kes.NewError(http.StatusBadGateway, "bad gateway: failed to access key")
+	}
+
+	var response Response
+	if err = json.NewDecoder(io.LimitReader(resp.Body, 2<<20)).Decode(&response); err != nil {
+		logf(s.ErrorLog, "gemalto: failed to parse server response: %v", err)
+		return "", kes.NewError(http.StatusBadGateway, "bad gateway: failed to access key")
+	}
+	return response.Value, nil
+}
+
+// Delete removes a the value associated with the given key
+// from Vault, if it exists.
+func (s *KeySecure) Delete(key string) error {
+	url := fmt.Sprintf("%s/api/v1/vault/secrets/%s?type=name", s.Endpoint, key)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", s.client.AuthToken())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		// BUG(aead): The KeySecure server returns 404 NotFound if the
+		// secret does not exist but also when we are not allowed to access/delete
+		// the secret due to insufficient policy permissions.
+		// The reason for this is probably that a client should not be able
+		// to determine whether a particular secret exists (if the client has
+		// no access to it).
+		// Unfortunately, we cannot guarantee anymore that we actually deleted the
+		// secret. It could also be the case that we lost access (e.g. due to a
+		// policy change). So, in this case we don't return an error such that the
+		// client thinks it has deleted the secret successfully.
+		if response, err := parseServerError(resp); err != nil {
+			logf(s.ErrorLog, "gemalto: %s: failed to parse server response: %v", resp.Status, err)
+		} else {
+			logf(s.ErrorLog, "gemalto: failed to delete key '%s': %s (%d)", key, response.Message, response.Code)
+		}
+		return kes.NewError(http.StatusBadGateway, "bad gateway: failed to delete key")
+	}
+	return nil
+}
+
+// errResponse represents a KeySecure API error
+// response.
+type errResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"codeDesc"`
+}
+
+func parseServerError(resp *http.Response) (errResponse, error) {
+	const MaxSize = 1 << 20 // max. 1 MiB
+	var size = resp.ContentLength
+	if size < 0 || size > MaxSize {
+		size = MaxSize
+	}
+	defer resp.Body.Close()
+
+	// The KeySecure server does not always return a JSON error
+	// response bodies. It only returns a JSON body in case
+	// of a well-defined API error - e.g. when trying to create
+	// a secret with a name that already exists.
+	// It does not return a JSON body in case of a missing
+	// authorization header.
+	// Therefore, we try to unmarshal the body only when the
+	// Content-Type is application/json. Otherwise, we just assume
+	// the body is a raw text string and use the HTTP response code
+	// as error code.
+
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if strings.HasPrefix(contentType, "application/json") {
+		var response errResponse
+		err := json.NewDecoder(io.LimitReader(resp.Body, size)).Decode(&response)
+		return response, err
+	}
+
+	var s strings.Builder
+	if _, err := io.Copy(&s, io.LimitReader(resp.Body, size)); err != nil {
+		return errResponse{}, err
+	}
+	message := strings.TrimSpace(s.String())
+	if strings.HasSuffix(message, "\n") { // Some error message end with '\n' causing messy logs
+		message = strings.TrimSuffix(message, "\n")
+	}
+	return errResponse{
+		Code:    resp.StatusCode,
+		Message: message,
+	}, nil
+}
+
+// loadCustomCAs returns a new RootCA certificate pool
+// that contains one or multiple certificates found at
+// the given path.
+//
+// If path is a file then loadCustomCAs tries to parse
+// the file as a PEM-encoded certificate.
+//
+// If path is a directory then loadCustomCAs tries to
+// parse any file inside path as PEM-encoded certificate.
+// It returns a non-nil error if one file is not a valid
+// PEM-encoded X.509 certificate.
+func loadCustomCAs(path string) (*x509.CertPool, error) {
+	var rootCAs = x509.NewCertPool()
+
+	f, err := os.Open(path)
+	if err != nil {
+		return rootCAs, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return rootCAs, err
+	}
+	if !stat.IsDir() {
+		bytes, err := ioutil.ReadAll(f)
+		if err != nil {
+			return rootCAs, err
+		}
+		if !rootCAs.AppendCertsFromPEM(bytes) {
+			return rootCAs, fmt.Errorf("'%s' does not contain a valid X.509 PEM-encoded certificate", path)
+		}
+		return rootCAs, nil
+	}
+
+	files, err := f.Readdir(0)
+	if err != nil {
+		return rootCAs, err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := filepath.Join(path, file.Name())
+		bytes, err := ioutil.ReadFile(name)
+		if err != nil {
+			return rootCAs, err
+		}
+		if !rootCAs.AppendCertsFromPEM(bytes) {
+			return rootCAs, fmt.Errorf("'%s' does not contain a valid X.509 PEM-encoded certificate", name)
+		}
+	}
+	return rootCAs, nil
+}
+
+func logf(logger *log.Logger, format string, v ...interface{}) {
+	if logger == nil {
+		log.Printf(format, v...)
+	} else {
+		logger.Printf(format, v...)
+	}
+}

--- a/internal/http/retry.go
+++ b/internal/http/retry.go
@@ -1,0 +1,261 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// RetryReader returns an io.ReadSeeker that can be
+// used as request body for retriable requests via
+// Seek(0, io.SeekStart).
+// The returned io.ReadSeeker implements io.Closer.
+//
+// If r does not implement io.Closer RetryReader returns
+// an io.ReadSeeker that implements io.Closer as nop.
+func RetryReader(r io.ReadSeeker) io.ReadSeeker {
+	if _, ok := r.(io.Closer); ok {
+		return r
+	}
+	return nopCloser{r}
+}
+
+type nopCloser struct{ io.ReadSeeker }
+
+func (nopCloser) Close() error { return nil }
+
+// Retry wraps an HTTP client and retries requests
+// when they fail because of a temporary network
+// error or a 5xx response status code.
+//
+// Its zero value is a usable client that uses
+// http.DefaultTransport and may retry a request
+// a few times before giving up.
+//
+// If a request contains a non-nil body then this
+// body must implement io.Seeker. Any io.ReadSeeker
+// can be turned into a requst body via the RetryReader
+// function.
+//
+// Retry retries a request at most N times and waits
+// at least Delay and at most Delay + Jitter before
+// sending the request again. If not specified then
+// Retry uses sane default values for N, Delay and Jitter.
+type Retry struct {
+	// Client is the underlying HTTP client.
+	// Using Client directly bypasses the
+	// retry mechanism.
+	http.Client
+
+	// N is the number of retry attempts. If a request
+	// fails because of a temporary network error or
+	// 5xx response code then Retry keeps sending the
+	// same request N times before giving up and returning
+	// the last error encountered.
+	N uint
+
+	// Delay is the duration Retry waits at least before
+	// retrying a request.
+	Delay time.Duration
+
+	// Jitter is the maximum duration Retry adds to Delay.
+	// Retry waits at most Delay + Jitter before retrying
+	// a request.
+	//
+	// In particular, Retry chooses a pseudo-random
+	// duration [0, Jitter) and adds it do Delay.
+	Jitter time.Duration
+}
+
+// Get issues a GET to the specified URL as specified by http.Client.
+// It follows redirects after calling the underlying Client's
+// CheckRedirect function.
+//
+// If the GET fails due to a temporary network error or 5xx server
+// response then GET retries the request N times.
+func (r *Retry) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return r.Do(req)
+}
+
+// Head issues a HEAD to the specified URL as specified by http.Client.
+// It follows redirects after calling the underlying Client's
+// CheckRedirect function.
+//
+// If the HEAD fails due to a temporary network error or 5xx server
+// response then Head retries the request N times.
+func (r *Retry) Head(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return r.Do(req)
+}
+
+// Post issues a POST to the specified URL as specified by http.Client.
+// The provided body must implement io.Seeker and io.Closer. To obtain
+// an io.Closer from an io.ReadSeeker refer to the RetryReader function.
+//
+// Caller should close resp.Body when done reading from it.
+//
+// If the POST fails due to a temporary network error or 5xx server
+// response the Post retries the request N times.
+//
+// See the Retry.Do method documentation for details on how redirects
+// are handled.
+func (r *Retry) Post(url, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return r.Do(req)
+}
+
+// PostForm issues a POST to the specified URL as specified by http.Client,
+// with data's keys and values URL-encoded as the request body.
+//
+// The Content-Type header is set to application/x-www-form-urlencoded.
+//
+// If the POST fails due to a temporary network error or 5xx server
+// response the Post retries the request N times.
+//
+// See the Client.Do method documentation for details on how redirects
+// are handled.
+func (r *Retry) PostForm(url string, data url.Values) (*http.Response, error) {
+	return r.Post(url, "application/x-www-form-urlencoded", RetryReader(strings.NewReader(data.Encode())))
+}
+
+// Do sends an HTTP request and returns an HTTP response, following
+// policy (such as redirects, cookies, auth) as configured on the
+// client and as specified by http.Client.
+//
+// If the request fails due to a temporary network error or the server
+// returns a 5xx response then Do retries the request N times.
+//
+// If non-nil, the request body must implement io.Seeker.
+//
+// Any returned error will be of type *url.Error. The url.Error
+// value's Timeout method will report true if request timed out or was
+// canceled.
+func (r *Retry) Do(req *http.Request) (*http.Response, error) {
+	var (
+		N      = r.N
+		Delay  = r.Delay
+		Jitter = r.Jitter
+	)
+	if N == 0 {
+		N = 2 // default to 2 re-tries
+	}
+	if Delay == 0 {
+		Delay = 200 * time.Millisecond // default to waiting at least 200ms
+	}
+	if Jitter == 0 {
+		Jitter = 800 * time.Millisecond // default to waiting at most r.Delay + 800ms
+	}
+
+	type RetryReader interface {
+		io.Reader
+		io.Seeker
+		io.Closer
+	}
+
+	var body RetryReader
+	if req.Body != nil {
+		var ok bool
+		body, ok = req.Body.(RetryReader)
+		if !ok {
+			return nil, &url.Error{
+				Op:  req.Method,
+				URL: req.URL.String(),
+				Err: errors.New("http: request body does not implemement io.Seeker"),
+			}
+		}
+	}
+
+	resp, err := r.Client.Do(req)
+	for N > 0 && (isTemporary(err) || (resp != nil && resp.StatusCode >= http.StatusInternalServerError)) {
+		N--
+		var delay time.Duration
+		switch {
+		case Jitter < time.Microsecond:
+			delay = Delay + time.Duration(rand.Int63n(int64(Jitter)))*time.Nanosecond
+		case Jitter < time.Millisecond:
+			delay = Delay + time.Duration(rand.Int63n(int64(Jitter)))*time.Microsecond
+		default:
+			delay = Delay + time.Duration(rand.Int63n(Jitter.Milliseconds()))*time.Millisecond
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, &url.Error{
+				Op:  req.Method,
+				URL: req.URL.String(),
+				Err: req.Context().Err(),
+			}
+		case <-timer.C:
+			timer.Stop()
+		}
+
+		// If there is a body we have to reset it. Otherwise, we may send
+		// only partial data to the server when we retry the request.
+		if body != nil {
+			if _, err = body.Seek(0, io.SeekStart); err != nil {
+				return nil, err
+			}
+			req.Body = body
+		}
+		resp, err = r.Client.Do(req) // Now, retry.
+	}
+	if isTemporary(err) {
+		// If the request still fails with a temporary error
+		// we wrap the error to provide more information to the
+		// caller.
+		return nil, &url.Error{
+			Op:  req.Method,
+			URL: req.URL.String(),
+			Err: fmt.Errorf("http: temporary network error: %v", err),
+		}
+	}
+	return resp, err
+}
+
+// isTemporary returns true if the given error is
+// temporary - e.g. a temporary *url.Error or an
+// net.Error that indicates that a request got
+// timed-out.
+//
+// A nil error is not temporary.
+func isTemporary(err error) bool {
+	if err == nil { // fast path
+		return false
+	}
+	if netErr, ok := err.(net.Error); ok { // *url.Error implements net.Error
+		if netErr.Timeout() || netErr.Temporary() {
+			return true
+		}
+
+		// If a connection drops (e.g. server dies) while sending the request
+		// http.Do returns either io.EOF or io.ErrUnexpected. We treat that as
+		// temp. since the server may get restared such that the retry may succeed.
+		if errors.Is(netErr, io.EOF) || errors.Is(netErr, io.ErrUnexpectedEOF) {
+			return true
+		}
+	}
+	return false
+}

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -164,6 +164,7 @@ keys:
       ca: ""      # Path to one or multiple PEM root CA certificates 
     status:     # Vault status configuration. The server will periodically reach out to Vault to check its status. 
       ping: 10s   # Duration until the server checks Vault's status again.
+
   aws:
     # The AWS SecretsManager key store. The server will store
     # secret keys at the AWS SecretsManager encrypted with
@@ -176,3 +177,15 @@ keys:
         accesskey: ""  # Your AWS Access Key
         secretkey: ""  # Your AWS Secret Key
         token: ""      # Your AWS session token (usually optional)
+
+   gemalto:
+     # The Gemalto KeySecure key store. The server will store
+     # keys as secrets on the KeySecure instance.
+     keysecure:
+       endpoint: ""    # The KeySecure endpoint - e.g. https://127.0.0.1
+       credentials:    # The authentication to access the KeySecure instance.
+         token: ""     # The refresh token to obtain new short-lived authentication tokens.
+         domain: ""    # The KeySecure domain for which the refresh token is valid. If empty, defaults to the root domain.
+         retry: 15s    # The time the KES server waits before it tries to re-authenticate after connection loss.
+       tls:            # The KeySecure client TLS configuration
+         ca: ""        # Path to one or multiple PEM-encoded CA certificates for verifying the KeySecure TLS certificate.


### PR DESCRIPTION
This commit adds support for Gemalto KeySecure
as KMS.

KeySecure is a KMS implementation developed by Gemalto
(now Thales) and provides a KMIP as well as a REST API.
This commit adds a REST client that uses the KeySecure
secrets API (`/v1/vault/secrets`) to fetch and store
cryptographic keys.

***

KeySecure has multi-user support (username / password).
However, KeySecure also has the concept of refresh and
authentication tokens for programmatic access.

A refresh token is an opaque string, e.g.
`CEvk5cdHLG7si05LReIeDbXE3PKD082YdUFAnxX75md3jzV0BnyHyAmPPJiA0Kgn`,
that can be generated by a user to give an application programmatic
access. With the refresh token an application can request a short-lived
(5 min by default) authentication token. The authentication token
can then be used to perform operations - like creating a new secret.
Therefore, it has to be sent as part of the `Authorization` header.

With the refresh token the application can renew the authentication
token before it expires. KES supports only refresh tokens, not
username/password, since a refresh token is the recommended approach
to grant programmatic access. A refresh token can be easily revoked.

***

Apart from authentication, KeySecure provides a secret store that is
quite similar to e.g. Hashicorp Vault's K/V engine. Therefore, KES
uses the secrets API to store cryptographic keys.

***

This commit also adds a wrapper for an HTTP client that implements an
automatic retry mechanism. This is needed since KeySecure does not
provide a Go SDK and KES should be robust and tolerate temp. network
errors.