### PR TITLE
reject unknown fields in the yaml config file

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -129,7 +129,9 @@ func loadServerConfig(path string) (config serverConfig, err error) {
 	if err != nil {
 		return config, err
 	}
-	if err = yaml.NewDecoder(file).Decode(&config); err != nil {
+	decoder := yaml.NewDecoder(file)
+	decoder.SetStrict(true) // Reject unknown fields in the config file
+	if err = decoder.Decode(&config); err != nil {
 		file.Close()
 		return config, err
 	}


### PR DESCRIPTION
This commit changes the behavior of config file parsing.
Now, a KES server rejects config files with unknown fields
by making the decoding strict.

The main reason for this change is that when a user specifies
a non-existing `keys` backend or an existing `keys` backend has
a typo the KES server will start with a in-memory backend key store
instead of reporting an error.