### PR TITLE
ci: update golang-ci version (1.20 -> 1.33)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
       env:
         GO111MODULE: on
       run: |
-         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.20.0
+         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
          $(go env GOPATH)/bin/golangci-lint run --config ./.golangci.yml
          go vet ./...
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,9 @@ linters:
     - unparam
     - unused
     - structcheck
+    - prealloc
+    - maligned
+    - unconvert
 
 issues:
   exclude-use-default: false
@@ -27,4 +30,4 @@ issues:
       - error strings should not be capitalized or end with punctuation or a newline
       - should have comment           # TODO(aead): Remove once all exported ident. have comments!
 service:
-  golangci-lint-version: 1.20.0 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.33.0 # use the fixed version to not introduce new linters unexpectedly

--- a/integration_test.go
+++ b/integration_test.go
@@ -306,7 +306,8 @@ func TestListKeys(t *testing.T) {
 	if !*IsIntegrationTest {
 		t.SkipNow()
 	}
-	t.SkipNow() // TODO(aead): enable test once play.min.io:7373 has been updated and supports the /v1/key/list/ API
+	_ = listKeysTests // TODO(aead): make golang-ci happy. Remove once we enable the test on CI.
+	t.SkipNow()       // TODO(aead): enable test once play.min.io:7373 has been updated and supports the /v1/key/list/ API
 
 	client, err := newClient()
 	if err != nil {


### PR DESCRIPTION
This commit updates the golang-ci version and
adds some useful linters - like detecting potential
pre-allocation optimizations.