### PR TITLE
metrics: exclude the +Inf bucket when parsing metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -844,6 +845,10 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 		case kind == dto.MetricType_HISTOGRAM && name == MetricResponseTime:
 			metric.LatencyHistogram = map[time.Duration]uint64{}
 			for _, bucket := range rawMetric.GetHistogram().GetBucket() {
+				if math.IsInf(bucket.GetUpperBound(), 0) { // Ignore the +Inf bucket
+					continue
+				}
+
 				duration := time.Duration(1000*bucket.GetUpperBound()) * time.Millisecond
 				metric.LatencyHistogram[duration] = bucket.GetCumulativeCount()
 			}


### PR DESCRIPTION
This commit fixes a bug when converting Prometheus
metrics into a struct type. Before, the `+Inf` bucket
was not ignored. This lead to confusing metrics output
containing a negative duration entry.

```
{
  "RequestOK": 50979,
  "RequestErr": 1814,
  "RequestFail": 0,
  "RequestActive": 0,
  "LatencyHistogram": {
    "-1000000": 52793,
    "10000000": 52701,
    "100000000": 52780,
    "1000000000": 52793,
    "10000000000": 52793,
    "1500000000": 52793,
    "250000000": 52780,
    "3000000000": 52793,
    "50000000": 52775,
    "500000000": 52790,
    "5000000000": 52793
  },
  "UpTime": 159265000000000
}
```

This commit fixes this by checking whether the bucket
is the `+Inf` bucket.