### PR TITLE
secret: add key ID to encrypted keys

### DIFF
--- a/internal/secret/cache.go
+++ b/internal/secret/cache.go
@@ -43,16 +43,15 @@ func (c *cache) Set(name string, secret Secret) {
 	}
 }
 
-// SetOrGet adds  given secret to the cache
-// if and only if no entry for name already
-// exists. Instead, if an entry for the given
-// name exists it returns the secret that is
-// currently present.
+// CompareAndSwap adds the secret to the cache
+// if and only if no entry for given name exists.
+// If an entry for the given name exists it returns
+// the secret that is currently in the cache.
 //
-// SetOrGet will always return the secret that
-// is in the cache right now - either the given
-// one or the one that has been there before.
-func (c *cache) SetOrGet(name string, secret Secret) Secret {
+// CompareAndSwap will always return the secret that
+// is in the cache - either the existing one or the
+// one that has been added by CompareAndSwap itself.
+func (c *cache) CompareAndSwap(name string, secret Secret) Secret {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/internal/secret/cache_test.go
+++ b/internal/secret/cache_test.go
@@ -31,7 +31,7 @@ func TestCacheSetOrGet(t *testing.T) {
 	secret[0] = 0xff
 
 	var c cache
-	if s := c.SetOrGet("0", secret); s != secret {
+	if s := c.CompareAndSwap("0", secret); s != secret {
 		t.Fatalf("Expected to be able to add an entry: got: %x - want: %x", s, secret)
 	}
 	if s, ok := c.Get("0"); !ok || s != secret {
@@ -39,7 +39,7 @@ func TestCacheSetOrGet(t *testing.T) {
 	}
 
 	secret[0] = 0x11
-	if s := c.SetOrGet("0", secret); s == secret {
+	if s := c.CompareAndSwap("0", secret); s == secret {
 		t.Fatal("Cache entry should already exist")
 	}
 }

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -112,46 +112,56 @@ var secretUnwrapTests = []struct {
 		AssociatedData: nil,
 	},
 	{ // 2
+		Ciphertext:     `{"aead":"ChaCha20Poly1305","id":"66687aadf862bd776c8fc18b8e9f8e20","iv":"EC0eZp7Pqt+LnkOae5xaAg==","nonce":"X1ejXKmH/ugFZPkk","bytes":"wIGBTDs6aOvsqJfekZ0PYRT/OHyFX2TXqeNwl1SLXOI="}`,
+		AssociatedData: nil,
+	},
+	{ // 3
 		Ciphertext:     `{"aead":"AES-256-GCM","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // Invalid algorithm
 		Err:            kes.NewError(http.StatusUnprocessableEntity, "unsupported cryptographic algorithm"),
 	},
-	{ // 3
+	{ // 4
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"EjOY4JKqjIrPmQ5z1KSR8zlhggY=","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid IV length
 		Err:            kes.NewError(http.StatusBadRequest, "invalid iv size"),
 	},
-	{ // 4
+	{ // 5
 		Ciphertext:     `{"aead":"ChaCha20Poly1305","iv":"s3fSZ6vk5m+DfQA8yZWeUg==","nonce":"SXAbms731/c=","bytes":"cw22HjLq/4cx8507SW4hhSrYbDiMuRao4b5+GE+XfbE="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid nonce length
 		Err:            kes.NewError(http.StatusBadRequest, "invalid nonce size"),
 	},
-	{ // 5
+	{ // 6
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"efY+4kYF9n8=","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid nonce length
 		Err:            kes.NewError(http.StatusBadRequest, "invalid nonce size"),
 	},
-	{ // 6
+	{ // 7
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"QTza1g5oX3f9cGJMbY1xJwWPj1F7R2VnNl6XpFKYQy0="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // ciphertext not authentic
 		Err:            kes.ErrDecrypt,
 	},
-	{ // 7
+	{ // 8
 		Ciphertext:     `{"aead":"ChaCha20Poly1305","iv":"s3fSZ6vk5m+DfQA8yZWeUg==","nonce":"8/kHMnCMs3h9NZ2a","bytes":"TTi8pkO+Jh1JWAHvPxZeUk/iVoBPUCE4ZSVGBy3fW2s="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // ciphertext not authentic
 		Err:            kes.ErrDecrypt,
 	},
-	{ // 8
+	{ // 9
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256" "iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid JSON
 		Err:            kes.NewError(http.StatusBadRequest, "invalid ciphertext"),
+	},
+	{ // 10
+		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256", "id":"00010203040506070809101112131415", "iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
+		AssociatedData: nil,
+		ShouldFail:     true, // invalid key ID
+		Err:            kes.NewError(http.StatusBadRequest, "invalid ciphertext: key ID mismatch"),
 	},
 }
 

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -115,7 +115,6 @@ func (s *Store) Create(name string, secret Secret) (err error) {
 	if err = s.Remote.Create(name, secret.String()); err != nil {
 		return err
 	}
-	s.cache.SetOrGet(name, secret)
 	return nil
 }
 
@@ -145,7 +144,7 @@ func (s *Store) Get(name string) (Secret, error) {
 	if err != nil {
 		return Secret{}, err
 	}
-	return s.cache.SetOrGet(name, secret), nil
+	return s.cache.CompareAndSwap(name, secret), nil
 }
 
 // List returns a new Iterator over all key names.


### PR DESCRIPTION
This commit adds unique key IDs to generated
ciphertexts. The key ID identifies the root/master
key used to generate the ciphertext. Now it is possible,
to determine whether a particular key was used to encrypt
a certain ciphertext.

However, the key ID is just for informational purposes.
It is derived from the root/master key content as:
```
id := HEX(SHA-256(key)[:16])
```

The ID is a truncated hash for two reasons:
 1. Avoid additional size overhead
 2. Limit the damage a broken hash function (i.e. SHA-256)
    could cause.

W.r.t. truncating SHA-256 to 128 bits:
This is not a security issue but instead a common technique.
In particular, SHA-224 is truncated SHA-256 and SHA-384 is truncated
SHA-512.
Truncating the hash only reduces the collision resistance boundary.
However, we are not interested in collision resistance w.r.t. an
attacker crafting a collision. Instead, we only want to use that
IDs are "sufficiently" unique - such that two keys have different
IDs with very high probability.

The most important property of the ID is that it must not reveal
anything about the root/master key content.

This should be the case since we use a collision resistant hash
function. Further, even if SHA-256 would reveal information about
the hashed message (and therefore would be crypto. broken) we
limit the damage by truncating the hash to 128 bits. It's very
unlikely that a 128 bit hash value would reveal more than 128 bit
about the message - here the hashed key.