### PR TITLE
add internal/fips package for FIPS 140 support

### DIFF
--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"github.com/minio/kes"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // Use e.g.: go build -ldflags "-X main.version=v1.0.0"
@@ -122,7 +122,7 @@ func newClient(insecureSkipVerify bool) *kes.Client {
 	})
 }
 
-func isTerm(f *os.File) bool { return terminal.IsTerminal(int(f.Fd())) }
+func isTerm(f *os.File) bool { return term.IsTerminal(int(f.Fd())) }
 
 // cancelOnSignal returns a new Context that gets canceled when
 // one of the signals is received. It is allowed to call the

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/prometheus/common v0.13.0
 	github.com/secure-io/sio-go v0.3.0
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
-	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72
 	google.golang.org/api v0.31.0
 	google.golang.org/genproto v0.0.0-20200901141002-b3bf27a9dbd1
 	google.golang.org/grpc v1.31.1

--- a/go.sum
+++ b/go.sum
@@ -550,8 +550,10 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a h1:i47hUS795cOydZI4AwJQCKXOr4BvxzvikwDoDtHhP2Y=
-golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72 h1:VqE9gduFZ4dbR7XoL77lHFp0/DyDUBKSXK7CMFkVcV0=
+golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/fips/api.go
+++ b/internal/fips/api.go
@@ -1,0 +1,13 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package fips
+
+// Enabled indicates whether cryptographic primitives,
+// like AES or SHA-256, are implemented using a FIPS 140
+// certified module.
+//
+// If FIPS-140 is enabled no non-NIST/FIPS approved
+// primitives must be used.
+const Enabled = enabled

--- a/internal/fips/fips.go
+++ b/internal/fips/fips.go
@@ -1,0 +1,9 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+// +build fips,linux,amd64
+
+package fips
+
+const enabled = 0 == 0

--- a/internal/fips/nofips.go
+++ b/internal/fips/nofips.go
@@ -1,0 +1,9 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+// +build !fips
+
+package fips
+
+const enabled = 0 == 1

--- a/internal/xterm/table.go
+++ b/internal/xterm/table.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // HCell represents a single header cell of a table.
@@ -119,7 +119,7 @@ func (t *Table) Draw() {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	width, height, _ := terminal.GetSize(int(os.Stdout.Fd()))
+	width, height, _ := term.GetSize(int(os.Stdout.Fd()))
 
 	fmt.Print("\033[3J\033[0;0H", "\r") // ASCII sequence to clean scroll + move to position (0,0)
 	fmt.Printf("\033[%dM", height+1)    // ASCII sequence to delete height+1 rows


### PR DESCRIPTION
This commit adds a `internal/fips` package.
Now, the KES server / CLI can be built using
the Go BoringCrypto FIPS 140 module. This module
is only available on linux/amd64.

In FIPS mode, a KES server will only used NIST/FIPS
approved primitives and reject any ciphertexts (including
valid ones) generated e.g. using ChaCha20-Poly1305.