### PR TITLE
fix decoding of data encryption keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func (d DEK) MarshalText() ([]byte, error) {
 // It returns an error if text is not base64-encoded.
 //
 // UnmarshalText sets DEK's plaintext to nil.
-func (d *DEK) UnmarshalText(text []byte) error {
+func (d *DEK) UnmarshalText(text []byte) (err error) {
 	n := base64.StdEncoding.DecodedLen(len(text))
 	if len(d.Ciphertext) < n {
 		if cap(d.Ciphertext) >= n {
@@ -168,7 +168,8 @@ func (d *DEK) UnmarshalText(text []byte) error {
 	}
 
 	d.Plaintext = nil // Forget any previous plaintext
-	_, err := base64.StdEncoding.Decode(d.Ciphertext, text)
+	n, err = base64.StdEncoding.Decode(d.Ciphertext, text)
+	d.Ciphertext = d.Ciphertext[:n]
 	return err
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,11 @@
 
 package kes
 
-import "testing"
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+)
 
 var endpointTests = []struct {
 	Endpoint string
@@ -43,4 +47,52 @@ func TestEndpoint(t *testing.T) {
 			t.Fatalf("Test %d: endpoint url mismatch: got '%s' - want '%s'", i, url, test.URL)
 		}
 	}
+}
+
+var dekEncodeDecodeTests = []struct {
+	Key DEK
+}{
+	{
+		Key: DEK{},
+	},
+	{
+		Key: DEK{
+			Plaintext:  nil,
+			Ciphertext: mustDecodeB64("eyJhZWFkIjoiQUVTLTI1Ni1HQ00tSE1BQy1TSEEtMjU2IiwiaXYiOiJ3NmhLUFVNZXVtejZ5UlVZL29pTFVBPT0iLCJub25jZSI6IktMSEU3UE1jRGo2N2UweHkiLCJieXRlcyI6Ik1wUkhjQWJaTzZ1Sm5lUGJGcnpKTkxZOG9pdkxwTmlUcTNLZ0hWdWNGYkR2Y0RlbEh1c1lYT29zblJWVTZoSXIifQ=="),
+		},
+	},
+	{
+		Key: DEK{
+			Plaintext:  mustDecodeB64("GM2UvLXp/X8lzqq0mibFC0LayDCGlmTHQhYLj7qAy7Q="),
+			Ciphertext: mustDecodeB64("eyJhZWFkIjoiQUVTLTI1Ni1HQ00tSE1BQy1TSEEtMjU2IiwiaXYiOiJ3NmhLUFVNZXVtejZ5UlVZL29pTFVBPT0iLCJub25jZSI6IktMSEU3UE1jRGo2N2UweHkiLCJieXRlcyI6Ik1wUkhjQWJaTzZ1Sm5lUGJGcnpKTkxZOG9pdkxwTmlUcTNLZ0hWdWNGYkR2Y0RlbEh1c1lYT29zblJWVTZoSXIifQ=="),
+		},
+	},
+}
+
+func TestEncodeDecodeDEK(t *testing.T) {
+	for i, test := range dekEncodeDecodeTests {
+		text, err := test.Key.MarshalText()
+		if err != nil {
+			t.Fatalf("Test %d: failed to marshal DEK: %v", i, err)
+		}
+
+		var key DEK
+		if err = key.UnmarshalText(text); err != nil {
+			t.Fatalf("Test %d: failed to unmarshal DEK: %v", i, err)
+		}
+		if key.Plaintext != nil {
+			t.Fatalf("Test %d: unmarshaled DEK contains non-nil plaintext", i)
+		}
+		if !bytes.Equal(key.Ciphertext, test.Key.Ciphertext) {
+			t.Fatalf("Test %d: ciphertext mismatch: got %x - want %x", i, key.Ciphertext, test.Key.Ciphertext)
+		}
+	}
+}
+
+func mustDecodeB64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }


### PR DESCRIPTION
The text decoding of data encryption keys produced
incorrect ciphertexts when the encoded text contained
base64-padding bytes.

Now, the decoding sets the length of the decoded ciphertext
to the actual data size.