### PR TITLE
add metrics support to client SDK

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -232,7 +232,9 @@ func server(args []string) {
 	mux.Handle("/v1/log/audit/trace", metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.EnforceHTTP2(xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/log/audit/trace", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleTraceAuditLog(auditLog)))))))))))
 	mux.Handle("/v1/log/error/trace", metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.EnforceHTTP2(xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/log/error/trace", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleTraceErrorLog(errorLog)))))))))))
 
-	mux.Handle("/v1/metrics", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.EnforceHTTP2(xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/metrics", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleMetrics(metrics))))))))))))
+	// Scrapping /v1/metrics should not change the metrics itself.
+	// Doing so may cause misleading statistics.
+	mux.Handle("/v1/metrics", xhttp.Timeout(10*time.Second, xhttp.AuditLog(auditLog.Log(), roles, xhttp.EnforceHTTP2(xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/metrics", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleMetrics(metrics))))))))))
 
 	mux.Handle("/version", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.EnforceHTTP2(xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/version", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.HandleVersion(version))))))))))) // /version is accessible to any identity
 	mux.Handle("/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.EnforceHTTP2(xhttp.AuditLog(auditLog.Log(), roles, xhttp.TLSProxy(proxy, http.NotFound)))))))

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.13.0
 	github.com/secure-io/sio-go v0.3.0
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899

--- a/integration_test.go
+++ b/integration_test.go
@@ -463,6 +463,25 @@ func TestForgetIdentity(t *testing.T) {
 	}
 }
 
+func TestMetrics(t *testing.T) {
+	if !*IsIntegrationTest {
+		t.SkipNow()
+	}
+
+	client, err := newClient()
+	if err != nil {
+		t.Fatalf("Failed to create KES client: %v", err)
+	}
+	metric, err := client.Metrics()
+	if err != nil {
+		t.Fatalf("Failed to fetch KES metrics: %v", err)
+	}
+	N := metric.RequestOK + metric.RequestErr + metric.RequestFail
+	if n := metric.RequestN(); n != N {
+		t.Fatalf("Invalid server metrics: incorrect request count: got %d - want %d", n, N)
+	}
+}
+
 func newClient() (*kes.Client, error) {
 	certificate, err := tls.LoadX509KeyPair(*ClientCert, *ClientKey)
 	if err != nil {

--- a/metric.go
+++ b/metric.go
@@ -1,0 +1,41 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import "time"
+
+// Metric is a KES server metric snapshot.
+type Metric struct {
+	RequestOK   uint64 // Requests that succeeded
+	RequestErr  uint64 // Requests that failed with a well-defined error
+	RequestFail uint64 // Requests that failed unexpectedly due to an internal error
+
+	// Histogram of the KES server response latency.
+	// It shows how fast the server can handle requests.
+	//
+	// The KES server response latency is the time
+	// it takes to reply with a response once a request
+	// has been received.
+	//
+	// The histogram consists of n time buckets. Each
+	// time bucket contains the number of responses
+	// that took the time T or less. For example:
+	//
+	//   10ms │ 50ms │ 100ms │ 250ms │ 500ms │ ...
+	//   ─────┼──────┼───────┼───────┼───────┼────
+	//    100 │  115 │  121  │  126  │  130  │
+	//
+	//   Here, there were 100 responses that took
+	//   10ms or less to generate. There were also
+	//   115 responses that took 50ms or less.
+	//
+	//   So, there were 15 responses in the window
+	//   >10ms and <=50ms.
+	//
+	LatencyHistogram map[time.Duration]uint64
+}
+
+// RequestN returns the total number of received requests.
+func (m *Metric) RequestN() uint64 { return m.RequestOK + m.RequestErr + m.RequestFail }


### PR DESCRIPTION
This commit adds support for KES server
metrics to the client SDK.

Now, a client can fetch the KES server
metrics via the `client.Metrics()` method.

Further, this commit prevents the KES server
metrics from being updated when the metrics
are scrapped. This avoids misleading statistics
that include the metrics gathering as regular
traffic.