### PR TITLE
add mechanism to create keys in a declarative way

### DIFF
--- a/cmd/kes/config_v0.13.5.go
+++ b/cmd/kes/config_v0.13.5.go
@@ -1,0 +1,59 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package main
+
+import "github.com/minio/kes"
+
+// serverConfigV0135 represents a KES server configuration up to
+// v0.13.5. It provides backward-compatible unmarshaling of exiting
+// configuration files.
+//
+// It will be removed at some time in the future.
+type serverConfigV0135 struct {
+	Addr string       `yaml:"address"`
+	Root kes.Identity `yaml:"root"`
+
+	TLS struct {
+		KeyPath  string `yaml:"key"`
+		CertPath string `yaml:"cert"`
+		Proxy    struct {
+			Identities []kes.Identity `yaml:"identities"`
+			Header     struct {
+				ClientCert string `yaml:"cert"`
+			} `yaml:"header"`
+		} `yaml:"proxy"`
+	} `yaml:"tls"`
+
+	Policies map[string]struct {
+		Paths      []string       `yaml:"paths"`
+		Identities []kes.Identity `yaml:"identities"`
+	} `yaml:"policy"`
+
+	Cache struct {
+		Expiry struct {
+			Any    duration `yaml:"any"`    // Use custom type for env. var support
+			Unused duration `yaml:"unused"` // Use custom type for env. var support
+		} `yaml:"expiry"`
+	} `yaml:"cache"`
+
+	Log struct {
+		Error string `yaml:"error"`
+		Audit string `yaml:"audit"`
+	} `yaml:"log"`
+
+	Keys kmsServerConfig `yaml:"keys"`
+}
+
+func (c *serverConfigV0135) Migrate() serverConfig {
+	return serverConfig{
+		Addr:     c.Addr,
+		Root:     c.Root,
+		TLS:      c.TLS,
+		Policies: c.Policies,
+		Cache:    c.Cache,
+		Log:      c.Log,
+		KeyStore: c.Keys,
+	}
+}

--- a/cmd/kes/tool.go
+++ b/cmd/kes/tool.go
@@ -395,8 +395,8 @@ func migrate(args []string) {
 	if err != nil {
 		stdlog.Fatalf("Error: failed to read config file: %v", err)
 	}
-	sourceConfig.Keys.SetDefaults()
-	if err := sourceConfig.Keys.Verify(); err != nil {
+	sourceConfig.KeyStore.SetDefaults()
+	if err := sourceConfig.KeyStore.Verify(); err != nil {
 		stdlog.Fatalf("Error: %v", err)
 	}
 
@@ -404,16 +404,16 @@ func migrate(args []string) {
 	if err != nil {
 		stdlog.Fatalf("Error: failed to read config file: %v", err)
 	}
-	targetConfig.Keys.SetDefaults()
-	if err := targetConfig.Keys.Verify(); err != nil {
+	targetConfig.KeyStore.SetDefaults()
+	if err := targetConfig.KeyStore.Verify(); err != nil {
 		stdlog.Fatalf("Error: %v", err)
 	}
 
-	src, err := sourceConfig.Keys.Connect(quietFlag, nil)
+	src, err := sourceConfig.KeyStore.Connect(quietFlag, nil)
 	if err != nil {
 		stdlog.Fatalf("Error: %v", err)
 	}
-	dst, err := targetConfig.Keys.Connect(quietFlag, nil)
+	dst, err := targetConfig.KeyStore.Connect(quietFlag, nil)
 	if err != nil {
 		stdlog.Fatalf("Error: %v", err)
 	}

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -128,13 +128,19 @@ log:
   # request-response pair - including invalid requests.
   audit: off
 
-# The keys section specifies which KMS - or in general key store - is
+# In the keys section, pre-defined keys can be specified. The KES
+# server will try to create the listed keys before startup.
+keys:
+  - name: some-key-name 
+  - name: another-key-name
+
+# The keystore section specifies which KMS - or in general key store - is
 # used to store and fetch encryption keys.
 # A KES server can only use one KMS / key store at the same time.
 # If no store is explicitly specified the server will use store
 # keys in-memory. In this case all keys are lost when the KES server
 # restarts.
-keys:
+keystore:
   # Configuration for storing keys on the filesystem.
   # The path must be path to a directory. If it doesn't
   # exist then the KES server will create the directory.


### PR DESCRIPTION
This commit adds a mechanism to create keys in
a declarative way. Now, keys can be specified
in the `keys` section of the config file:

```
keys:
  - name: my-key
  - name: my-key2
```

The KES server will create these keys before
startup.

This commit is a breaking change. The `keys`
section was used to define the KMS/KeyStore
backend. Now, the KMS backend can be specified
in the `keystore` section.