### PR TITLE
fix incorrect lookup of Vault TLS config

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -126,8 +126,8 @@ func loadServerConfig(path string) (config serverConfig, err error) {
 	config.Keys.Vault.Kubernetes.JWT = expandEnv(config.Keys.Vault.Kubernetes.JWT)
 	config.Keys.Vault.Kubernetes.Role = expandEnv(config.Keys.Vault.Kubernetes.Role)
 	config.Keys.Vault.TLS.KeyPath = expandEnv(config.Keys.Vault.TLS.KeyPath)
-	config.Keys.Vault.TLS.CertPath = expandEnv(config.Keys.Vault.TLS.KeyPath)
-	config.Keys.Vault.TLS.CAPath = expandEnv(config.Keys.Vault.TLS.CertPath)
+	config.Keys.Vault.TLS.CertPath = expandEnv(config.Keys.Vault.TLS.CertPath)
+	config.Keys.Vault.TLS.CAPath = expandEnv(config.Keys.Vault.TLS.CAPath)
 
 	// AWS SecretsManager backend
 	config.Keys.Aws.SecretsManager.Endpoint = expandEnv(config.Keys.Aws.SecretsManager.Endpoint)


### PR DESCRIPTION
This commit fixes a bug when merging the
KES configuration with env. variables.

Before, the Vault TLS client certificate
and CA path got replaced by the TLS private
key and TLS client certificate.

Now, the Vault TLS client certificate
and CA path get replaced by the value of
the correct env. variable.