### PR TITLE
identity: add support for creating server certificates

### DIFF
--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -141,3 +141,14 @@ func cancelOnSignal(signals ...os.Signal) context.Context {
 	}()
 	return ctx
 }
+
+type multiFlag []string
+
+var _ flag.Value = (*multiFlag)(nil) // compiler check
+
+func (f *multiFlag) String() string { return fmt.Sprint(*f) }
+
+func (f *multiFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}


### PR DESCRIPTION
This commit adds three new flags to the `kes tool identity new`
command for creating server certificates.

With the `--server` flag the created certificate is valid
for server authentication - instead of client authentication (default).
With the `--dns` and `--ip` flags SANs can be specified.

In general, it is useful to support the creation of server certificates
since e.g. not all openssl versions on major platforms can be used
to create certificates the same way.

For example, the current version of openssl on macOS does not support
the `-san` flag or supports Ed25519.

Now, the documentation can just use the `kes` CLI and does not need
to depend on other tools.