### PR TITLE
fs: do not return an error if delete succeeds

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -75,6 +75,28 @@ func TestCreateKey(t *testing.T) {
 	}
 }
 
+func TestDeleteKey(t *testing.T) {
+	if !*IsIntegrationTest {
+		t.SkipNow()
+	}
+
+	client, err := newClient()
+	if err != nil {
+		t.Fatalf("Failed to create KES client: %v", err)
+	}
+
+	key := fmt.Sprintf("KES-test-%x", sioutil.MustRandom(12))
+	if err := client.CreateKey(key); err != nil {
+		t.Fatalf("Failed to create key '%s': %v", key, err)
+	}
+	if err := client.DeleteKey(key); err != nil {
+		t.Fatalf("Failed to delete key '%s': %v", key, err)
+	}
+	if err := client.DeleteKey(key); err != nil {
+		t.Fatalf("Failed to delete key '%s' a 2nd time: %v", key, err)
+	}
+}
+
 var importKeyTests = []struct {
 	Key []byte
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -93,8 +93,9 @@ func (s *Store) Delete(key string) error {
 	}
 	if err != nil {
 		s.logf("fs: failed to delete '%s': %v", path, err)
+		return errDeleteKey
 	}
-	return errDeleteKey
+	return nil
 }
 
 // Get returns the secret key associated with the given name.


### PR DESCRIPTION
This commit fixes a bug in the FS key store.
When a delete occurs the FS key store used to
always return `errDeleteKey` even if the operation
succeeded.

This commit fixes this incorrect behavior.