### PR TITLE
server: listen on all net interfaces by default

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -37,7 +37,7 @@ const serverCmdUsage = `Usage:
     kes server [options]
 
 Options:
-    --addr <IP:PORT>       The address of the server (default: 127.0.0.1:7373)
+    --addr <IP:PORT>       The address of the server (default: 0.0.0.0:7373)
     --config <PATH>        Path to the server configuration file
     --root  <IDENTITY>     The identity of root - who can perform any operation.
                            A root identity must be specified - either via this
@@ -95,7 +95,7 @@ func server(args []string) {
 		mtlsAuthFlag string
 		quietFlag    quiet
 	)
-	cli.StringVar(&addrFlag, "addr", "127.0.0.1:7373", "The address of the server")
+	cli.StringVar(&addrFlag, "addr", "0.0.0.0:7373", "The address of the server")
 	cli.StringVar(&configFlag, "config", "", "Path to the server configuration file")
 	cli.StringVar(&rootFlag, "root", "", "The identity of root - who can perform any operation")
 	cli.BoolVar(&mlockFlag, "mlock", false, "Lock all allocated memory pages")


### PR DESCRIPTION
This commit changes the default behavior of the
server address binding. Before, if no TCP address
(IP:PORT) was specified, the server used `127.0.0.1:7373`.
So, the server would try to listen on port `7373` on
the link-local network interface.

While this behavior is not "wrong" it can lead to confusion
when there are multiple network interfaces and another service
is already listening on the port `7373` - e.g. in case of
docker in combination with port-forwarding:
(host:7373 -> container:7373).

In such a case, the KES server would not be able to listen on
port `7373` on the link-local interface - since it'S already used.
Therefore, an application trying to access the server would experience
errors as if the server is not available:
```
Get "https://localhost:7373/version: read tcp 127.0.0.1:57106->127.0.0.1:7373: read: connection reset by peer
```

This commit changes the default behavior to listen on all network
interfaces (`0.0.0.0`) instead of the link-local address (`127.0.0.1`)

A user who wants to specifically listen only on `127.0.0.1` can always
do that via `--addr=127.0.0.1:7373` or via the config file.