### PR TITLE
http: fix type conversion in timeout handler

### DIFF
--- a/internal/http/timeout.go
+++ b/internal/http/timeout.go
@@ -36,8 +36,12 @@ func Timeout(after time.Duration, f http.HandlerFunc) http.HandlerFunc {
 		)
 		var tw = &timeoutResponseWriter{
 			ResponseWriter: w,
-			Flusher:        w.(http.Flusher),
-			Pusher:         w.(http.Pusher),
+		}
+		if f, ok := w.(http.Flusher); ok {
+			tw.Flusher = f
+		}
+		if p, ok := w.(http.Pusher); ok {
+			tw.Pusher = p
 		}
 
 		ctx, cancelCtx := context.WithCancel(r.Context())


### PR DESCRIPTION
This commit fixes an incorrect type conversion
in the http timeout handler implementation.

Code like `x := y.(Interface)` leads to a panic
at runtime. Instead, you have to check the type
conversion:
```
var x Interface
if t, ok := y.(Interface); ok {
   x = t
}
```