### PR TITLE
cli: fetch and visualize server metrics

### DIFF
--- a/internal/xterm/table.go
+++ b/internal/xterm/table.go
@@ -91,15 +91,24 @@ func (t *Table) Header() []*HCell { return t.header }
 
 // AddRow adds a new row to the table. If the capacity
 // of the table is reached older rows get dropped.
-func (t *Table) AddRow(cells ...*Cell) {
+func (t *Table) AddRow(cells ...*Cell) { t.SetRow(-1, cells...) }
+
+// SetRow replaces a row at the given index. If the index
+// is negative or exceeds the size of the table the given
+// row is appended at the end.
+func (t *Table) SetRow(at int, cells ...*Cell) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	if len(t.rows) <= t.rowLimit {
-		t.rows = append(t.rows, cells)
+	if at < 0 || len(t.rows) <= at {
+		if len(t.rows) <= t.rowLimit {
+			t.rows = append(t.rows, cells)
+		} else {
+			t.rows = t.rows[len(t.rows)-1-t.rowLimit:]
+			t.rows = append(t.rows, cells)
+		}
 	} else {
-		t.rows = t.rows[len(t.rows)-1-t.rowLimit:]
-		t.rows = append(t.rows, cells)
+		t.rows[at] = cells
 	}
 }
 

--- a/metric.go
+++ b/metric.go
@@ -8,10 +8,10 @@ import "time"
 
 // Metric is a KES server metric snapshot.
 type Metric struct {
-	RequestOK     uint64 // Requests that succeeded
-	RequestErr    uint64 // Requests that failed with a well-defined error
-	RequestFail   uint64 // Requests that failed unexpectedly due to an internal error
-	RequestActive uint64 // Requests that are currently active and haven't completed yet
+	RequestOK     uint64 `json:"kes_http_request_success"` // Requests that succeeded
+	RequestErr    uint64 `json:"kes_http_request_error"`   // Requests that failed with a well-defined error
+	RequestFail   uint64 `json:"kes_http_request_failure"` // Requests that failed unexpectedly due to an internal error
+	RequestActive uint64 `json:"kes_http_request_active"`  // Requests that are currently active and haven't completed yet
 
 	// Histogram of the KES server response latency.
 	// It shows how fast the server can handle requests.
@@ -35,9 +35,9 @@ type Metric struct {
 	//   So, there were 15 responses in the window
 	//   >10ms and <=50ms.
 	//
-	LatencyHistogram map[time.Duration]uint64
+	LatencyHistogram map[time.Duration]uint64 `json:"kes_http_response_time"`
 
-	UpTime time.Duration // The time the KES server has been up and running
+	UpTime time.Duration `json:"kes_system_up_time"` // The time the KES server has been up and running
 }
 
 // RequestN returns the total number of received requests.


### PR DESCRIPTION
This commit adds the `--type=metric` option
to the `kes log trace` command. When the
`metric` type is specified then the CLI will
fetch the server metrics periodically and either
output a nd-JSON stream of metrics or display
the metrics in a table-like view:

```
┌───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┐
│  0-10ms   │  10-50ms  │ 50-100ms  │ 100-250ms │ 250-500ms │ 500ms-1s  │  1-1.5s   │  1.5-3s   │   3-5s    │   5-10s   │
├───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│  219489   │    803    │    114    │    89     │    75     │    27     │     6     │    19     │     2     │     3     │
└───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┘
 Active : 0
 Success: 98.07% | 216378
 Error  : 01.93% | 4249
 Failure: 00.00% | 0

 UpTime : 92h40m47s
```

When standard output is not a terminal or when the
`--json` flag is specified then `kes log trace --type=metric`
outputs the metrics as JSON.