### PR TITLE
do not update once updated to latest release

### DIFF
--- a/cmd/kes/update.go
+++ b/cmd/kes/update.go
@@ -80,6 +80,11 @@ func updateInplace() error {
 		return err
 	}
 
+	if rel == version {
+		fmt.Printf("You are already running the most recent version of 'kes'.\n")
+		return nil
+	}
+
 	kesBin := fmt.Sprintf("https://github.com/minio/kes/releases/download/%s/kes-%s-%s", rel, runtime.GOOS, runtime.GOARCH)
 	reader, length, err := getUpdateReaderFromURL(kesBin, transport)
 	if err != nil {

--- a/cmd/kes/update.go
+++ b/cmd/kes/update.go
@@ -81,7 +81,7 @@ func updateInplace() error {
 	}
 
 	if rel == version {
-		fmt.Printf("You are already running the most recent version of 'kes'.\n")
+		fmt.Printf("You are already running the latest version %q.\n", version)
 		return nil
 	}
 


### PR DESCRIPTION
avoid repeatedly updating `kes` if already on
the latest version
    
```
kes -u
```
