### PR TITLE
sdk: fix incorrect policy name concatenation

### DIFF
--- a/client.go
+++ b/client.go
@@ -480,7 +480,7 @@ func (c *Client) ListPolicies(pattern string) ([]string, error) {
 		pattern = "*" // => default to: list "all" policies
 	}
 	client := retry(c.HTTPClient)
-	resp, err := client.Get(endpoint(c.Endpoint, "/v1/policy/list", c.Endpoint, url.PathEscape(pattern)))
+	resp, err := client.Get(endpoint(c.Endpoint, "/v1/policy/list", url.PathEscape(pattern)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit fixes a bug in the SDK introduced by
945afb7. The SDK incorrectly concatenated the
KES server endpoint and the policy name which
usually causes the client request to fail due to
an pattern mismatch.

To reproduce this bug:
```sh
export KES_SERVER=https://play.min.io:7373
export KES_CLIENT_KEY=<root.key>
export KES_CLIENT_CERT=<root.cert>

kes policy list
```