### PR TITLE
add active request and uptime metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -802,10 +802,12 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 	defer resp.Body.Close()
 
 	const (
-		MetricRequestOK    = "kes_http_request_success"
-		MetricRequestErr   = "kes_http_request_error"
-		MetricRequestFail  = "kes_http_request_failure"
-		MetricResponseTime = "kes_http_response_time"
+		MetricRequestOK     = "kes_http_request_success"
+		MetricRequestErr    = "kes_http_request_error"
+		MetricRequestFail   = "kes_http_request_failure"
+		MetricRequestActive = "kes_http_request_active"
+		MetricResponseTime  = "kes_http_response_time"
+		MetricSystemUpTme   = "kes_system_up_time"
 	)
 
 	var (
@@ -837,6 +839,8 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 			metric.RequestErr = uint64(rawMetric.GetCounter().GetValue())
 		case kind == dto.MetricType_COUNTER && name == MetricRequestFail:
 			metric.RequestFail = uint64(rawMetric.GetCounter().GetValue())
+		case kind == dto.MetricType_GAUGE && name == MetricRequestActive:
+			metric.RequestActive = uint64(rawMetric.GetGauge().GetValue())
 		case kind == dto.MetricType_HISTOGRAM && name == MetricResponseTime:
 			metric.LatencyHistogram = map[time.Duration]uint64{}
 			for _, bucket := range rawMetric.GetHistogram().GetBucket() {
@@ -844,6 +848,8 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 				metric.LatencyHistogram[duration] = bucket.GetCumulativeCount()
 			}
 			delete(metric.LatencyHistogram, 0) // Delete the artificial zero entry
+		case kind == dto.MetricType_GAUGE && name == MetricSystemUpTme:
+			metric.UpTime = time.Duration(rawMetric.GetGauge().GetValue()) * time.Second
 		}
 	}
 	return metric, nil

--- a/metric.go
+++ b/metric.go
@@ -8,9 +8,10 @@ import "time"
 
 // Metric is a KES server metric snapshot.
 type Metric struct {
-	RequestOK   uint64 // Requests that succeeded
-	RequestErr  uint64 // Requests that failed with a well-defined error
-	RequestFail uint64 // Requests that failed unexpectedly due to an internal error
+	RequestOK     uint64 // Requests that succeeded
+	RequestErr    uint64 // Requests that failed with a well-defined error
+	RequestFail   uint64 // Requests that failed unexpectedly due to an internal error
+	RequestActive uint64 // Requests that are currently active and haven't completed yet
 
 	// Histogram of the KES server response latency.
 	// It shows how fast the server can handle requests.
@@ -35,6 +36,8 @@ type Metric struct {
 	//   >10ms and <=50ms.
 	//
 	LatencyHistogram map[time.Duration]uint64
+
+	UpTime time.Duration // The time the KES server has been up and running
 }
 
 // RequestN returns the total number of received requests.


### PR DESCRIPTION
This commit adds two new metrics to the KES server:
 - The number of currently active but not yet completed requests
 - The server up-time in seconds

Now, the KES server returns the following prometheus text format
when hitting `https://<endpoint>:<port>/v1/metrics`:

```
# HELP kes_http_request_active Number of active requests that are not finished, yet.
# TYPE kes_http_request_active gauge
kes_http_request_active 1
# HELP kes_http_request_error Number of request that failed due to some error. (HTTP 4xx status code)
# TYPE kes_http_request_error counter
kes_http_request_error 0
# HELP kes_http_request_failure Number of request that failed due to some internal failure. (HTTP 5xx status code)
# TYPE kes_http_request_failure counter
kes_http_request_failure 0
# HELP kes_http_request_success Number of requests that have been served successfully.
# TYPE kes_http_request_success counter
kes_http_request_success 2
# HELP kes_http_response_time Histogram of request response times spawning from 10ms to 10s.
# TYPE kes_http_response_time histogram
kes_http_response_time_bucket{le="0.01"} 2
kes_http_response_time_bucket{le="0.05"} 2
kes_http_response_time_bucket{le="0.1"} 2
kes_http_response_time_bucket{le="0.25"} 2
kes_http_response_time_bucket{le="0.5"} 2
kes_http_response_time_bucket{le="1"} 2
kes_http_response_time_bucket{le="1.5"} 2
kes_http_response_time_bucket{le="3"} 2
kes_http_response_time_bucket{le="5"} 2
kes_http_response_time_bucket{le="10"} 2
kes_http_response_time_bucket{le="+Inf"} 2
kes_http_response_time_sum 8.5001e-05
kes_http_response_time_count 2
# HELP kes_system_up_time The time the server has been up and running in seconds
# TYPE kes_system_up_time gauge
kes_system_up_time 20.3
```