### PR TITLE
replace `os.Is{...}` error checks with `errors.Is(err, ...)`

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -254,13 +254,13 @@ func server(args []string) {
 	switch {
 	case config.Keys.Fs.Path != "":
 		f, err := os.Stat(config.Keys.Fs.Path)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			stdlog.Fatalf("Error: failed to open %q: %v", config.Keys.Fs.Path, err)
 		}
 		if err == nil && !f.IsDir() {
 			stdlog.Fatalf("Error: %q is not a directory", config.Keys.Fs.Path)
 		}
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			msg := fmt.Sprintf("Creating directory '%s' ... ", config.Keys.Fs.Path)
 			quiet.Print(msg)
 			if err = os.MkdirAll(config.Keys.Fs.Path, 0700); err != nil {

--- a/cmd/kes/tool.go
+++ b/cmd/kes/tool.go
@@ -178,7 +178,7 @@ func newIdentityCmd(args []string) {
 	)
 	keyFile, err = os.OpenFile(keyPath, fileFlags, 0600)
 	if err != nil {
-		if os.IsExist(err) {
+		if errors.Is(err, os.ErrExist) {
 			stdlog.Fatalf("Error: private key %q already exists: Use --force to overwrite it", keyPath)
 		}
 		stdlog.Fatalf("Error: failed to create private key %q: %v", keyPath, err)
@@ -187,7 +187,7 @@ func newIdentityCmd(args []string) {
 
 	certFile, err = os.OpenFile(certPath, fileFlags, 0600)
 	if err != nil {
-		if os.IsExist(err) {
+		if errors.Is(err, os.ErrExist) {
 			stdlog.Fatalf("Error: certificate %q already exists: Use --force to overwrite it", certPath)
 		}
 		stdlog.Fatalf("Error: failed to create certificate %q: %v", certPath, err)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -9,6 +9,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -54,7 +55,7 @@ func (s *Store) Create(key, value string) error {
 	// file must not have existed before.
 	path := filepath.Join(s.Dir, key)
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-	if err != nil && os.IsExist(err) {
+	if errors.Is(err, os.ErrExist) {
 		return kes.ErrKeyExists
 	}
 	if err != nil {
@@ -87,7 +88,7 @@ func (s *Store) Create(key, value string) error {
 func (s *Store) Delete(key string) error {
 	path := filepath.Join(s.Dir, key)
 	err := os.Remove(path)
-	if err != nil && os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		err = nil // Ignore the error if the file does not exist
 	}
 	if err != nil {
@@ -104,7 +105,7 @@ func (s *Store) Delete(key string) error {
 func (s *Store) Get(key string) (string, error) {
 	path := filepath.Join(s.Dir, key)
 	file, err := os.Open(path)
-	if err != nil && os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return "", kes.ErrKeyNotFound
 	}
 	if err != nil {


### PR DESCRIPTION
This commit replaces the error checks using the `os.Is{...}`
functions - e.g. `os.IsExist(err)` - with the more generic
`errors.Is(err, ...)`.

In general, the `os.Is{...}` functions should not be used.
See: https://github.com/golang/go/issues/41122