### PR TITLE
plugin: add generic KES KeyStore plugin v1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - unused
     - structcheck
     - prealloc
-    - maligned
     - unconvert
 
 issues:

--- a/internal/gemalto/key-secure.go
+++ b/internal/gemalto/key-secure.go
@@ -218,7 +218,7 @@ func (s *KeySecure) Get(key string) (string, error) {
 }
 
 // Delete removes a the value associated with the given key
-// from Vault, if it exists.
+// from Gemalto, if it exists.
 func (s *KeySecure) Delete(key string) error {
 	url := fmt.Sprintf("%s/api/v1/vault/secrets/%s?type=name", s.Endpoint, key)
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -295,7 +295,7 @@ func (s *KeySecure) List(ctx context.Context) (secret.Iterator, error) {
 			url := fmt.Sprintf("%s/api/v1/vault/secrets?limit=%d&skip=%d", s.Endpoint, limit, skip)
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 			if err != nil {
-				logf(s.ErrorLog, "gemalto: failed to list keys: %q", err)
+				logf(s.ErrorLog, "gemalto: failed to list keys: %v", err)
 				iterator.SetErr(errListKey)
 				break
 			}

--- a/internal/generic/client.go
+++ b/internal/generic/client.go
@@ -1,0 +1,407 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package generic
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/minio/kes"
+	xhttp "github.com/minio/kes/internal/http"
+	"github.com/minio/kes/internal/secret"
+)
+
+// Store is a generic KeyStore that stores/fetches keys from a
+// v1 KeyStore plugin compatible service.
+type Store struct {
+	Endpoint string // Endpoint of the KeyStore plugin / generic KeyStore.
+
+	KeyPath  string // Path to the TLS client private key.
+	CertPath string // Path to the TLS client certificate.
+	CAPath   string // Path to one (or directory of) root CA certificates.
+
+	// ErrorLog specifies an optional logger for errors.
+	// If an unexpected error is encountered while trying
+	// to fetch, store or delete a key or when an authentication
+	// error happens then an error event is written to the error
+	// log.
+	//
+	// If nil, logging is done via the log package's standard
+	// logger.
+	ErrorLog *log.Logger
+
+	client xhttp.Retry
+}
+
+var (
+	errCreateKey = kes.NewError(http.StatusBadGateway, "bad gateway: failed to create key")
+	errGetKey    = kes.NewError(http.StatusBadGateway, "bad gateway: failed to access key")
+	errDeleteKey = kes.NewError(http.StatusBadGateway, "bad gateway: failed to delete key")
+	errListKey   = kes.NewError(http.StatusBadGateway, "bad gateway: failed to list keys")
+)
+
+// Create creates the given key-value pair at the generic KeyStore if
+// and only if the given key does not exist. If such an entry already
+// exists it returns kes.ErrKeyExists.
+func (s *Store) Create(key, value string) error {
+	type Request struct {
+		Bytes []byte `json:"bytes"`
+	}
+	body, err := json.Marshal(Request{
+		Bytes: []byte(value),
+	})
+	if err != nil {
+		s.logf("generic: failed to create key %q: %v", key, err)
+		return errCreateKey
+	}
+
+	url := endpoint(s.Endpoint, "/v1/key", url.PathEscape(key))
+	req, err := http.NewRequest(http.MethodPost, url, xhttp.RetryReader(bytes.NewReader(body)))
+	if err != nil {
+		s.logf("generic: failed to create key %q: %v", key, err)
+		return errCreateKey
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.logf("generic: failed to create key %q: %v", key, err)
+		return errCreateKey
+	}
+	if resp.StatusCode != http.StatusCreated {
+		switch err = parseErrorResponse(resp); {
+		case err == kes.ErrKeyExists:
+			return kes.ErrKeyExists
+		default:
+			s.logf("generic: failed to create key %q: %v", key, err)
+			return errCreateKey
+		}
+	}
+	return nil
+}
+
+// Delete removes a the value associated with the given key
+// from the generic KeyStore, if it exists.
+func (s *Store) Delete(key string) error {
+	url := endpoint(s.Endpoint, "/v1/key", url.PathEscape(key))
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		s.logf("generic: failed to delete key %q: %v", key, err)
+		return errDeleteKey
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.logf("generic: failed to delete key %q: %v", key, err)
+		return errDeleteKey
+	}
+	if resp.StatusCode != http.StatusOK {
+		if err = parseErrorResponse(resp); err != nil {
+			s.logf("generic: failed to delete key %q: %v", key, err)
+		}
+		return errDeleteKey
+	}
+	return nil
+}
+
+// Get returns the value associated with the given key.
+// If no entry for the key exists it returns kes.ErrKeyNotFound.
+func (s *Store) Get(key string) (string, error) {
+	type Response struct {
+		Bytes []byte `json:"bytes"`
+	}
+
+	url := endpoint(s.Endpoint, "/v1/key", url.PathEscape(key))
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		s.logf("generic: failed to access key %q: %v", key, err)
+		return "", errGetKey
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.logf("generic: failed to access key %q: %v", key, err)
+		return "", errGetKey
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		switch err = parseErrorResponse(resp); {
+		case err == kes.ErrKeyNotFound:
+			return "", kes.ErrKeyNotFound
+		default:
+			s.logf("generic: failed to access key %q: %v", key, err)
+			return "", errGetKey
+		}
+	}
+
+	var (
+		decoder  = json.NewDecoder(io.LimitReader(resp.Body, secret.MaxSize))
+		response Response
+	)
+	if err = decoder.Decode(&response); err != nil {
+		s.logf("generic: failed to parse server response: %v", err)
+		return "", errGetKey
+	}
+	return string(response.Bytes), nil
+}
+
+// List returns a new Iterator over the names of all stored keys.
+func (s *Store) List(ctx context.Context) (secret.Iterator, error) {
+	url := endpoint(s.Endpoint, "/v1/key")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		s.logf("generic: failed to list keys: %v", err)
+		return nil, errListKey
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.logf("generic: failed to list keys: %v", err)
+		return nil, errListKey
+	}
+	if resp.StatusCode != http.StatusOK {
+		if err = parseErrorResponse(resp); err != nil {
+			s.logf("generic: failed to list keys: %v", err)
+		}
+		return nil, errListKey
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	return &iterator{
+		response: resp,
+		decoder:  decoder,
+	}, nil
+}
+
+func (s *Store) Authenticate() error {
+	var config = &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+	if s.CertPath != "" || s.KeyPath != "" {
+		certificate, err := tls.LoadX509KeyPair(s.CertPath, s.KeyPath)
+		if err != nil {
+			return err
+		}
+		config.Certificates = append(config.Certificates, certificate)
+	}
+	if s.CAPath != "" {
+		rootCAs, err := loadCustomCAs(s.CAPath)
+		if err != nil {
+			return err
+		}
+		config.RootCAs = rootCAs
+	}
+	s.client = xhttp.Retry{
+		Client: http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: config,
+				Proxy:           http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 10 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       30 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+	}
+	return nil
+}
+
+type keyDescription struct {
+	Name string `json:"name"`
+	Last bool   `json:"last"`
+}
+
+type iterator struct {
+	response *http.Response
+	decoder  *json.Decoder
+
+	last   keyDescription
+	err    error
+	closed bool
+}
+
+func (i *iterator) Next() bool {
+	if i.closed || i.err != nil {
+		return false
+	}
+	if err := i.decoder.Decode(&i.last); err != nil {
+		if err == io.EOF {
+			i.err = i.Close()
+			if i.err == nil && !i.last.Last {
+				i.err = io.ErrUnexpectedEOF
+			}
+		} else {
+			i.err = err
+		}
+		return false
+	}
+	if i.last.Last {
+		i.err = i.Close()
+	}
+	return true
+}
+
+func (i *iterator) Value() string {
+	return i.last.Name
+}
+
+func (i *iterator) Err() error { return i.err }
+
+func (i *iterator) Close() error {
+	i.closed = true
+	if err := i.response.Body.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// endpoint returns an endpoint URL starting with the
+// given endpoint followed by the path elements.
+//
+// For example:
+//   • endpoint("https://127.0.0.1:7373", "version")                => "https://127.0.0.1:7373/version"
+//   • endpoint("https://127.0.0.1:7373/", "/key/create", "my-key") => "https://127.0.0.1:7373/key/create/my-key"
+//
+// Any leading or trailing whitespaces are removed from
+// the endpoint before it is concatenated with the path
+// elements.
+//
+// The path elements will not be URL-escaped.
+func endpoint(endpoint string, elems ...string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	endpoint = strings.TrimSuffix(endpoint, "/")
+
+	if len(elems) > 0 && !strings.HasPrefix(elems[0], "/") {
+		endpoint += "/"
+	}
+	return endpoint + path.Join(elems...)
+}
+
+// parseErrorResponse returns an error containing
+// the response status code and response body
+// as error message if the response is an error
+// response - i.e. status code >= 400.
+//
+// If the response status code is < 400, e.g. 200 OK,
+// parseErrorResponse returns nil and does not attempt
+// to read or close the response body.
+//
+// If resp is an error response, parseErrorResponse reads
+// and closes the response body.
+func parseErrorResponse(resp *http.Response) error {
+	if resp == nil || resp.StatusCode < 400 {
+		return nil
+	}
+	if resp.Body == nil {
+		return kes.NewError(resp.StatusCode, "")
+	}
+	defer resp.Body.Close()
+
+	const MaxBodySize = 1 << 20
+	var size = resp.ContentLength
+	if size < 0 || size > MaxBodySize {
+		size = MaxBodySize
+	}
+
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if strings.HasPrefix(contentType, "application/json") {
+		type Response struct {
+			Message string `json:"message"`
+		}
+		var response Response
+		if err := json.NewDecoder(io.LimitReader(resp.Body, size)).Decode(&response); err != nil {
+			return err
+		}
+		return kes.NewError(resp.StatusCode, response.Message)
+	}
+
+	var sb strings.Builder
+	if _, err := io.Copy(&sb, io.LimitReader(resp.Body, size)); err != nil {
+		return err
+	}
+	return kes.NewError(resp.StatusCode, sb.String())
+}
+
+// loadCustomCAs returns a new RootCA certificate pool
+// that contains one or multiple certificates found at
+// the given path.
+//
+// If path is a file then loadCustomCAs tries to parse
+// the file as a PEM-encoded certificate.
+//
+// If path is a directory then loadCustomCAs tries to
+// parse any file inside path as PEM-encoded certificate.
+// It returns a non-nil error if one file is not a valid
+// PEM-encoded X.509 certificate.
+func loadCustomCAs(path string) (*x509.CertPool, error) {
+	var rootCAs = x509.NewCertPool()
+
+	f, err := os.Open(path)
+	if err != nil {
+		return rootCAs, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return rootCAs, err
+	}
+	if !stat.IsDir() {
+		bytes, err := ioutil.ReadAll(f)
+		if err != nil {
+			return rootCAs, err
+		}
+		if !rootCAs.AppendCertsFromPEM(bytes) {
+			return rootCAs, fmt.Errorf("'%s' does not contain a valid X.509 PEM-encoded certificate", path)
+		}
+		return rootCAs, nil
+	}
+
+	files, err := f.Readdir(0)
+	if err != nil {
+		return rootCAs, err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := filepath.Join(path, file.Name())
+		bytes, err := ioutil.ReadFile(name)
+		if err != nil {
+			return rootCAs, err
+		}
+		if !rootCAs.AppendCertsFromPEM(bytes) {
+			return rootCAs, fmt.Errorf("'%s' does not contain a valid X.509 PEM-encoded certificate", name)
+		}
+	}
+	return rootCAs, nil
+}
+
+func (s *Store) logf(format string, v ...interface{}) {
+	if s.ErrorLog != nil {
+		s.ErrorLog.Printf(format, v...)
+	} else {
+		log.Printf(format, v...)
+	}
+}

--- a/internal/generic/server.go
+++ b/internal/generic/server.go
@@ -1,0 +1,202 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+// go run server.go --endpoint <endpoint> --key <path> --cert <path>
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/minio/kes"
+	xhttp "github.com/minio/kes/internal/http"
+)
+
+func main() {
+	log.SetFlags(0)
+	var (
+		address  string
+		certPath string
+		keyPath  string
+	)
+	flag.StringVar(&address, "addr", "0.0.0.0:7001", "")
+	flag.StringVar(&certPath, "cert", "", "")
+	flag.StringVar(&keyPath, "key", "", "")
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/key/", &KeyStore{})
+
+	server := http.Server{
+		Addr:    address,
+		Handler: mux,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		},
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	serveChan := make(chan error, 1)
+	go func() {
+		host, port, err := net.SplitHostPort(server.Addr)
+		if err != nil {
+			log.Fatalf("Error: invalid server address: %q", server.Addr)
+		}
+		if host == "" {
+			host = "0.0.0.0"
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			log.Fatalf("Error: invalid server address: %q", server.Addr)
+		}
+		if ip.IsUnspecified() {
+			ip = net.IPv4(127, 0, 0, 1)
+		}
+		if certPath == "" && keyPath == "" {
+			log.Printf("Starting server listening on http://%s:%s ...", ip.String(), port)
+			serveChan <- server.ListenAndServe()
+		} else {
+			log.Printf("Starting server listening on https://%s:%s ...", ip.String(), port)
+			serveChan <- server.ListenAndServeTLS(certPath, keyPath)
+		}
+	}()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 800*time.Millisecond)
+		defer timeoutCancel()
+
+		log.Println("\nStopping server... ")
+		if err := server.Shutdown(timeoutCtx); err != nil {
+			log.Fatalf("Error: Failed to shutdown server gracefully: %v", err)
+		}
+	case err := <-serveChan:
+		if err != nil {
+			log.Fatalf("Error: Failed to serve requests: %v", err)
+		}
+	}
+}
+
+func (s *KeyStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.URL.Path, "/") {
+		r.URL.Path = "/" + r.URL.Path
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		s.CreateKey(w, r)
+	case http.MethodDelete:
+		s.DeleteKey(w, r)
+	case http.MethodGet:
+		if r.URL.Path == "/v1/key" || r.URL.Path == "/v1/key/" {
+			s.ListKey(w, r)
+		} else {
+			s.GetKey(w, r)
+		}
+	default:
+		w.Header().Add("Allow", http.MethodPost)
+		w.Header().Add("Allow", http.MethodGet)
+		w.Header().Add("Allow", http.MethodDelete)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+type KeyStore struct {
+	lock  sync.RWMutex
+	store map[string][]byte
+}
+
+func (s *KeyStore) CreateKey(w http.ResponseWriter, r *http.Request) {
+	type Request struct {
+		Bytes []byte `json:"bytes"`
+	}
+	const MaxSize = 1 << 20
+	var request Request
+	if err := json.NewDecoder(io.LimitReader(r.Body, MaxSize)).Decode(&request); err != nil {
+		xhttp.Error(w, kes.NewError(http.StatusBadRequest, err.Error()))
+		return
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.store == nil {
+		s.store = map[string][]byte{}
+	}
+	var key = strings.TrimPrefix(r.URL.Path, "/v1/key/")
+	if _, ok := s.store[key]; ok {
+		xhttp.Error(w, kes.ErrKeyExists)
+		return
+	}
+	s.store[key] = request.Bytes
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *KeyStore) DeleteKey(w http.ResponseWriter, r *http.Request) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.store == nil {
+		s.store = map[string][]byte{}
+	}
+	var key = strings.TrimPrefix(r.URL.Path, "/v1/key/")
+	delete(s.store, key)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *KeyStore) GetKey(w http.ResponseWriter, r *http.Request) {
+	type Response struct {
+		Bytes []byte `json:"bytes"`
+	}
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	var key = strings.TrimPrefix(r.URL.Path, "/v1/key/")
+	v, ok := s.store[key]
+	if !ok {
+		xhttp.Error(w, kes.ErrKeyNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(Response{
+		Bytes: v,
+	})
+}
+
+func (s *KeyStore) ListKey(w http.ResponseWriter, r *http.Request) {
+	type Response struct {
+		Name string `json:"name"`
+		Last bool   `json:"last,omitempty"`
+	}
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	var (
+		encoder = json.NewEncoder(w)
+		i       int
+	)
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.WriteHeader(http.StatusOK)
+	for key := range s.store {
+		encoder.Encode(Response{
+			Name: key,
+			Last: i == len(s.store)-1,
+		})
+	}
+}

--- a/internal/generic/spec-v1.md
+++ b/internal/generic/spec-v1.md
@@ -1,0 +1,207 @@
+## KES KeyStore Plugin Specification 
+
+### Introduction
+
+KES supports various KMS / KeyStore implementations. However, some KMS / KeyStore
+implementations cannot or should not be supported directly for multiple reasons. For example,
+the KMS / KeyStore may be a proprietary custom solution. Adding a direct integration would
+disclose IP or confidential information about the KMS / KeyStore implementation or about the
+underlying infrastructure. Usually, those details must not be disclosed due to compliance rules
+or even by law.
+
+Therefore, KES provides a plugin interface. The plugin interface defines an REST API that has
+to be implemented by a KES KeyStore plugin. The KES server can then create, access, list and
+delete keys indirectly at the KeyStore by talking to the plugin service.
+
+```    
+                          ┌────────────────────────────────────────────────────┐
+┌────────────┐   REST API │ ┌─────────────────────┐             ┌───────────┐  │
+│ KES Server ├────────────┼─┤ KES KeyStore Plugin ├─────────────┤ Key Store │  │
+└────────────┘            │ └─────────────────────┘             └───────────┘  │
+                          └────────────────────────────────────────────────────┘ 
+                                          internal/proprietary
+```
+
+Hence, the KES plugin interface enables integrations of arbitrary KMS / KeyStore implementations.
+
+### KeyStore Plugin
+
+A `v1` compatible key store plugin implements and exposes four HTTP API endpoints
+for creating, accessing, listing and deleting keys. 
+
+#### 1. CreateKey
+
+The `CreateKey` API endpoint creates a new key if and only if no key with the same
+name exists. It MUST be exposed as:
+```
+POST {HTTP | HTTPS}://{HOSTNAME}/v1/key/{KEY_NAME}
+```
+The `{KEY_NAME}` MUST be a valid URL path segment.
+
+A key creation request MUST contain the key value as JSON object in the request body:
+```
+{
+  "bytes":"eyJieXRlcyI6Ilg4RUEwU3dkbUQzOXB4YzdUa293c0theWw1bC9sc0tJK1B6Zko1NDBCeW89In0K",
+}
+```
+
+If the key creation succeeded `CreateKey` MUST respond with HTTP status code `201`
+to the client.
+
+When a request tries to create a key but an entry with this key name already exists then
+the `CreateKey` API endpoint MUST return the HTTP status code `400` with the following
+JSON object as response body:
+```
+{
+  "message":"key already exists", 
+}
+```
+
+`CreateKey` MUST be implemented as atomic operation that only succeeds if and only if
+no key with the same name exists. If multiple requests try to create a key with the same
+name concurrently then only one MAY succeed and all other requests MUST fail.
+
+**Example:**
+
+```
+POST https://127.0.0.1:7373/v1/key/my-key
+{
+  "bytes":"eyJieXRlcyI6Ilg4RUEwU3dkbUQzOXB4YzdUa293c0theWw1bC9sc0tJK1B6Zko1NDBCeW89In0K",
+}
+
+
+HTTP/1.1 201 Created
+```
+
+#### 2. GetKey
+
+The `GetKey` API endpoint returns the value for a given key, if it exists. It MUST be
+exposed as:
+```
+GET {HTTP | HTTPS}://{HOSTNAME}/v1/key/{KEY_NAME}
+```
+
+The `{KEY_NAME}` MUST be a valid URL path segment.
+
+If a key with the requested key name exists then `GetKey` MUST respond with HTTP status
+code `200` and a respond body that contains the value of the key:
+```
+{
+  "bytes":{KEY_VALUE},
+}
+```
+
+When a request tries to access a key that does not exist resp. no entry could be found then
+the `GetKey` API endpoint MUST return the HTTP status code `404` with the following
+error message as response body:
+```
+{
+  "message":"key does not exist", 
+}
+```
+ 
+**Example:**
+
+```
+GET https://127.0.0.1:7337/v1/key/my-key
+
+
+HTTP/1.1 200 OK
+{
+  "bytes":"eyJieXRlcyI6Ilg4RUEwU3dkbUQzOXB4YzdUa293c0theWw1bC9sc0tJK1B6Zko1NDBCeW89In0K",
+}
+```
+
+#### 3. DeleteKey
+
+The `DeleteKey` API endpoint deletes the key with the given key, if it exists. It MUST be
+exposed as:
+```
+DELETE {HTTP | HTTPS}://{HOSTNAME}/v1/key/{KEY_NAME}
+```
+
+The `{KEY_NAME}` MUST be a valid URL path segment.
+
+If a key has been deleted successfully the `DeleteKey` endpoint MUST respond with the HTTP
+status code `200`. It MAY also respond with the HTTP status code `200` if the requested key
+does not exist.
+
+**Example:**
+
+```
+DELETE https://127.0.0.1:7373/v1/key/my-key
+
+
+HTTP/1.1 200 OK
+```
+
+#### 4. ListKeys
+
+The `ListKeys` API endpoint lists all key names. It MUST be exposed as:
+```
+GET {HTTP | HTTPS}://{HOSTNAME}/v1/key
+```
+
+The `ListKeys` API endpoint returns a stream of JSON objects as `nd-json`:
+```
+{
+  "name":{KEY_NAME},
+  "last":[true | false],
+}
+```
+Each JSON object MAY contain an additional `last` field. It MUST always be
+set to `false`, if present, unless the JSON object is the last element of
+the `nd-json` stream. The last JSON object MUST contain the `last` field
+and it MUST be set to `true`. Multiple JSON objects MUST be separated by the
+new-line character (`\n`).
+
+The response SHOULD set the HTTP header `Content-Type` to `application/x-ndjson`.
+
+**Example:**
+
+```
+GET https://127.0.0.1:7373/v1/key
+
+HTTP/1.1 200 OK
+{"name":"my-key"}
+{"name":"some-key"}
+{"name":"another-key","last":true}
+```
+
+### Errors
+
+Whenever a `v1` compatible plugin encounters an error while processing a client request
+it SHOULD respond with an appropriate HTTP status code and error message. All returned
+errors MUST be JSON objects of the following format:
+```
+{
+  "message":{ERROR_MESSAGE},
+}
+```
+
+A plugin SHOULD only send a HTTP status code `5xx` if appropriate and no HTTP status code `4xx`
+describes the error situation adequately. A error response MUST always contain an HTTP status code
+`4xx` or `5xx`.
+
+### Security Considerations
+
+A KES KeyStore plugin implementation SHOULD only accept TLS/HTTPS request. The usage of plaintext
+HTTP will leak cryptographic key material exchanged between the KES server and the plugin. Therefore,
+it SHOULD NOT accept plaintext HTTP connection attempts except during development or for testing purposes.
+
+If a plugin implementation accepts TLS/HTTPS connections it MUST support at least TLS 1.2. If it only supports
+TLS 1.2 then it MUST support at least one of the following TLS 1.2 cipher suites:
+ - `ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
+ - `ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256`
+ - `ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+ - `ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+ - `ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+ - `ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+
+The KES server and the KeyStore plugin SHOULD mutually authenticate via X.509 certificates (mTLS). Therefore,
+the KES server will verify the X.509 certificate of the plugin and the plugin SHOULD verify the X.509 client
+certificate of the KES server.
+
+Additionally, the plugin MAY verify that the cryptographic hash of the public key within the KES server client
+certificate matches an expected value (TLS HPKP). This cryptographic hash should be computed as SHA-256 of the
+raw subject public key of the X.509 certificate.

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -150,6 +150,16 @@ keystore:
   fs:
     path: "" # Path to directory. Keys will be stored as files.
 
+  # Configuration for storing keys via a KES KeyStore plugin or at
+  # a KeyStore that exposes an API compatible to the KES KeyStore
+  # plugin specification: https://github.com/minio/kes/blob/master/internal/generic/spec-v1.md
+  generic:
+    endpoint: "" # The plugin endpoint - e.g. https://127.0.0.1:7001
+    tls:         # The KES client TLS configuration for mTLS authentication and certificate verification.
+      key: ""    # Path to the TLS client private key for mTLS authentication
+      cert: ""   # Path to the TLS client certificate for mTLS authentication
+      ca: ""     # Path to one or multiple PEM root CA certificates
+
   # Hashicorp Vault configuration. The KES server will store/fetch
   # secret keys at/from Vault's key-value backend.
   #


### PR DESCRIPTION
This commit adds a generic KeyStore plugin API
to the KES server.

Now, the KES server can talk to an external plugin
that implements four REST endpoints for creating,
listing, accessing and deleting keys.

This commit also adds the plugin specification.

With KeyStore plugins it is possible to support
proprietary/custom KMS/KeyStore implementations
that should not be published.

For a more detailed explanation about plugins
and how they should be implemented take a look
at the generic/spec-v1.md