### PR TITLE
tls: add support for encrypted private keys

### DIFF
--- a/cmd/kes/config.go
+++ b/cmd/kes/config.go
@@ -36,9 +36,10 @@ type serverConfig struct {
 	} `yaml:"admin"`
 
 	TLS struct {
-		KeyPath  string `yaml:"key"`
-		CertPath string `yaml:"cert"`
-		Proxy    struct {
+		KeyPath     string `yaml:"key"`
+		KeyPassword string `yaml:"password"`
+		CertPath    string `yaml:"cert"`
+		Proxy       struct {
 			Identities []kes.Identity `yaml:"identities"`
 			Header     struct {
 				ClientCert string `yaml:"cert"`
@@ -122,6 +123,7 @@ func loadServerConfig(path string) (config serverConfig, err error) {
 	config.Admin.Identity = kes.Identity(expandEnv(config.Admin.Identity.String()))
 
 	config.TLS.KeyPath = expandEnv(config.TLS.KeyPath)
+	config.TLS.KeyPassword = expandEnv(config.TLS.KeyPassword)
 	config.TLS.CertPath = expandEnv(config.TLS.CertPath)
 	config.TLS.Proxy.Header.ClientCert = expandEnv(config.TLS.Proxy.Header.ClientCert)
 	for i, identity := range config.TLS.Proxy.Identities { // The TLS proxy identities section

--- a/cmd/kes/config_v0.13.5.go
+++ b/cmd/kes/config_v0.13.5.go
@@ -49,12 +49,16 @@ type serverConfigV0135 struct {
 func (c *serverConfigV0135) Migrate() serverConfig {
 	config := serverConfig{
 		Addr:     c.Addr,
-		TLS:      c.TLS,
 		Cache:    c.Cache,
 		Log:      c.Log,
 		KeyStore: c.Keys,
 	}
 	config.Admin.Identity = c.Root
+
+	config.TLS.KeyPath = c.TLS.KeyPath
+	config.TLS.CertPath = c.TLS.CertPath
+	config.TLS.Proxy = c.TLS.Proxy
+
 	config.Policies = make(map[string]policyConfig, len(c.Policies))
 	for name, policy := range c.Policies {
 		config.Policies[name] = policyConfig{

--- a/cmd/kes/config_v0.14.0.go
+++ b/cmd/kes/config_v0.14.0.go
@@ -54,13 +54,17 @@ type serverConfigV0140 struct {
 func (c *serverConfigV0140) Migrate() serverConfig {
 	config := serverConfig{
 		Addr:     c.Addr,
-		TLS:      c.TLS,
 		Cache:    c.Cache,
 		Log:      c.Log,
 		Keys:     c.Keys,
 		KeyStore: c.KeyStore,
 	}
 	config.Admin.Identity = c.Root
+
+	config.TLS.KeyPath = c.TLS.KeyPath
+	config.TLS.CertPath = c.TLS.CertPath
+	config.TLS.Proxy = c.TLS.Proxy
+
 	config.Policies = make(map[string]policyConfig, len(c.Policies))
 	for name, policy := range c.Policies {
 		config.Policies[name] = policyConfig{

--- a/cmd/kes/config_v0.17.0.go
+++ b/cmd/kes/config_v0.17.0.go
@@ -48,16 +48,20 @@ type serverConfigV0170 struct {
 	KeyStore kmsServerConfig `yaml:"keystore"`
 }
 
-func (s *serverConfigV0170) Migrate() serverConfig {
+func (c *serverConfigV0170) Migrate() serverConfig {
 	var config = serverConfig{
-		Addr:     s.Addr,
-		TLS:      s.TLS,
-		Policies: s.Policies,
-		Cache:    s.Cache,
-		Log:      s.Log,
-		Keys:     s.Keys,
-		KeyStore: s.KeyStore,
+		Addr:     c.Addr,
+		Policies: c.Policies,
+		Cache:    c.Cache,
+		Log:      c.Log,
+		Keys:     c.Keys,
+		KeyStore: c.KeyStore,
 	}
-	config.Admin.Identity = s.Root
+	config.Admin.Identity = c.Root
+
+	config.TLS.KeyPath = c.TLS.KeyPath
+	config.TLS.CertPath = c.TLS.CertPath
+	config.TLS.Proxy = c.TLS.Proxy
+
 	return config
 }

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -217,7 +217,7 @@ func server(args []string) {
 		}
 	}
 
-	certificate, err := xhttp.LoadCertificate(config.TLS.CertPath, config.TLS.KeyPath)
+	certificate, err := xhttp.LoadCertificate(config.TLS.CertPath, config.TLS.KeyPath, config.TLS.KeyPassword)
 	if err != nil {
 		stdlog.Fatalf("Error: failed to load TLS certificate: %v", err)
 	}
@@ -389,8 +389,11 @@ func server(args []string) {
 		quietFlag.Println("         ", bold.Sprint("kes --help"))
 	}
 
-	// Start the HTTPS server
-	if err := server.ListenAndServeTLS(config.TLS.CertPath, config.TLS.KeyPath); err != http.ErrServerClosed {
+	// Start the HTTPS server. We pass a tls.Config.GetCertificate.
+	// Therefore, we pass no certificate or private key file.
+	// Passing the private key file here directly would break support
+	// for encrypted private keys - which must be decrypted beforehand.
+	if err := server.ListenAndServeTLS("", ""); err != http.ErrServerClosed {
 		stdlog.Fatalf("Error: failed to start server: %v", err)
 	}
 }

--- a/internal/http/tls.go
+++ b/internal/http/tls.go
@@ -5,9 +5,13 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"os"
 	"sync"
 	"time"
 
@@ -16,8 +20,16 @@ import (
 
 // LoadCertificate returns a X.509 TLS certificate from the
 // given certificate and private key files.
-func LoadCertificate(certFile, keyFile string) (*Certificate, error) {
-	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+func LoadCertificate(certFile, keyFile, password string) (*Certificate, error) {
+	certBytes, err := readCertificate(certFile)
+	if err != nil {
+		return nil, err
+	}
+	keyBytes, err := readPrivateKey(keyFile, password)
+	if err != nil {
+		return nil, err
+	}
+	certificate, err := tls.X509KeyPair(certBytes, keyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -31,6 +43,7 @@ func LoadCertificate(certFile, keyFile string) (*Certificate, error) {
 		certificate: certificate,
 		certFile:    certFile,
 		keyFile:     keyFile,
+		password:    password,
 	}, nil
 }
 
@@ -42,6 +55,7 @@ type Certificate struct {
 	certificate tls.Certificate
 
 	certFile, keyFile string
+	password          string
 }
 
 // GetCertificate returns a X.509 TLS certificate
@@ -69,14 +83,31 @@ func (c *Certificate) ReloadAfter(ctx context.Context, interval time.Duration) {
 		case <-timer.C:
 		}
 
-		newCert, err := tls.LoadX509KeyPair(c.certFile, c.keyFile)
+		certBytes, err := readCertificate(c.certFile)
 		if err != nil {
 			if c.ErrorLog != nil && (lastReloadErr == nil || err.Error() != lastReloadErr.Error()) {
-				c.ErrorLog.Log().Printf("http: failed to reload certificate %q", c.certFile)
+				c.ErrorLog.Log().Printf("http: failed to reload certificate %q: %v", c.certFile, err)
 				lastReloadErr = err
 			}
 			continue
 		}
+		keyBytes, err := readPrivateKey(c.keyFile, c.password)
+		if err != nil {
+			if c.ErrorLog != nil && (lastReloadErr == nil || err.Error() != lastReloadErr.Error()) {
+				c.ErrorLog.Log().Printf("http: failed to reload private key %q: %v", c.keyFile, err)
+				lastReloadErr = err
+			}
+			continue
+		}
+		newCert, err := tls.X509KeyPair(certBytes, keyBytes)
+		if err != nil {
+			if c.ErrorLog != nil && (lastReloadErr == nil || err.Error() != lastReloadErr.Error()) {
+				c.ErrorLog.Log().Printf("http: failed to reload certificate %q: %v", c.certFile, err)
+				lastReloadErr = err
+			}
+			continue
+		}
+
 		// We set the certificate leaf to the actual certificate such that
 		// we don't have to do the parsing (multiple times) when matching the
 		// certificate to the client hello. This a performance optimisation.
@@ -88,4 +119,44 @@ func (c *Certificate) ReloadAfter(ctx context.Context, interval time.Duration) {
 		c.certificate = newCert
 		c.lock.Unlock()
 	}
+}
+
+// readCertificate reads the TLS certificate from
+// the given file path.
+func readCertificate(certFile string) ([]byte, error) {
+	data, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(data), nil
+}
+
+// readPrivateKey reads the TLS private key from the
+// given file path.
+//
+// It decrypts the private key using the given password
+// if the private key is an encrypted PEM block.
+func readPrivateKey(keyFile, password string) ([]byte, error) {
+	keyPEMBlock, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	pemBlock, rest := pem.Decode(keyPEMBlock)
+	if len(rest) > 0 {
+		return nil, errors.New("http: private key contains additional data")
+	}
+
+	if !x509.IsEncryptedPEMBlock(pemBlock) {
+		return keyPEMBlock, nil
+	}
+	if password == "" {
+		return nil, errors.New("http: private key is encrypted: password required")
+	}
+
+	plaintext, err := x509.DecryptPEMBlock(pemBlock, []byte(password))
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: pemBlock.Type, Bytes: plaintext}), nil
 }

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -11,8 +11,9 @@ root: c84cc9b91ae2399b043da7eca616048d4b4200edf2ff418d8af3835911db945d
 # private key and public certificate must be specified,
 # either here as part of the config file or via CLI arguments.
 tls:
-  key: ./server.key   # Path to the TLS private key
-  cert: ./server.cert # Path to the TLS certificate
+  key:      ./server.key   # Path to the TLS private key
+  cert:     ./server.cert  # Path to the TLS certificate
+  password: ""             # An optional password to decrypt the TLS private key
 
   # The TLS proxy configuration. A TLS proxy, like nginx, sits in
   # between a KES client and the KES server and usually acts as a


### PR DESCRIPTION
This commit adds support for encrypted TLS private
keys.

Now, a TLS private key password can be specified
in the KES config file:
```
tls:
  key: private.key
  cert: public.crt
  password: my-password
```

If the password should not be persisted as part of
the KES configuration it can be fetched from the
environment using env. variable substitution:
```
tls:
  key: private.key
  cert: public.crt
  password: ${KES_TLS_PRIVATE_KEY_PASSWORD}
```

```
export KES_TLS_PRIVATE_KEY_PASSWORD=my-password
```

***
For testing, an encrypted private key can be generated using the following command:
```
openssl ecparam -genkey -name prime256v1 | openssl ec -aes256 -out private.key -passout pass:123456
```
The corresponding certificate using this command:
```
openssl req -new -x509 -days 30 -key private.key -out public.crt \
   -subj "/C=/ST=/L=/O=/CN=localhost" -addext "subjectAltName = IP:127.0.0.1"
```