### PR TITLE
proxy: avoid passing nil as http.ResponseWriter to handlers

### DIFF
--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -43,6 +43,6 @@ func TLSProxy(proxy *auth.TLSProxy, f http.HandlerFunc) http.HandlerFunc {
 			// not the TLS proxy.
 			aw.Identity = auth.Identify(r, proxy.Identify)
 		}
-		f(aw, r)
+		f(w, r)
 	}
 }


### PR DESCRIPTION
This commit fixes a bug in the `TLSProxy` handler function
that occurs when KES does not create an audit log entry for
the request. This happens only in case of `/v1/metrics` API.

In case of a `/v1/metrics` API request, KES will not create
an `AuditResponseWriter`. In this case, a type check:
`aw, ok := w.(*AuditResponseWriter)` will result in `aw == nil`.

Therefore, not the assumed `AuditResponseWriter` but the actual
`http.ResponseWriter` must be passed to any subsequent handler.