### PR TITLE
cache: if no cache expiry is provided, set default expiry

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -199,6 +199,12 @@ func loadServerConfig(path string) (config serverConfig, err error) {
 
 // SetDefaults set default values for fields that may be empty b/c not specified by user.
 func (config *serverConfig) SetDefaults() {
+	if config.Cache.Expiry.Any == 0 {
+		config.Cache.Expiry.Any = duration(5 * time.Minute)
+	}
+	if config.Cache.Expiry.Unused == 0 {
+		config.Cache.Expiry.Unused = duration(30 * time.Second)
+	}
 	if config.Log.Audit == "" {
 		config.Log.Audit = "off" // If not set, default is off.
 	}

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -87,10 +87,14 @@ cache:
     # Period after which any cache entries are discarded.
     # It determines how often the KES server has to fetch
     # a secret key from the KMS.
+    #
+    # If not set, KES will default to an expiry of 5 minutes.
     any: 5m0s
     # Period after which all unused cache entries are discarded.
     # It determines how often "not frequently" used secret keys
     # must be fetched from the KMS.
+    #
+    # If not set, KES will default to an expiry of 30 seconds.
     unused: 20s
 
 # The console logging configuration. In general, the KES server


### PR DESCRIPTION
This commit changes the default behavior when no cache
expiry has been specified via the configuration file.

Before, KES never removed a key from the cache if no
cache expiry has been specified.

Now, KES sets a default any expiry of 5 minutes and
a default unused expiry of 30 seconds. Those defaults
only apply if the user did not specify a cache expiry,
resp. set the expiry to 0.