### PR TITLE
vault: add support for kubernetes authentication method

### DIFF
--- a/server-config.yaml
+++ b/server-config.yaml
@@ -159,6 +159,11 @@ keys:
       id: ""      # Your AppRole Role ID
       secret: ""  # Your AppRole Secret ID
       retry: 15s  # Duration until the server tries to re-authenticate after connection loss.
+    kubernetes: # Kubernetes credentials. See: https://www.vaultproject.io/docs/auth/kubernetes
+      engine: ""  # The path of the Kubernetes engine e.g. authenticate. If empty, defaults to: kubernetes. (Vault default)
+      role: ""    # The Kubernetes JWT role
+      jwt:  ""    # Either the JWT provided by K8S or a path to a K8S secret containing the JWT.
+      retry: 15s  # Duration until the server tries to re-authenticate after connection loss.
     tls:        # The Vault client TLS configuration for mTLS authentication and certificate verification
       key: ""     # Path to the TLS client private key for mTLS authentication to Vault
       cert: ""    # Path to the TLS client certificate for mTLS authentication to Vault


### PR DESCRIPTION
This commit adds support for the Vault kubernetes authentication
method: https://www.vaultproject.io/docs/auth/kubernetes

Now, the KES configuration can contain the following K8S auth section:
```
kubernetes:
  engine: ""
  role:   ""
  jwt:    ""
  retry:  15s
```

The `engine` allows the customization of the auth path configured
at Vault. It defaults to the Vault default: `kubernetes`.

The `retry` is the delay KES waits before trying to re-authenticate
after connection loss.

The `role` and `jwt` are the credentials received from K8S.

Currently, KES does not support both auth methods (`approle` | `kubernetes`)
at the same time. So, a operator must not set AppRole and Kubernetes
credentials.