### PR TITLE
cli: fix incorrect handling of the context argument

### DIFF
--- a/cmd/kes/key.go
+++ b/cmd/kes/key.go
@@ -166,7 +166,7 @@ func decryptKey(args []string) {
 	if err != nil {
 		stdlog.Fatalf("Error: invalid ciphertext: %v", err)
 	}
-	if len(args) == 3 {
+	if cli.NArg() == 3 {
 		cryptoCtx, err = base64.StdEncoding.DecodeString(cli.Arg(2))
 		if err != nil {
 			stdlog.Fatalf("Error: invalid context: %v", err)


### PR DESCRIPTION
Before, an incorrect check caused the CLI to not pass
the correct context value to the server when decrypting
some data.