### PR TITLE
test: enable policy and identity CI tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -415,9 +415,6 @@ func TestReadWritePolicy(t *testing.T) {
 		t.SkipNow()
 	}
 
-	_ = readWritePolicyTests // TODO: remove once we enable the tests again
-	t.Skip("TODO: enable once there is a release newer than v0.14.0")
-
 	client, err := newClient()
 	if err != nil {
 		t.Fatalf("Failed to create KES client: %v", err)
@@ -452,9 +449,6 @@ func TestAssignIdentity(t *testing.T) {
 		t.SkipNow()
 	}
 
-	_ = newPolicy() // TODO: remove once we enable the tests again
-	t.Skip("TODO: enable once there is a release newer than v0.14.0")
-
 	client, err := newClient()
 	if err != nil {
 		t.Fatalf("Failed to create KES client: %v", err)
@@ -476,7 +470,6 @@ func TestForgetIdentity(t *testing.T) {
 	if !*IsIntegrationTest {
 		t.SkipNow()
 	}
-	t.Skip("TODO: enable once there is a release newer than v0.14.0")
 
 	client, err := newClient()
 	if err != nil {


### PR DESCRIPTION
This commit enables the policy and identity CI tests
again since the KES instance at `https://play.min.io:7373`
has been updated to version `v0.15.0`.

Between `v0.14.0` and `v0.15.0` there have been some breaking
API changes w.r.t. policies that made it necessary to disable
these CI tests.