### PR TITLE
policy: add deny rules

### DIFF
--- a/cmd/kes/config_v0.14.0.go
+++ b/cmd/kes/config_v0.14.0.go
@@ -6,12 +6,13 @@ package main
 
 import "github.com/minio/kes"
 
-// serverConfigV0135 represents a KES server configuration up to
-// v0.13.5. It provides backward-compatible unmarshaling of exiting
+// serverConfigV0140 represents a KES server configuration between v0.13.5
+// and v0.14.0. It provides backward-compatible unmarshaling of exiting
 // configuration files.
 //
-// It will be removed at some time in the future.
-type serverConfigV0135 struct {
+// It will be removed at some time in the future - once serverConfigV0135
+// got removed.
+type serverConfigV0140 struct {
 	Addr string       `yaml:"address"`
 	Root kes.Identity `yaml:"root"`
 
@@ -43,17 +44,22 @@ type serverConfigV0135 struct {
 		Audit string `yaml:"audit"`
 	} `yaml:"log"`
 
-	Keys kmsServerConfig `yaml:"keys"`
+	Keys []struct {
+		Name string `yaml:"name"`
+	} `yaml:"keys"`
+
+	KeyStore kmsServerConfig `yaml:"keystore"`
 }
 
-func (c *serverConfigV0135) Migrate() serverConfig {
+func (c *serverConfigV0140) Migrate() serverConfig {
 	config := serverConfig{
 		Addr:     c.Addr,
 		Root:     c.Root,
 		TLS:      c.TLS,
 		Cache:    c.Cache,
 		Log:      c.Log,
-		KeyStore: c.Keys,
+		Keys:     c.Keys,
+		KeyStore: c.KeyStore,
 	}
 	config.Policies = make(map[string]policyConfig, len(c.Policies))
 	for name, policy := range c.Policies {

--- a/cmd/kes/policy.go
+++ b/cmd/kes/policy.go
@@ -159,14 +159,14 @@ func showPolicy(args []string) {
 		}
 		stdlog.Fatalf("Error: failed to fetch policy %q: %v", name, err)
 	}
+
+	output, err := json.MarshalIndent(policy, "", "  ")
+	if err != nil {
+		stdlog.Fatalf("Error: %v", err)
+	}
+	os.Stdout.Write(output)
 	if isTerm(os.Stdout) {
-		fmt.Println(policy.String())
-	} else {
-		output, err := policy.MarshalJSON()
-		if err != nil {
-			stdlog.Fatalf("Error: %v", err)
-		}
-		os.Stdout.Write(output)
+		os.Stdout.WriteString("\n")
 	}
 }
 

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -186,9 +186,12 @@ func server(args []string) {
 		Root: config.Root,
 	}
 	for name, policy := range config.Policies {
-		p, err := kes.NewPolicy(policy.Paths...)
+		p, err := kes.NewPolicy(policy.Allow...)
 		if err != nil {
-			stdlog.Fatalf("Error: policy %q contains invalid glob patterns: %v", name, err)
+			stdlog.Fatalf("Error: policy %q contains invalid allow pattern: %v", name, err)
+		}
+		if err = p.Deny(policy.Deny...); err != nil {
+			stdlog.Fatalf("Error: policy %q contains invalid deny pattern: %v", name, err)
 		}
 		roles.Set(name, p)
 

--- a/policy.go
+++ b/policy.go
@@ -7,35 +7,101 @@ package kes
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"path"
-	"strings"
 )
 
+// Policy contains a set of rules that explicitly allow
+// or deny HTTP requests.
+//
+// These rules are specified as glob patterns. The rule
+// applies if the pattern matches the request URL path.
+// For more details on the glob syntax in general see [1]
+// and for the specific pattern syntax see [2].
+//
+// A policy contains two different rule sets:
+//   • Allow rules
+//   • Deny  rules
+//
+// A policy determines whether a request should be allowed
+// or denied in two steps. First, it iterates over all deny
+// rules. If any deny rules matches the given request then
+// the request is rejected. Then it iterates over all
+// allow rules. If any allow rule matches the given request
+// then the request is accepted. Otherwise, the request
+// is rejected by default.
+// Hence, a request is only accepted if at least one allow
+// rules and no deny rule matches the request. Also, a deny
+// rule takes precedence over an allow rule.
+//
+// [1]: https://en.wikipedia.org/wiki/Glob_(programming)
+// [2]: https://golang.org/pkg/path/#Match
 type Policy struct {
-	patterns []string
+	allowPatterns []string
+	denyPatterns  []string
 }
 
+// NewPolicy returns a new policy that accepts requests
+// if at least one of the given patterns matches the
+// with request URL path. It returns an error if one
+// of the patterns contains invalid glob syntax.
 func NewPolicy(patterns ...string) (*Policy, error) {
-	for _, pattern := range patterns {
-		if _, err := path.Match(pattern, pattern); err != nil {
-			return nil, err
-		}
+	policy := new(Policy)
+	if err := policy.Allow(patterns...); err != nil {
+		return nil, err
 	}
-	return &Policy{
-		patterns: patterns,
-	}, nil
+	return policy, nil
+}
+
+// Allow adds the given patterns to the list of
+// allow rules. It ignores empty patterns and
+// returns an error if one of the patterns contains
+// invalid glob syntax.
+func (p *Policy) Allow(patterns ...string) error {
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		if _, err := path.Match(pattern, pattern); err != nil {
+			return err
+		}
+		p.allowPatterns = append(p.allowPatterns, pattern)
+	}
+	return nil
+}
+
+// Deny adds the given patterns to the list of
+// deny rules. It ignores empty patterns and
+// returns an error if one of the patterns contains
+// invalid glob syntax.
+func (p *Policy) Deny(patterns ...string) error {
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		if _, err := path.Match(pattern, pattern); err != nil {
+			return err
+		}
+		p.denyPatterns = append(p.denyPatterns, pattern)
+	}
+	return nil
 }
 
 func (p Policy) MarshalJSON() ([]byte, error) {
 	type PolicyJSON struct {
-		Patterns []string `json:"paths"`
+		Allow []string `json:"allow"`
+		Deny  []string `json:"deny"`
 	}
 
-	policy := PolicyJSON{Patterns: p.patterns}
-	if len(policy.Patterns) == 0 {
-		policy.Patterns = []string{} // marshal nil as empty array ([]) -  not null
+	policy := PolicyJSON{
+		Allow: p.allowPatterns,
+		Deny:  p.denyPatterns,
+	}
+	if len(policy.Allow) == 0 {
+		policy.Allow = []string{} // marshal nil as empty array ([]) -  not null
+	}
+	if len(policy.Deny) == 0 {
+		policy.Deny = []string{} // marshal nil as empty array ([]) -  not null
 	}
 	return json.Marshal(policy)
 }
@@ -45,35 +111,48 @@ func (p *Policy) UnmarshalJSON(b []byte) error {
 	d.DisallowUnknownFields()
 
 	var policyJSON struct {
-		Patterns []string `json:"paths"`
+		Allow []string `json:"allow"`
+		Deny  []string `json:"deny"`
 	}
 	if err := d.Decode(&policyJSON); err != nil {
 		return err
 	}
-	for _, pattern := range policyJSON.Patterns {
+
+	var deny = make([]string, 0, len(policyJSON.Deny))
+	for _, pattern := range policyJSON.Deny {
+		if pattern == "" {
+			continue
+		}
 		if _, err := path.Match(pattern, pattern); err != nil {
 			return err
 		}
+		deny = append(deny, pattern)
 	}
-	p.patterns = policyJSON.Patterns
+	var allow = make([]string, 0, len(policyJSON.Allow))
+	for _, pattern := range policyJSON.Allow {
+		if pattern == "" {
+			continue
+		}
+		if _, err := path.Match(pattern, pattern); err != nil {
+			return err
+		}
+		allow = append(allow, pattern)
+	}
+	p.allowPatterns, p.denyPatterns = allow, deny
 	return nil
 }
 
-func (p *Policy) String() string {
-	var builder strings.Builder
-	fmt.Fprintln(&builder, "[")
-	for _, pattern := range p.patterns {
-		if pattern != "" {
-			fmt.Fprintf(&builder, "  %s\n", pattern)
+// Verify determines whether a request should be accepted
+// or rejected. It returns ErrNotAllowed if any deny rule
+// or no allow rule matches the given request.
+func (p *Policy) Verify(r *http.Request) error {
+	for _, pattern := range p.denyPatterns {
+		if ok, _ := path.Match(pattern, r.URL.Path); ok {
+			return ErrNotAllowed
 		}
 	}
-	fmt.Fprintln(&builder, "]")
-	return builder.String()
-}
-
-func (p *Policy) Verify(r *http.Request) error {
-	for _, pattern := range p.patterns {
-		if ok, err := path.Match(pattern, r.URL.Path); ok && err == nil {
+	for _, pattern := range p.allowPatterns {
+		if ok, _ := path.Match(pattern, r.URL.Path); ok {
 			return nil
 		}
 	}

--- a/policy_test.go
+++ b/policy_test.go
@@ -54,17 +54,21 @@ var policyMarshalJSONTests = []struct {
 	Policy *Policy
 	Output string
 }{
-	{
-		Policy: mustNewPolicy(),
-		Output: `{"paths":[]}`,
+	{ // 0
+		Policy: allowPolicy(),
+		Output: `{"allow":[],"deny":[]}`,
 	},
-	{
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*"),
-		Output: `{"paths":["/v1/key/create/*","/v1/key/delete/*"]}`,
+	{ // 1
+		Policy: allowPolicy("/v1/key/create/*", "/v1/key/delete/*"),
+		Output: `{"allow":["/v1/key/create/*","/v1/key/delete/*"],"deny":[]}`,
 	},
-	{
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
-		Output: `{"paths":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key"]}`,
+	{ // 2
+		Policy: allowPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Output: `{"allow":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key"],"deny":[]}`,
+	},
+	{ // 3
+		Policy: denyPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Output: `{"allow":[],"deny":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key"]}`,
 	},
 }
 
@@ -88,33 +92,53 @@ var policyUnmarshalJSONTests = []struct {
 	Err    error
 }{
 	{ // 0
-		Source: `{"paths":null}`,
-		Policy: mustNewPolicy(),
+		Source: `{"allow":null}`,
+		Policy: allowPolicy(),
 		Err:    nil,
 	},
 	{ // 1
-		Source: `{"paths":[]}`,
-		Policy: mustNewPolicy(),
+		Source: `{"allow":null,"deny":null}`,
+		Policy: allowPolicy(),
 		Err:    nil,
 	},
 	{ // 2
-		Source: `{"paths":[""]}`,
-		Policy: mustNewPolicy(""),
+		Source: `{"allow":[]}`,
+		Policy: allowPolicy(),
 		Err:    nil,
 	},
 	{ // 3
-		Source: `{"paths":["/v1/key/create/*","/v1/key/delete/*"]}`,
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*"),
+		Source: `{"allow":[""]}`,
+		Policy: allowPolicy(""),
 		Err:    nil,
 	},
 	{ // 4
-		Source: `{"paths":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key"]}`,
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Source: `{"allow":[""],"deny":[""]}`,
+		Policy: allowPolicy(""),
 		Err:    nil,
 	},
 	{ // 5
-		Source: `{"paths":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key\\"]}`,
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Source: `{"allow":["/v1/key/create/*","/v1/key/delete/*"]}`,
+		Policy: allowPolicy("/v1/key/create/*", "/v1/key/delete/*"),
+		Err:    nil,
+	},
+	{ // 6
+		Source: `{"allow":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key"]}`,
+		Policy: allowPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Err:    nil,
+	},
+	{ // 7
+		Source: `{"allow":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key\\"]}`,
+		Policy: allowPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Err:    path.ErrBadPattern,
+	},
+	{ // 8
+		Source: `{"deny":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key"]}`,
+		Policy: denyPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
+		Err:    nil,
+	},
+	{ // 9
+		Source: `{"deny":["/v1/key/create/*","/v1/key/delete/*","/v1/key/generate/my-key\\"]}`,
+		Policy: denyPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
 		Err:    path.ErrBadPattern,
 	},
 }
@@ -127,90 +151,83 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 			t.Fatalf("Test %d: got error %v - want error: %v", i, err, test.Err)
 		}
 		if err == nil {
-			if len(policy.patterns) != len(test.Policy.patterns) {
-				t.Fatalf("Test %d: policy differs in paths: got %d - want %d", i, len(policy.patterns), len(test.Policy.patterns))
+			if len(policy.allowPatterns) != len(test.Policy.allowPatterns) {
+				t.Fatalf("Test %d: policy differs in paths: got %d - want %d", i, len(policy.allowPatterns), len(test.Policy.allowPatterns))
 			}
 
-			sort.Strings(policy.patterns)
-			sort.Strings(test.Policy.patterns)
-			for j := range policy.patterns {
-				if policy.patterns[j] != test.Policy.patterns[j] {
-					t.Fatalf("Test %d: policy path %d does not match: got %s - want %s", i, j, policy.patterns[j], test.Policy.patterns[j])
+			sort.Strings(policy.allowPatterns)
+			sort.Strings(test.Policy.allowPatterns)
+			for j := range policy.allowPatterns {
+				if policy.allowPatterns[j] != test.Policy.allowPatterns[j] {
+					t.Fatalf("Test %d: policy path %d does not match: got %s - want %s", i, j, policy.allowPatterns[j], test.Policy.allowPatterns[j])
 				}
 			}
 		}
 	}
 }
 
-var policyStringTests = []struct {
-	Policy *Policy
-	Output string
-}{
-	{ // 0
-		Policy: mustNewPolicy(),
-		Output: "[\n]\n",
-	},
-	{ // 1
-		Policy: mustNewPolicy(""),
-		Output: "[\n]\n",
-	},
-	{ // 2
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*"),
-		Output: "[\n  /v1/key/create/*\n  /v1/key/delete/*\n]\n",
-	},
-	{ // 3
-		Policy: mustNewPolicy("/v1/key/create/*", "/v1/key/delete/*", "/v1/key/generate/my-key"),
-		Output: "[\n  /v1/key/create/*\n  /v1/key/delete/*\n  /v1/key/generate/my-key\n]\n",
-	},
-}
-
-func TestPolicyString(t *testing.T) {
-	for i, test := range policyStringTests {
-		output := test.Policy.String()
-		if output != test.Output {
-			t.Fatalf("Test %d: got %s - want %s", i, output, test.Output)
-		}
-	}
-}
-
 var policyVerifyTests = []struct {
-	Pattern     string
+	Allow       string
+	Deny        string
 	Path        string
 	ShouldMatch bool
 }{
-	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key", ShouldMatch: true},                      // 0
-	{Pattern: "/v1/key/import/*", Path: "/v1/key/import/my-key", ShouldMatch: true},                      // 1
-	{Pattern: "/v1/key/delete/*", Path: "/v1/key/delete/my-key", ShouldMatch: true},                      // 2
-	{Pattern: "/v1/key/generate/*", Path: "/v1/key/generate/my-key", ShouldMatch: true},                  // 3
-	{Pattern: "/v1/key/decrypt/*", Path: "/v1/key/decrypt/my-key", ShouldMatch: true},                    // 4
-	{Pattern: "/v1/policy/write/*", Path: "/v1/policy/write/my-policy", ShouldMatch: true},               // 5
-	{Pattern: "/v1/policy/read/*", Path: "/v1/policy/read/my-policy", ShouldMatch: true},                 // 6
-	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/my-policy", ShouldMatch: true},                 // 7
-	{Pattern: "/v1/policy/list/*", Path: "/v1/policy/list/*", ShouldMatch: true},                         // 8
-	{Pattern: "/v1/policy/delete/*", Path: "/v1/policy/delete/my-policy", ShouldMatch: true},             // 9
-	{Pattern: "/v1/identity/assign/*/*", Path: "/v1/identity/assign/af43c/my-policy", ShouldMatch: true}, // 10
-	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/af43c", ShouldMatch: true},                 // 11
-	{Pattern: "/v1/identity/list/*", Path: "/v1/identity/list/*", ShouldMatch: true},                     // 12
-	{Pattern: "/v1/identity/forget/*", Path: "/v1/identity/forget/af43c", ShouldMatch: true},             // 13
-	{Pattern: "/v1/log/audit/trace", Path: "/v1/log/audit/trace", ShouldMatch: true},                     // 14
+	{Allow: "/v1/key/create/*", Path: "/v1/key/create/my-key", ShouldMatch: true},                      // 0
+	{Allow: "/v1/key/import/*", Path: "/v1/key/import/my-key", ShouldMatch: true},                      // 1
+	{Allow: "/v1/key/delete/*", Path: "/v1/key/delete/my-key", ShouldMatch: true},                      // 2
+	{Allow: "/v1/key/generate/*", Path: "/v1/key/generate/my-key", ShouldMatch: true},                  // 3
+	{Allow: "/v1/key/decrypt/*", Path: "/v1/key/decrypt/my-key", ShouldMatch: true},                    // 4
+	{Allow: "/v1/policy/write/*", Path: "/v1/policy/write/my-policy", ShouldMatch: true},               // 5
+	{Allow: "/v1/policy/read/*", Path: "/v1/policy/read/my-policy", ShouldMatch: true},                 // 6
+	{Allow: "/v1/policy/list/*", Path: "/v1/policy/list/my-policy", ShouldMatch: true},                 // 7
+	{Allow: "/v1/policy/list/*", Path: "/v1/policy/list/*", ShouldMatch: true},                         // 8
+	{Allow: "/v1/policy/delete/*", Path: "/v1/policy/delete/my-policy", ShouldMatch: true},             // 9
+	{Allow: "/v1/identity/assign/*/*", Path: "/v1/identity/assign/af43c/my-policy", ShouldMatch: true}, // 10
+	{Allow: "/v1/identity/list/*", Path: "/v1/identity/list/af43c", ShouldMatch: true},                 // 11
+	{Allow: "/v1/identity/list/*", Path: "/v1/identity/list/*", ShouldMatch: true},                     // 12
+	{Allow: "/v1/identity/forget/*", Path: "/v1/identity/forget/af43c", ShouldMatch: true},             // 13
+	{Allow: "/v1/log/audit/trace", Path: "/v1/log/audit/trace", ShouldMatch: true},                     // 14
 
-	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/my-key/..", ShouldMatch: false},   // 15
-	{Pattern: "/v1/key/create/*", Path: "/v1/key/create/../my-key", ShouldMatch: false},   // 16
-	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/my-key", ShouldMatch: false},      // 17
-	{Pattern: "/v1/key/generate/*", Path: "/v1/key/create/my-key/x", ShouldMatch: false},  // 18
-	{Pattern: "/v1/key/create/[a-z]", Path: "/v1/key/create/my-key0", ShouldMatch: false}, // 19
-	{Pattern: "/v1/key/decypt/*", Path: "/v1/key/create/./*/../a", ShouldMatch: false},    // 20
-	{Pattern: "/v1/log/audit/trace", Path: "/v1/log/audit/trace/.", ShouldMatch: false},   // 21
+	{Deny: "/v1/key/create/*", Path: "/v1/key/create/my-key", ShouldMatch: false},                      // 15
+	{Deny: "/v1/key/import/*", Path: "/v1/key/import/my-key", ShouldMatch: false},                      // 16
+	{Deny: "/v1/key/delete/*", Path: "/v1/key/delete/my-key", ShouldMatch: false},                      // 17
+	{Deny: "/v1/key/generate/*", Path: "/v1/key/generate/my-key", ShouldMatch: false},                  // 18
+	{Deny: "/v1/key/decrypt/*", Path: "/v1/key/decrypt/my-key", ShouldMatch: false},                    // 19
+	{Deny: "/v1/policy/write/*", Path: "/v1/policy/write/my-policy", ShouldMatch: false},               // 20
+	{Deny: "/v1/policy/read/*", Path: "/v1/policy/read/my-policy", ShouldMatch: false},                 // 21
+	{Deny: "/v1/policy/list/*", Path: "/v1/policy/list/my-policy", ShouldMatch: false},                 // 22
+	{Deny: "/v1/policy/list/*", Path: "/v1/policy/list/*", ShouldMatch: false},                         // 23
+	{Deny: "/v1/policy/delete/*", Path: "/v1/policy/delete/my-policy", ShouldMatch: false},             // 24
+	{Deny: "/v1/identity/assign/*/*", Path: "/v1/identity/assign/af43c/my-policy", ShouldMatch: false}, // 25
+	{Deny: "/v1/identity/list/*", Path: "/v1/identity/list/af43c", ShouldMatch: false},                 // 26
+	{Deny: "/v1/identity/list/*", Path: "/v1/identity/list/*", ShouldMatch: false},                     // 27
+	{Deny: "/v1/identity/forget/*", Path: "/v1/identity/forget/af43c", ShouldMatch: false},             // 28
+	{Deny: "/v1/log/audit/trace", Path: "/v1/log/audit/trace", ShouldMatch: false},                     // 29
+
+	{Allow: "/v1/key/create/*", Path: "/v1/key/create/my-key/..", ShouldMatch: false},   // 30
+	{Allow: "/v1/key/create/*", Path: "/v1/key/create/../my-key", ShouldMatch: false},   // 31
+	{Allow: "/v1/key/decypt/*", Path: "/v1/key/create/my-key", ShouldMatch: false},      // 32
+	{Allow: "/v1/key/generate/*", Path: "/v1/key/create/my-key/x", ShouldMatch: false},  // 33
+	{Allow: "/v1/key/create/[a-z]", Path: "/v1/key/create/my-key0", ShouldMatch: false}, // 34
+	{Allow: "/v1/key/decypt/*", Path: "/v1/key/create/./*/../a", ShouldMatch: false},    // 35
+	{Allow: "/v1/log/audit/trace", Path: "/v1/log/audit/trace/.", ShouldMatch: false},   // 36
 }
 
 func TestPolicyVerify(t *testing.T) {
 	const baseURL = "https://localhost:7373"
 
 	for i, test := range policyVerifyTests {
-		policy, err := NewPolicy(test.Pattern)
+		policy, err := NewPolicy()
 		if err != nil {
 			t.Fatalf("Test %d: failed to create policy: %v", i, err)
 		}
+		if err = policy.Allow(test.Allow); err != nil {
+			t.Fatalf("Test %d: failed to add allow pattern: %v", i, err)
+		}
+		if err = policy.Deny(test.Deny); err != nil {
+			t.Fatalf("Test %d: failed to add deny pattern: %v", i, err)
+		}
+
 		req, err := http.NewRequest(http.MethodGet, baseURL+test.Path, nil)
 		if err != nil {
 			t.Fatalf("Test %d: failed to create request: %v", i, err)
@@ -226,10 +243,19 @@ func TestPolicyVerify(t *testing.T) {
 	}
 }
 
-func mustNewPolicy(patterns ...string) *Policy {
+func allowPolicy(patterns ...string) *Policy {
 	p, err := NewPolicy(patterns...)
 	if err != nil {
 		panic(err)
 	}
+	return p
+}
+
+func denyPolicy(patterns ...string) *Policy {
+	p, err := NewPolicy()
+	if err != nil {
+		panic(err)
+	}
+	p.Deny(patterns...)
 	return p
 }

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -45,8 +45,8 @@ tls:
 #   <API-version>/<API>/<operation>/[<argument-0>/<argument-1>/...]>
 #
 # Each KES server API has an unique path - e.g. /v1/key/create/<key-name>.
-# A client request is allowed if and only if the request URL path matches
-# one of the policy path patterns.
+# A client request is allowed if and only if no deny pattern AND at least one
+# allow pattern matches the request URL path.
 #
 # A policy has zero (by default) or more assigned identities. However,
 # an identity can never be assigned to more than one policy at the same
@@ -62,16 +62,19 @@ tls:
 # Please remove/adjust to your needs.
 policy:
   my-app:
-    paths:
+    allow:
     - /v1/key/create/my-app*
     - /v1/key/generate/my-app*
     - /v1/key/decrypt/my-app*
+    deny:
+    - /v1/key/generate/my-app-internal*
+    - /v1/key/decrypt/my-app-internal*
     identities:
     - df7281ca3fed4ef7d06297eb7cb9d590a4edc863b4425f4762bb2afaebfd3258
     - c0ecd5962eaf937422268b80a93dde4786dc9783fb2480ddea0f3e5fe471a731
 
   my-app-ops:
-    paths:
+    allow:
     - /v1/key/delete/my-app*
     - /v1/policy/show/my-app
     - /v1/identity/assign/my-app/*


### PR DESCRIPTION
This commit adds `deny` rules - in addition to
the existing `allow` rules.

Before, a KES server policy contained a list of
patterns. If a request URL path matches any of
the pattern the request was accepted.

Now, a KES server policy can also contain a list
of `deny` patterns. If a request URL path matches
any of the `deny` patterns then the request is
rejected.

This is an API breaking change since the JSON representation
of a policy is changed by this commit. However, this
is acceptable since we have not committed to a stable `v1.0.0`
version, yet. From now on, more fields can be added to the KES
policy representation backwards-compatibly.

Before, a KES policy had the following format:
```
policy:
  my-policy:
    paths:
    - /v1/key/create/*
    - /v1/key/delete/*
    identities:
    - ...
```

From now on, a policy is defined using the following format:
```
policy:
  my-policy:
    allow:
    - /v1/key/create/*
    - /v1/key/delete/*
    deny:
    - /v1/key/delete/my-key
    identities:
    - ...
```

***

`Allow` and `deny` rules may overlap (one URL path may match
an `allow` and a `deny` pattern at the same time). A KES server
policy has the following semantics:
 1. If any deny rule matches the URL path then the request is rejected.
 2. Otherwise, if any allow rule matches the URL path the requested is
    accepted.
 3. Otherwise, the request is rejected.

So, a `deny` rule takes precedence over an `allow` rule. The main
usage of `deny` rules is to restrict a set of `allow` rules. For
example, an application may be allowed to decrypt DEKs generated
by `my-key*` except for `my-key-2` and `my-key-internal*`.

This can be expressed as following:
```
policy:
  my-policy:
    allow:
    - /v1/key/decrypt/my-key*
    deny:
    - /v1/key/decrypt/my-key-2
    - /v1/key/decrypt/my-key-internal*
    identities:
    - ...
```

This commit also temp. disables the policy integration tests since
this policy change is an API breaking change. Once we have released
this change (and once the CI instance has upgraded to it) we should
enable these tests again.