### PR TITLE
add new server API for listing keys

### DIFF
--- a/cmd/kes/log.go
+++ b/cmd/kes/log.go
@@ -164,7 +164,7 @@ func traceAuditLogWithUI(stream *kes.AuditStream) {
 				table.Draw()
 			case event.ID == "<C-c>" || event.ID == "<Escape>":
 				if err := stream.Close(); err != nil {
-					fmt.Fprintln(os.Stderr, fmt.Sprintf("Error: audit log stream closed with: %v", err))
+					fmt.Fprintf(os.Stderr, "Error: audit log stream closed with: %v\n", err)
 				}
 				return
 			}
@@ -241,7 +241,7 @@ func traceErrorLogWithUI(stream *kes.ErrorStream) {
 				table.Draw()
 			case event.ID == "<C-c>" || event.ID == "<Escape>":
 				if err := stream.Close(); err != nil {
-					fmt.Fprintln(os.Stderr, fmt.Sprintf("Error: error log stream closed with: %v", err))
+					fmt.Fprintf(os.Stderr, "Error: error log stream closed with: %v\n", err)
 				}
 				return
 			}

--- a/internal/http/error.go
+++ b/internal/http/error.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 )
 
-// Error sends the given err as JSON error responds to w.
+// Error sends the given err as JSON error response to w.
 //
 // If err has a 'Status() int' method then Error sets the
 // response status code to err.Status(). Otherwise, it will
@@ -38,4 +39,40 @@ func Error(w http.ResponseWriter, err error) error {
 		_, err = io.WriteString(w, fmt.Sprintf(format, err))
 	}
 	return err
+}
+
+// ErrorTrailer sends the given err as JSON error to w as
+// HTTP trailer.
+//
+// ErrorTrailer should be used to communicate an error to
+// the client if the error occurred after a response has
+// been sent to client.
+//
+// A caller of ErrorTrailer has to pre-define the:
+//   • Status
+//   • Error
+// trailers via http.ResponseWriter.Header().Set("Trailer", "Status, Error")
+//
+// If err has a 'Status() int' method then Error sets the
+// response status code to err.Status(). Otherwise, it will
+// send 500 (internal server error).
+//
+// If err is nil then ErrorTrailer will send the status
+// code 500 and an empty JSON error - i.e. '{}'.
+func ErrorTrailer(w http.ResponseWriter, err error) {
+	var status = http.StatusInternalServerError
+	if e, ok := err.(interface{ Status() int }); ok {
+		status = e.Status()
+	}
+
+	const (
+		emptyMsg = `{}`
+		format   = `{"message":"%v"}`
+	)
+	w.Header().Set("Status", strconv.Itoa(status))
+	if err == nil {
+		w.Header().Set("Error", emptyMsg)
+	} else {
+		w.Header().Set("Error", fmt.Sprintf(format, err))
+	}
 }

--- a/internal/http/timeout.go
+++ b/internal/http/timeout.go
@@ -1,0 +1,210 @@
+// Copyright 2020 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/minio/kes"
+)
+
+// Timeout returns an HTTP handler that runs f
+// with the given time limit.
+//
+// A timeout is triggered if there is no activity
+// within the given time limit.
+//
+// If the time limit exceeds before f has written
+// any response to the client, Timeout will return
+// http.StatusServiceUnavailable (503) to the client.
+//
+// If the time limit exceeds after f has written
+// a response to the client - without any further
+// activity - Timeout will send two (non-empty)
+// HTTP trailers:
+//   • Status: http.StatusServiceUnavailable
+//   • Error: {"message":"timeout"}
+//
+// In any case, the timeout handler eventually closes
+// the underlying connection. Any further attempt by f
+// to write to the client after the timeout limit has
+// been exceeded will fail with http.ErrHandlerTimeout.
+//
+// If f implements a long-running job then it should either
+// stop once request.Context().Done() completes or once
+// a http.ResponseWriter.Write(...) call returns http.ErrHandlerTimeout.
+//
+// If f returns a stream (of messages) to the client then
+// it must send another message to the client before the
+// the time limit exceeds and must send the HTTP trailers:
+//   • Status: "200"
+//   • Error:  ""
+// once it completes successfully.
+// If f fails after streaming at least one message to the
+// client it should use ErrorTrailer to send the error as
+// HTTP trailer to the client.
+func Timeout(after time.Duration, f http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		r = r.WithContext(ctx)
+		tw := newTimeoutWriter(w)
+		tw.Header().Set("Trailer", "Status, Error")
+
+		done := make(chan struct{})
+		panicChan := make(chan interface{}, 1)
+		go func() {
+			defer func() {
+				if p := recover(); p != nil {
+					panicChan <- p
+				}
+			}()
+			f(tw, r)
+			close(done)
+		}()
+
+		timer := time.NewTimer(after)
+		defer timer.Stop()
+		for {
+			select {
+			case p := <-panicChan:
+				panic(p)
+			case <-timer.C:
+				if tw.isInactive() {
+					tw.timeout()
+					return
+				}
+				tw.markInactive()
+				timer.Reset(after)
+			case <-ctx.Done():
+				tw.timeout()
+				return
+			case <-done:
+				return
+			}
+		}
+	}
+}
+
+// timeoutWriter is a http.ResponseWriter that implements
+// http.Flusher and http.Pusher. It synchronizes a potential
+// timeout and the writes by the http.ResponseWriter it wraps.
+type timeoutWriter struct {
+	writer  http.ResponseWriter
+	flusher http.Flusher
+	pusher  http.Pusher
+
+	writeHappened uint32
+
+	lock       sync.Mutex
+	timedOut   bool
+	hasWritten bool
+}
+
+var _ http.ResponseWriter = (*timeoutWriter)(nil)
+var _ http.Flusher = (*timeoutWriter)(nil)
+var _ http.Pusher = (*timeoutWriter)(nil)
+
+var errTimeout = kes.NewError(http.StatusServiceUnavailable, "timeout")
+
+func newTimeoutWriter(w http.ResponseWriter) *timeoutWriter {
+	tw := &timeoutWriter{
+		writer: w,
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		tw.flusher = flusher
+	}
+	if pusher, ok := w.(http.Pusher); ok {
+		tw.pusher = pusher
+	}
+	return tw
+}
+
+// timeout returns http.StatusServiceUnavailable to the client
+// if no response has been written to the client, yet.
+func (tw *timeoutWriter) timeout() {
+	tw.lock.Lock()
+	defer tw.lock.Unlock()
+
+	tw.timedOut = true
+	if !tw.hasWritten {
+		tw.hasWritten = true
+		Error(tw.writer, errTimeout)
+	} else {
+		ErrorTrailer(tw.writer, errTimeout)
+	}
+}
+
+// isInactive returns true if no Write has happened
+// ever resp. since the last call to markInactive.
+func (tw *timeoutWriter) isInactive() bool { return atomic.LoadUint32(&tw.writeHappened) == 0 }
+
+// markInactive marks the http.ResponseWriter as
+// inactive. Another call to Write marks it as
+// active again.
+func (tw *timeoutWriter) markInactive() { atomic.StoreUint32(&tw.writeHappened, 0) }
+
+func (tw *timeoutWriter) Header() http.Header { return tw.writer.Header() }
+
+func (tw *timeoutWriter) WriteHeader(statusCode int) {
+	tw.lock.Lock()
+	defer tw.lock.Unlock()
+
+	if tw.timedOut {
+		if !tw.hasWritten {
+			tw.hasWritten = true
+			Error(tw.writer, errTimeout)
+		}
+	} else {
+		tw.hasWritten = true
+		tw.writer.WriteHeader(statusCode)
+	}
+}
+
+func (tw *timeoutWriter) Write(p []byte) (int, error) {
+	// We must not hold the lock while writing to the
+	// underlying http.ResponseWriter (via Write([]byte))
+	// b/c e.g. a slow/malicious client would block the
+	// lock.Unlock.
+	// In this case we cannot accquire the lock when we
+	// want to mark the timeoutWriter as timed out (See: timeout()).
+	// So, the client would block the actual handler by slowly
+	// reading the response and the timeout handler since it
+	// would not be able to accquire the lock until the Write([]byte)
+	// finishes.
+	// Therefore, we must release the lock before writing
+	// the (eventually large) response body to the client.
+	tw.lock.Lock()
+	if tw.timedOut {
+		tw.lock.Unlock()
+		return 0, http.ErrHandlerTimeout
+	}
+	if !tw.hasWritten {
+		tw.hasWritten = true
+		tw.writer.WriteHeader(http.StatusOK)
+	}
+	tw.lock.Unlock()
+
+	atomic.StoreUint32(&tw.writeHappened, 1)
+	return tw.writer.Write(p)
+}
+
+func (tw *timeoutWriter) Flush() {
+	if tw.flusher != nil {
+		tw.flusher.Flush()
+	}
+}
+
+func (tw *timeoutWriter) Push(target string, opts *http.PushOptions) error {
+	if tw.pusher != nil {
+		return tw.pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}


### PR DESCRIPTION
This commit adds a new server API:
```
/v1/key/list/<pattern>
```

This API returns a nd-json stream of
`KeyDescription` objects - each one
describing one key at the KES server.

The key listing API is designed to have
a low memory footprint (since there may
be thousands of keys) even when many
clients try to list keys in parallel.

Therefore, the listing implementation
(at the KES server as well as at the client)
uses iterators to list keys lazy. As soon
as a client disconnects / times out /...
the listing is aborted to not waste server
resources.

This commit also adds a CLI command:
```
kes key list [options] [<pattern>]
```