### PR TITLE
update Go versions in CI and README

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v1
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker pull minio/kes
 GO111MODULE=on go get github.com/minio/kes/cmd/kes
 ```
 > You will need a working Go environment. Therefore, please follow [How to install Go](https://golang.org/doc/install). 
-> Minimum version required is go1.13
+> Minimum version required is go1.14
 
 ## Getting Started
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/kes
 
-go 1.13
+go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.26.3


### PR DESCRIPTION
Go 1.15 has been released on 2020-08-11. This commit
updates the Go versions in the README.md, module file
and CI configuration to Go version:
 - `Go 1.14`
 - `Go 1.15`

Go 1.13 has now reached EOL.