### PR TITLE
docker: fix versioning in container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as build
+FROM golang:1.15-alpine as build
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,10 +3,12 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 LABEL name="MinIO" \
       vendor="MinIO Inc <dev@min.io>" \
       maintainer="MinIO Inc <dev@min.io>" \
-      version="v0.12.1" \
-      release="v0.12.1" \
+      version="v0.13.3" \
+      release="v0.13.3" \
       summary="KES is a stateless and distributed key-management system for high-performance applications." \
       description="KES as the bridge between modern applications - running as containers on Kubernetes - and centralized KMS solutions. Therefore, KES has been designed to be simple, scalable and secure by default. It has just a few knobs to tweak instead of a complex configuration and does not require a deep understanding of secure key-management or cryptography."
+
+ENV VERSION=v0.13.3
 
 RUN \
     microdnf update --nodocs && \
@@ -14,9 +16,9 @@ RUN \
     microdnf clean all && \
     mkdir /licenses && \
     curl -s -q https://raw.githubusercontent.com/minio/kes/master/CREDITS -o /licenses/CREDITS && \
-    curl -s -q https://raw.githubusercontent.com/minio/kes/master/LICENSE -o /licenses/LICENSE
-
-COPY kes /kes
+    curl -s -q https://raw.githubusercontent.com/minio/kes/master/LICENSE -o /licenses/LICENSE && \
+    curl -sSL -q https://github.com/minio/kes/releases/download/$VERSION/kes-linux-amd64 -o kes && \
+    chmod +x kes
 
 EXPOSE 7373
 


### PR DESCRIPTION
This commit address a problem w.r.t. versioning
for docker containers. Now, the container fetches the
binary with the correct version and for the right
architecture on startup.

Before, the container reported an unexpected version
when executing `docker run <id> --version`.

The main problem was that binary versions were not aligned
with docker image tags. A container running the image
`v0.13.0` should also run the binary `v0.13.0` - not the
latest binary version.