### PR TITLE
config: add env. variable support for durations

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -207,7 +207,7 @@ func server(args []string) {
 	if err != nil {
 		stdlog.Fatalf("Error: %v", err)
 	}
-	store.StartGC(context.Background(), config.Cache.Expiry.Any, config.Cache.Expiry.Unused)
+	store.StartGC(context.Background(), time.Duration(config.Cache.Expiry.Any), time.Duration(config.Cache.Expiry.Unused))
 
 	const MaxBody = 1 << 20 // 1 MiB
 	metrics := metric.New()


### PR DESCRIPTION
This commit adds support for overwriting durations
in the config file (e.g. `cache.expiry.Any`) with
values provided via environment variables.

Therefore, this commit adds a custom duration type
that implements YAML (un)marshaling. The custom
unmarshaling treats durations in the config file
as strings and then checks whether they refer to a
env. variable before it parses it as `time.Duration`