### PR TITLE
client: add support for multiple server endpoints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - ineffassign
     - gosimple
     - deadcode
-    - unparam
     - unused
     - structcheck
     - prealloc


### PR DESCRIPTION
This commit adds support for multiple KES server
endpoints to the client.
Now a client contains a list of KES server endpoints:
```
Endpoints: []string {
   "https://kes1.domain.local",
   "https://kes2.domain.local",
},
```

If a client has multiple endpoints it will pick one
at random for each request. Two subsequent requests
may be sent to two different KES server instances.

The client will try to send one request multiple
times to the same server in case of a tmp. network
error (retry mechanism) before it gives up and tries
to reach the next KES server. It will continue until
it either got a HTTP response or it has tried all
KES server endpoints.

Multiple endpoints should only be specified if
no round-robin DNS is used. Instead, it can be
used as alternative to a server-side load-balancer.