### PR TITLE
fix the docker CI build by adding Dockerfile.release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,7 +64,7 @@ dockers:
   -
     goos: linux
     goarch: amd64
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.release
     image_templates:
       - minio/kes:{{ .Tag }}
       - minio/kes:latest

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,12 @@
+FROM alpine:latest as alpine
+RUN apk add -U --no-cache ca-certificates
+
+FROM scratch
+MAINTAINER MinIO Development "dev@min.io"
+
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY kes /kes
+
+EXPOSE 7373
+
+ENTRYPOINT ["/kes"]


### PR DESCRIPTION
This commit fixes the docker CI build by adding
another `Dockerfile.release`.

Now, there are again two docker files and the CI
builds two different docker images:
 - One from `Dockerfile` with the tag `:edge`
 - One from `Dockerfile.release` with the tag `:latest`

The docker image tagged `:latest` is the latest stable
release while the image tagged `:edge` is the image
built from the latest commit in master.