### PR TITLE
client: fix ListPolicies HTTP method

### DIFF
--- a/client.go
+++ b/client.go
@@ -592,7 +592,7 @@ func (c *Client) ListPolicies(ctx context.Context, pattern string) ([]string, er
 		pattern = "*" // => default to: list "all" policies
 	}
 	client := retry(c.HTTPClient)
-	resp, err := client.Send(ctx, http.MethodPost, c.Endpoints, path.Join("/v1/policy/list", url.PathEscape(pattern)), nil)
+	resp, err := client.Send(ctx, http.MethodGet, c.Endpoints, path.Join("/v1/policy/list", url.PathEscape(pattern)), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit fixes a bug the client SDK introduced by b9e4806.
The `ListPolicies` client SDK call should use an HTTP GET request
instead of a POST request to fetch the policies.

Currently, the client SDK fails to list policies an returns a
`MethodNotAllowed` error.