### PR TITLE
fix docker file for edge image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
+FROM golang:1.14-alpine as build
+
+LABEL maintainer="MinIO Inc <dev@min.io>"
+
+ENV GOPATH /go
+ENV CGO_ENABLED 0
+ENV GO111MODULE on
+
+RUN  \
+     apk add --no-cache git && \
+     git clone https://github.com/minio/kes && cd kes && \
+     GOPROXY=$(go env GOPROXY) go install -v -ldflags "-s -w" ./cmd/kes
+
 FROM alpine:latest as alpine
 RUN apk add -U --no-cache ca-certificates
 
 FROM scratch
-MAINTAINER MinIO Development "dev@min.io"
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY kes /kes
+COPY --from=build /go/bin/kes /kes
 
 EXPOSE 7373
 


### PR DESCRIPTION
This commit fixes the docker file for the `minio/kes:edge`
image. The previous docker file incorrectly assumed that
the CI will build and push a docker image as for the `edge`
label to the docker hub.

Now, the docker file clones the minio/kes repo from scratch and
builds the `kes` binary via the Go 1.14 toolchain.