### PR TITLE
metric: add counters for error and audit events

### DIFF
--- a/client.go
+++ b/client.go
@@ -732,6 +732,8 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 		MetricRequestErr    = "kes_http_request_error"
 		MetricRequestFail   = "kes_http_request_failure"
 		MetricRequestActive = "kes_http_request_active"
+		MetricAuditEvents   = "kes_log_audit_events"
+		MetricErrorEvents   = "kes_log_error_events"
 		MetricResponseTime  = "kes_http_response_time"
 		MetricSystemUpTme   = "kes_system_up_time"
 	)
@@ -767,6 +769,10 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 			metric.RequestFail = uint64(rawMetric.GetCounter().GetValue())
 		case kind == dto.MetricType_GAUGE && name == MetricRequestActive:
 			metric.RequestActive = uint64(rawMetric.GetGauge().GetValue())
+		case kind == dto.MetricType_COUNTER && name == MetricAuditEvents:
+			metric.AuditEvents = uint64(rawMetric.GetCounter().GetValue())
+		case kind == dto.MetricType_COUNTER && name == MetricErrorEvents:
+			metric.ErrorEvents = uint64(rawMetric.GetCounter().GetValue())
 		case kind == dto.MetricType_HISTOGRAM && name == MetricResponseTime:
 			metric.LatencyHistogram = map[time.Duration]uint64{}
 			for _, bucket := range rawMetric.GetHistogram().GetBucket() {

--- a/metric.go
+++ b/metric.go
@@ -13,6 +13,9 @@ type Metric struct {
 	RequestFail   uint64 `json:"kes_http_request_failure"` // Requests that failed unexpectedly due to an internal error
 	RequestActive uint64 `json:"kes_http_request_active"`  // Requests that are currently active and haven't completed yet
 
+	AuditEvents uint64 `json:"kes_log_audit_events"` // Number of generated audit events
+	ErrorEvents uint64 `json:"kes_log_error_events"` // Number of generated error events
+
 	// Histogram of the KES server response latency.
 	// It shows how fast the server can handle requests.
 	//


### PR DESCRIPTION
This commit adds two metrics counting the number
of error resp. audit events.

Further, accessing the `/v1/metrics` API does no
longer produce an audit event. The `/v1/metrics`
was already excluded from the metrics collection.

It is also very unlikely that any audit log monitoring
is interested in the `/v1/metrics` API. A monitoring
system (e.g. Prometheus) will scrape the `/v1/metrics`
endpoint quiet often (every few seconds) leading to a
lot of audit event "noise".

Therefore, this PR disables audit events for the `/v1/metrics`
endpoint. If comprehensive audit events are desired this
can be enabled - as an option - in the future.

Now, the KES server metrics contains two additional counters:
```
 # HELP kes_log_audit_events Number of audit log events written to the audit log targets.
 # TYPE kes_log_audit_events counter
 kes_log_audit_events 2
 # HELP kes_log_error_events Number of error log events written to the error log targets.
 # TYPE kes_log_error_events counter
 kes_log_error_events 3
```