### PR TITLE
improve request timeout handling

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -274,8 +274,9 @@ func server(args []string) {
 		},
 		ErrorLog: errorLog.Log(),
 
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 0 * time.Second, // explicitly set no write timeout - see timeout handler.
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      0 * time.Second, // explicitly set no write timeout - see timeout handler.
+		IdleTimeout:       90 * time.Second,
 	}
 
 	// Limit the supported cipher suites to the secure TLS 1.2/1.3 subset - i.e. only ECDHE key exchange and only AEAD ciphers.

--- a/internal/gemalto/key-secure.go
+++ b/internal/gemalto/key-secure.go
@@ -423,9 +423,8 @@ func parseServerError(resp *http.Response) (errResponse, error) {
 		return errResponse{}, err
 	}
 	message := strings.TrimSpace(s.String())
-	if strings.HasSuffix(message, "\n") { // Some error message end with '\n' causing messy logs
-		message = strings.TrimSuffix(message, "\n")
-	}
+	message = strings.TrimSuffix(message, "\n") // Some error message end with '\n' causing messy logs
+
 	return errResponse{
 		Code:    resp.StatusCode,
 		Message: message,

--- a/internal/http/timeout.go
+++ b/internal/http/timeout.go
@@ -6,205 +6,144 @@ package http
 
 import (
 	"context"
+	"log"
 	"net/http"
-	"sync"
+	"runtime"
 	"sync/atomic"
 	"time"
-
-	"github.com/minio/kes"
 )
 
-// Timeout returns an HTTP handler that runs f
-// with the given time limit.
+// Timeout returns an HTTP handler that aborts f
+// after the given time limit.
 //
-// A timeout is triggered if there is no activity
-// within the given time limit.
+// The request times out when it takes longer then
+// the given time limit to read the request body
+// and write a response back to the client.
 //
-// If the time limit exceeds before f has written
-// any response to the client, Timeout will return
-// http.StatusServiceUnavailable (503) to the client.
+// Once the timeout exceeds, any further Write call
+// by f to the http.ResponseWriter will return
+// http.ErrHandlerTimeout. Further, if the timeout
+// exceeds before f writes an HTTP status code then
+// Timeout will return 503 ServiceUnavailable to the
+// client.
 //
-// If the time limit exceeds after f has written
-// a response to the client - without any further
-// activity - Timeout will send two (non-empty)
-// HTTP trailers:
-//   • Status: http.StatusServiceUnavailable
-//   • Error: {"message":"timeout"}
-//
-// In any case, the timeout handler eventually closes
-// the underlying connection. Any further attempt by f
-// to write to the client after the timeout limit has
-// been exceeded will fail with http.ErrHandlerTimeout.
-//
-// If f implements a long-running job then it should either
-// stop once request.Context().Done() completes or once
-// a http.ResponseWriter.Write(...) call returns http.ErrHandlerTimeout.
-//
-// If f returns a stream (of messages) to the client then
-// it must send another message to the client before the
-// the time limit exceeds and must send the HTTP trailers:
-//   • Status: "200"
-//   • Error:  ""
-// once it completes successfully.
-// If f fails after streaming at least one message to the
-// client it should use ErrorTrailer to send the error as
-// HTTP trailer to the client.
+// Timeout cancels the request context before aborting f.
 func Timeout(after time.Duration, f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithCancel(r.Context())
-		defer cancel()
+		var (
+			doneCh  = make(chan struct{})
+			panicCh = make(chan interface{}, 1)
+		)
+		var tw = &timeoutResponseWriter{
+			ResponseWriter: w,
+			Flusher:        w.(http.Flusher),
+			Pusher:         w.(http.Pusher),
+		}
 
+		ctx, cancelCtx := context.WithCancel(r.Context())
+		defer cancelCtx()
 		r = r.WithContext(ctx)
-		tw := newTimeoutWriter(w)
-		tw.Header().Set("Trailer", "Status, Error")
 
-		done := make(chan struct{})
-		panicChan := make(chan interface{}, 1)
+		// We start f in a separate Go routine and wait until it
+		// completes resp. the timer expires - whatever happens first.
+		//
+		// Further, we have to recover from any potential panic that
+		// gets raised by f. However, we must not propagate the panic
+		// since that would shadow the actual location where the panic
+		// occurred. Instead, write a log message to the HTTP server error
+		// log - similar to the standard library - and abort the handler
+		// by panic'ing ErrAbortHandler.
 		go func() {
 			defer func() {
-				if p := recover(); p != nil {
-					panicChan <- p
+				err := recover()
+				if err != nil && err != http.ErrAbortHandler {
+					const size = 64 << 10
+					buf := make([]byte, size)
+					buf = buf[:runtime.Stack(buf, false)]
+
+					srv := r.Context().Value(http.ServerContextKey).(*http.Server)
+					if srv != nil && srv.ErrorLog != nil {
+						srv.ErrorLog.Printf("http: panic serving %v: %v\n%s", r.RemoteAddr, err, buf)
+					} else {
+						log.Printf("http: panic serving %v: %v\n%s", r.RemoteAddr, err, buf)
+					}
+				}
+				if err != nil {
+					panicCh <- http.ErrAbortHandler
 				}
 			}()
 			f(tw, r)
-			close(done)
+			close(doneCh)
 		}()
 
 		timer := time.NewTimer(after)
 		defer timer.Stop()
-		for {
-			select {
-			case p := <-panicChan:
-				panic(p)
-			case <-timer.C:
-				if tw.isInactive() {
-					tw.timeout()
-					return
-				}
-				tw.markInactive()
-				timer.Reset(after)
-			case <-ctx.Done():
-				tw.timeout()
-				return
-			case <-done:
-				return
-			}
+		select {
+		case err := <-panicCh:
+			panic(err)
+		case <-timer.C:
+			cancelCtx()
+			tw.timeout()
+		case <-ctx.Done():
+		case <-doneCh:
 		}
 	}
 }
 
-// timeoutWriter is a http.ResponseWriter that implements
-// http.Flusher and http.Pusher. It synchronizes a potential
-// timeout and the writes by the http.ResponseWriter it wraps.
-type timeoutWriter struct {
-	writer  http.ResponseWriter
-	flusher http.Flusher
-	pusher  http.Pusher
+// timeoutResponseWriter is an http.ResponseWriter
+// that can time out. Once it has timed out, any
+// further subsequent Write will return http.ErrHandlerTimeout.
+type timeoutResponseWriter struct {
+	http.ResponseWriter
+	http.Flusher
+	http.Pusher
 
-	writeHappened uint32
-
-	lock       sync.Mutex
-	timedOut   bool
-	hasWritten bool
+	writeHeaderHappened uint32
+	timedOut            uint32
 }
 
-var _ http.ResponseWriter = (*timeoutWriter)(nil)
-var _ http.Flusher = (*timeoutWriter)(nil)
-var _ http.Pusher = (*timeoutWriter)(nil)
-
-var errTimeout = kes.NewError(http.StatusServiceUnavailable, "timeout")
-
-func newTimeoutWriter(w http.ResponseWriter) *timeoutWriter {
-	tw := &timeoutWriter{
-		writer: w,
-	}
-	if flusher, ok := w.(http.Flusher); ok {
-		tw.flusher = flusher
-	}
-	if pusher, ok := w.(http.Pusher); ok {
-		tw.pusher = pusher
-	}
-	return tw
-}
-
-// timeout returns http.StatusServiceUnavailable to the client
-// if no response has been written to the client, yet.
-func (tw *timeoutWriter) timeout() {
-	tw.lock.Lock()
-	defer tw.lock.Unlock()
-
-	tw.timedOut = true
-	if !tw.hasWritten {
-		tw.hasWritten = true
-		Error(tw.writer, errTimeout)
-	} else {
-		ErrorTrailer(tw.writer, errTimeout)
+// timeout marks the ResponseWriter as timed out.
+//
+// If no HTTP status code has been written already,
+// then timeout will send the HTTP status code 503
+// service unavailable to the client.
+func (w *timeoutResponseWriter) timeout() {
+	atomic.StoreUint32(&w.timedOut, 1)
+	if atomic.CompareAndSwapUint32(&w.writeHeaderHappened, 0, 1) {
+		w.ResponseWriter.WriteHeader(http.StatusServiceUnavailable)
 	}
 }
 
-// isInactive returns true if no Write has happened
-// ever resp. since the last call to markInactive.
-func (tw *timeoutWriter) isInactive() bool { return atomic.LoadUint32(&tw.writeHappened) == 0 }
-
-// markInactive marks the http.ResponseWriter as
-// inactive. Another call to Write marks it as
-// active again.
-func (tw *timeoutWriter) markInactive() { atomic.StoreUint32(&tw.writeHappened, 0) }
-
-func (tw *timeoutWriter) Header() http.Header { return tw.writer.Header() }
-
-func (tw *timeoutWriter) WriteHeader(statusCode int) {
-	tw.lock.Lock()
-	defer tw.lock.Unlock()
-
-	if tw.timedOut {
-		if !tw.hasWritten {
-			tw.hasWritten = true
-			Error(tw.writer, errTimeout)
-		}
-	} else {
-		tw.hasWritten = true
-		tw.writer.WriteHeader(statusCode)
-	}
-}
-
-func (tw *timeoutWriter) Write(p []byte) (int, error) {
-	// We must not hold the lock while writing to the
-	// underlying http.ResponseWriter (via Write([]byte))
-	// b/c e.g. a slow/malicious client would block the
-	// lock.Unlock.
-	// In this case we cannot accquire the lock when we
-	// want to mark the timeoutWriter as timed out (See: timeout()).
-	// So, the client would block the actual handler by slowly
-	// reading the response and the timeout handler since it
-	// would not be able to accquire the lock until the Write([]byte)
-	// finishes.
-	// Therefore, we must release the lock before writing
-	// the (eventually large) response body to the client.
-	tw.lock.Lock()
-	if tw.timedOut {
-		tw.lock.Unlock()
+func (w *timeoutResponseWriter) Write(p []byte) (int, error) {
+	if atomic.LoadUint32(&w.timedOut) == 1 {
 		return 0, http.ErrHandlerTimeout
 	}
-	if !tw.hasWritten {
-		tw.hasWritten = true
-		tw.writer.WriteHeader(http.StatusOK)
-	}
-	tw.lock.Unlock()
 
-	atomic.StoreUint32(&tw.writeHappened, 1)
-	return tw.writer.Write(p)
+	if atomic.CompareAndSwapUint32(&w.writeHeaderHappened, 0, 1) {
+		w.ResponseWriter.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
 }
 
-func (tw *timeoutWriter) Flush() {
-	if tw.flusher != nil {
-		tw.flusher.Flush()
+func (w *timeoutResponseWriter) WriteHeader(statusCode int) {
+	if atomic.LoadUint32(&w.timedOut) == 1 {
+		return
+	}
+
+	if atomic.CompareAndSwapUint32(&w.writeHeaderHappened, 0, 1) {
+		w.ResponseWriter.WriteHeader(statusCode)
 	}
 }
 
-func (tw *timeoutWriter) Push(target string, opts *http.PushOptions) error {
-	if tw.pusher != nil {
-		return tw.pusher.Push(target, opts)
+func (w *timeoutResponseWriter) Flush() {
+	if w.Flusher != nil {
+		w.Flusher.Flush()
+	}
+}
+
+func (w *timeoutResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if w.Pusher != nil {
+		return w.Pusher.Push(target, opts)
 	}
 	return http.ErrNotSupported
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -118,9 +118,7 @@ func (w *ErrEncoder) WriteString(s string) (int, error) {
 	// A log.Logger will add a newline character to each
 	// log message. This newline has to be removed since
 	// it's not part of the actual error message.
-	if strings.HasSuffix(s, "\n") {
-		s = s[:len(s)-1]
-	}
+	s = strings.TrimSuffix(s, "\n")
 
 	err := w.encoder.Encode(kes.ErrorEvent{
 		Message: s,


### PR DESCRIPTION
This commit improves the handler timeout
implementation such that:
 - No more sporadic data races (concurrent map writes) occur
 - Panics in the actual HTTP handler no longer get propagated,
   and therefore, shadowed by the timeout handler.

Per handler timeouts are necessary since some handler (i.e.
log tracing) should not time out while others, like key generation,
should time out after a short period of time.

However, the Go HTTP server implementation only supports global
timeouts.

Therefore, this commit has apply some tricks to start an HTTP handler
in a separate Go routine and safely abort it once the timeout exceeds.

One major problem is that the timeout handler has to recover from a
potential panic within the actual HTTP handler and abort the request
without shadowing the panic message nor its original location.

Therefore, this implementation reuses some of the techniques used
by the Go standard library. It spawns the handler in a new go routine
and, in case of a panic, logs it to the server's error log and then
panics `http.ErrAbortHandler`.
This error is handled by the HTTP server specially in the sense that
it aborts the request but does not log an error message such that we
don't end up with two error log messages for one panic.

Further, the new timeout applies to the entire lifetime of the request
and does not get reset once the handler writes to the client connection.
So it behaves more like the global server timeouts but on a
handler-basis.