### PR TITLE
testing: new package kestest

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/minio/kes/kestest"
+)
+
+func TestClient_CreateKey(t *testing.T) {
+	var server = kestest.NewServer()
+	defer server.Close()
+
+	const KeyName = "my-key"
+	if err := server.Client().CreateKey(context.Background(), KeyName); err != nil {
+		t.Fatalf("Failed to create key %q: %v", KeyName, err)
+	}
+}
+
+func TestClient_DeleteKey(t *testing.T) {
+	var server = kestest.NewServer()
+	defer server.Close()
+
+	const KeyName = "my-key"
+	if err := server.Client().CreateKey(context.Background(), KeyName); err != nil {
+		t.Fatalf("Failed to create key %q: %v", KeyName, err)
+	}
+
+	if err := server.Client().DeleteKey(context.Background(), KeyName); err != nil {
+		t.Fatalf("Failed to delete key %q: %v", KeyName, err)
+	}
+
+}

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -233,45 +233,18 @@ func server(args []string) {
 	errorLog.Add(metrics.ErrorEventCounter())
 	auditLog.Add(metrics.AuditEventCounter())
 
-	const MaxBody = 1 << 20 // 1 MiB
-	mux := http.NewServeMux()
-	mux.Handle("/v1/key/create/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/key/create/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleCreateKey(manager)))))))))))
-	mux.Handle("/v1/key/import/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/key/import/*", xhttp.LimitRequestBody(MaxBody, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleImportKey(manager)))))))))))
-	mux.Handle("/v1/key/delete/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodDelete, xhttp.ValidatePath("/v1/key/delete/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleDeleteKey(manager)))))))))))
-	mux.Handle("/v1/key/generate/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/key/generate/*", xhttp.LimitRequestBody(MaxBody, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleGenerateKey(manager)))))))))))
-	mux.Handle("/v1/key/encrypt/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/key/encrypt/*", xhttp.LimitRequestBody(MaxBody/2, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleEncryptKey(manager)))))))))))
-	mux.Handle("/v1/key/decrypt/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/key/decrypt/*", xhttp.LimitRequestBody(MaxBody, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleDecryptKey(manager)))))))))))
-	mux.Handle("/v1/key/list/", xhttp.Timeout(15*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/key/list/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleListKeys(manager)))))))))))
-
-	mux.Handle("/v1/policy/write/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/policy/write/*", xhttp.LimitRequestBody(MaxBody, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleWritePolicy(roles)))))))))))
-	mux.Handle("/v1/policy/read/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/policy/read/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleReadPolicy(roles)))))))))))
-	mux.Handle("/v1/policy/list/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/policy/list/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleListPolicies(roles)))))))))))
-	mux.Handle("/v1/policy/delete/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodDelete, xhttp.ValidatePath("/v1/policy/delete/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleDeletePolicy(roles)))))))))))
-
-	mux.Handle("/v1/identity/assign/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodPost, xhttp.ValidatePath("/v1/identity/assign/*/*", xhttp.LimitRequestBody(MaxBody, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleAssignIdentity(roles)))))))))))
-	mux.Handle("/v1/identity/list/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/identity/list/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleListIdentities(roles)))))))))))
-	mux.Handle("/v1/identity/forget/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodDelete, xhttp.ValidatePath("/v1/identity/forget/*", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleForgetIdentity(roles)))))))))))
-
-	mux.Handle("/v1/log/audit/trace", metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/log/audit/trace", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleTraceAuditLog(auditLog))))))))))
-	mux.Handle("/v1/log/error/trace", metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/log/error/trace", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleTraceErrorLog(errorLog))))))))))
-
-	mux.Handle("/v1/status", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/status", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleStatus(version, certificate, errorLog)))))))))))
-
-	// Scrapping /v1/metrics should not change the metrics itself.
-	// Further, scrapping /v1/metrics should, by default, not produce
-	// an audit event. Monitoring systems will scrape the metrics endpoint
-	// every few seconds - depending on their configuration - such that
-	// the audit log will contain a lot of events simply pointing to the
-	// monitoring system. Logging an audit event may be something that
-	// can be enabled optionally.
-	mux.Handle("/v1/metrics", xhttp.Timeout(10*time.Second, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/v1/metrics", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.EnforcePolicies(roles, xhttp.HandleMetrics(metrics))))))))
-
-	mux.Handle("/version", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.RequireMethod(http.MethodGet, xhttp.ValidatePath("/version", xhttp.LimitRequestBody(0, xhttp.TLSProxy(proxy, xhttp.HandleVersion(version)))))))))) // /version is accessible to any identity
-	mux.Handle("/", xhttp.Timeout(10*time.Second, metrics.Count(metrics.Latency(xhttp.AuditLog(auditLog.Log(), roles, xhttp.TLSProxy(proxy, http.NotFound))))))
-
-	server := http.Server{
-		Addr:    config.Address.Value(),
-		Handler: mux,
+	var server = http.Server{
+		Addr: config.Address.Value(),
+		Handler: xhttp.NewServerMux(&xhttp.ServerConfig{
+			Version:     version,
+			Certificate: certificate,
+			Manager:     manager,
+			Roles:       roles,
+			Proxy:       proxy,
+			AuditLog:    auditLog,
+			ErrorLog:    errorLog,
+			Metrics:     metrics,
+		}),
 		TLSConfig: &tls.Config{
 			MinVersion:     tls.VersionTLS12,
 			GetCertificate: certificate.GetCertificate,

--- a/identity.go
+++ b/identity.go
@@ -1,3 +1,7 @@
+// Copyright 2019 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
 package kes
 
 import (

--- a/internal/http/handler_test.go
+++ b/internal/http/handler_test.go
@@ -50,7 +50,7 @@ func TestValidatePathHandler(t *testing.T) {
 		}
 
 		var resp dummyResponseWriter
-		ValidatePath(test.Pattern, f)(&resp, req)
+		validatePath(test.Pattern, f)(&resp, req)
 		if test.ShouldMatch && resp.StatusCode != http.StatusOK {
 			t.Fatalf("Test %d: path should have matched pattern: got %d - want %d", i, resp.StatusCode, http.StatusOK)
 		}

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/minio/kes/internal/auth"
 )
 
-// TLSProxy returns a handler function that checks if the
+// tlsProxy returns a handler function that checks if the
 // request has been forwarded by a TLS proxy and, if so,
 // verifies and adjusts the request such that handlers
 // further down the stack can treat it as sent by the
@@ -19,7 +19,7 @@ import (
 // Therefore, it replaces the proxy certificate in the
 // TLS connection state with the client certificate
 // forwarded by the proxy as part of the request headers.
-func TLSProxy(proxy *auth.TLSProxy, f http.HandlerFunc) http.HandlerFunc {
+func tlsProxy(proxy *auth.TLSProxy, f http.HandlerFunc) http.HandlerFunc {
 	if proxy == nil {
 		return f
 	}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,0 +1,114 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/key"
+	xlog "github.com/minio/kes/internal/log"
+	"github.com/minio/kes/internal/metric"
+)
+
+// A ServerConfig structure is used to configure a
+// KES server.
+type ServerConfig struct {
+	// Version is the KES server version.
+	// If empty, it defaults to v0.0.0-dev.
+	Version string
+
+	// Certificate is TLS server certificate.
+	Certificate *Certificate
+
+	// Manager is the key manager that fetches
+	// keys from a key store and stores them
+	// in a local in-memory cache.
+	Manager *key.Manager
+
+	// Roles is the authorization system that
+	// contains identities and the associated
+	// policies.
+	Roles *auth.Roles
+
+	// Proxy is an optional TLS proxy that sits
+	// in-front of this server and forwards client
+	// requests.
+	//
+	// A TLS proxy is responsible for forwarding
+	// the client certificates via a request
+	// header such that this server can apply
+	// the corresponding policy.
+	Proxy *auth.TLSProxy
+
+	// AuditLog is a log target that receives
+	// audit log events.
+	AuditLog *xlog.Target
+
+	// ErrorLog is a log target that receives
+	// error log events.
+	ErrorLog *xlog.Target
+
+	// Metrics gathers various informations about
+	// the server.
+	Metrics *metric.Metrics
+}
+
+// NewServerMux returns a new KES server handler that
+// uses the given ServerConfig to implement the KES
+// HTTP API.
+func NewServerMux(config *ServerConfig) *http.ServeMux {
+	var (
+		version     = config.Version
+		certificate = config.Certificate
+		manager     = config.Manager
+		roles       = config.Roles
+		proxy       = config.Proxy
+		auditLog    = config.AuditLog
+		errorLog    = config.ErrorLog
+		metrics     = config.Metrics
+	)
+	if version == "" {
+		version = "v0.0.0-dev"
+	}
+
+	const MaxBody = 1 << 20
+	var mux = http.NewServeMux()
+	mux.Handle("/v1/key/create/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/create/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleCreateKey(manager)))))))))))
+	mux.Handle("/v1/key/import/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/import/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleImportKey(manager)))))))))))
+	mux.Handle("/v1/key/delete/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodDelete, validatePath("/v1/key/delete/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleDeleteKey(manager)))))))))))
+	mux.Handle("/v1/key/generate/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/generate/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleGenerateKey(manager)))))))))))
+	mux.Handle("/v1/key/encrypt/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/encrypt/*", limitRequestBody(MaxBody/2, tlsProxy(proxy, enforcePolicies(roles, handleEncryptKey(manager)))))))))))
+	mux.Handle("/v1/key/decrypt/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/decrypt/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleDecryptKey(manager)))))))))))
+	mux.Handle("/v1/key/list/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/key/list/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleListKeys(manager)))))))))))
+
+	mux.Handle("/v1/policy/write/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/policy/write/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleWritePolicy(roles)))))))))))
+	mux.Handle("/v1/policy/read/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/policy/read/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleReadPolicy(roles)))))))))))
+	mux.Handle("/v1/policy/list/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/policy/list/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleListPolicies(roles)))))))))))
+	mux.Handle("/v1/policy/delete/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodDelete, validatePath("/v1/policy/delete/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleDeletePolicy(roles)))))))))))
+
+	mux.Handle("/v1/identity/assign/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/identity/assign/*/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleAssignIdentity(roles)))))))))))
+	mux.Handle("/v1/identity/list/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/identity/list/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleListIdentities(roles)))))))))))
+	mux.Handle("/v1/identity/forget/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodDelete, validatePath("/v1/identity/forget/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleForgetIdentity(roles)))))))))))
+
+	mux.Handle("/v1/log/audit/trace", metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/log/audit/trace", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleTraceAuditLog(auditLog))))))))))
+	mux.Handle("/v1/log/error/trace", metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/log/error/trace", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleTraceErrorLog(errorLog))))))))))
+
+	mux.Handle("/v1/status", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/status", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleStatus(version, certificate, errorLog)))))))))))
+
+	// Scrapping /v1/metrics should not change the metrics itself.
+	// Further, scrapping /v1/metrics should, by default, not produce
+	// an audit event. Monitoring systems will scrape the metrics endpoint
+	// every few seconds - depending on their configuration - such that
+	// the audit log will contain a lot of events simply pointing to the
+	// monitoring system. Logging an audit event may be something that
+	// can be enabled optionally.
+	mux.Handle("/v1/metrics", timeout(10*time.Second, requireMethod(http.MethodGet, validatePath("/v1/metrics", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleMetrics(metrics))))))))
+
+	mux.Handle("/version", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/version", limitRequestBody(0, tlsProxy(proxy, handleVersion(version)))))))))) // /version is accessible to any identity
+	mux.Handle("/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, tlsProxy(proxy, http.NotFound))))))
+	return mux
+}

--- a/internal/http/timeout.go
+++ b/internal/http/timeout.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Timeout returns an HTTP handler that aborts f
+// timeout returns an HTTP handler that aborts f
 // after the given time limit.
 //
 // The request times out when it takes longer then
@@ -23,8 +23,8 @@ import (
 // Timeout will return 503 ServiceUnavailable to the
 // client.
 //
-// Timeout cancels the request context before aborting f.
-func Timeout(after time.Duration, f http.HandlerFunc) http.HandlerFunc {
+// timeout cancels the request context before aborting f.
+func timeout(after time.Duration, f http.HandlerFunc) http.HandlerFunc {
 	const Message = `{"message":"request timeout exceeded"}`
 	var handler = http.TimeoutHandler(f, after, Message)
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/kestest/example_test.go
+++ b/kestest/example_test.go
@@ -1,0 +1,58 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kestest_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/kestest"
+)
+
+func ExampleServer() {
+	var server = kestest.NewServer()
+	defer server.Close()
+
+	version, err := server.Client().Version(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(version)
+
+	// Output:
+	// v0.0.0-dev
+}
+
+func ExampleServer_IssueClientCertificate() {
+	var server = kestest.NewServer()
+	defer server.Close()
+
+	server.Policy().Allow("test-policy",
+		"/v1/key/create/*",
+		"/v1/key/generate/*",
+		"/v1/key/decrypt/*",
+	)
+
+	var (
+		clientCert = server.IssueClientCertificate("test-client")
+		client     = kes.NewClientWithConfig(server.URL, &tls.Config{
+			Certificates: []tls.Certificate{clientCert},
+			RootCAs:      server.CAs(),
+		})
+	)
+	server.Policy().Assign("test-policy", kestest.Identify(&clientCert))
+
+	if err := client.CreateKey(context.Background(), "test-key"); err != nil {
+		log.Fatal(err)
+	}
+	if err := client.DeleteKey(context.Background(), "test-key"); err != kes.ErrNotAllowed {
+		log.Fatalf("Deleting a key did not fail with %v", kes.ErrNotAllowed)
+	}
+	// Output:
+	//
+}

--- a/kestest/policy.go
+++ b/kestest/policy.go
@@ -1,0 +1,74 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kestest
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+)
+
+// PolicySet holds a set of KES policies and
+// the identity-policy associations.
+type PolicySet struct {
+	roles *auth.Roles
+}
+
+// Admin returns the admin Identity that can
+// perform any KES API operation.
+func (p *PolicySet) Admin() kes.Identity { return p.roles.Root }
+
+// Add adds the given KES policy to the PolicySet.
+// Any existing policy with the same name is replaced.
+func (p *PolicySet) Add(name string, policy *kes.Policy) { p.roles.Set(name, policy) }
+
+// Allow adds a new KES policy that allows the given API
+// patterns to the PolicySet.
+//
+// Allow is a shorthand for first creating a KES Policy
+// and then adding it to the PolicySet.
+func (p *PolicySet) Allow(name string, patterns ...string) {
+	var policy, err = kes.NewPolicy(patterns...)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to create policy: %v", err))
+	}
+	p.Add(name, policy)
+}
+
+// Assign assigns the KES policy with the given name to
+// all given identities.
+//
+// It returns the first error encountered when assigning
+// identities, if any.
+func (p *PolicySet) Assign(name string, ids ...kes.Identity) error {
+	for _, id := range ids {
+		if err := p.roles.Assign(name, id); err != nil {
+			return fmt.Errorf("kestest: failed to assign policy %q to %q: %v", name, id, err)
+		}
+	}
+	return nil
+}
+
+// Identify returns the Identity of the TLS certificate.
+//
+// It computes the Identity as fingerprint of the
+// X.509 leaf certificate.
+func Identify(cert *tls.Certificate) kes.Identity {
+	if cert.Leaf == nil {
+		var err error
+		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			panic(fmt.Sprintf("kestest: failed to parse X.509 certificate: %v", err))
+		}
+	}
+
+	var id = sha256.Sum256(cert.Leaf.RawSubjectPublicKeyInfo)
+	return kes.Identity(hex.EncodeToString(id[:]))
+}

--- a/kestest/server.go
+++ b/kestest/server.go
@@ -1,0 +1,223 @@
+// Copyright 2021 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+// Package kestest provides utilities for end-to-end
+// KES testing.
+package kestest
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http/httptest"
+	"time"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+	xhttp "github.com/minio/kes/internal/http"
+	"github.com/minio/kes/internal/key"
+	"github.com/minio/kes/internal/log"
+	"github.com/minio/kes/internal/mem"
+	"github.com/minio/kes/internal/metric"
+)
+
+// NewServer starts and returns a new Server.
+// The caller should call Close when finished,
+// to shut it down.
+func NewServer() *Server {
+	var s = &Server{}
+	s.start()
+	return s
+}
+
+// A Server is a KES server listening on a system-chosen
+// port on the local loopback interface, for use in
+// end-to-end tests.
+type Server struct {
+	URL string // URL is the base URL of the form https://ipaddr:port.
+
+	policies *PolicySet
+	client   *kes.Client
+
+	caPrivateKey  crypto.PrivateKey
+	caCertificate *x509.Certificate
+
+	server *httptest.Server
+}
+
+// Client returns a KES client configured for making requests
+// to the server as admin identity.
+//
+// It is configured to trust the server's TLS test certificate.
+func (s *Server) Client() *kes.Client { return s.client }
+
+// Policy returns the PolicySet that contains all KES policies
+// and identity-policy associations.
+func (s *Server) Policy() *PolicySet { return s.policies }
+
+// Close shuts down the server and blocks until all outstanding
+// requests on this server have completed.
+func (s *Server) Close() { s.server.Close() }
+
+// IssueClientCertificate returns a new TLS certificate for
+// client authentication with the given common name.
+//
+// The returned certificate is issued by a testing CA that is
+// trusted by the Server.
+func (s *Server) IssueClientCertificate(name string) tls.Certificate {
+	if s.caCertificate == nil || s.caPrivateKey == nil {
+		s.caPrivateKey, s.caCertificate = newCA()
+	}
+	return issueCertificate(name, s.caCertificate, s.caPrivateKey, x509.ExtKeyUsageClientAuth)
+}
+
+func (s *Server) CAs() *x509.CertPool {
+	if s.caCertificate == nil || s.caPrivateKey == nil {
+		s.caPrivateKey, s.caCertificate = newCA()
+	}
+
+	var certpool = x509.NewCertPool()
+	certpool.AddCert(s.caCertificate)
+	return certpool
+}
+
+func (s *Server) start() {
+	if s.caPrivateKey == nil || s.caCertificate == nil {
+		s.caPrivateKey, s.caCertificate = newCA()
+	}
+
+	var rootCAs = x509.NewCertPool()
+	rootCAs.AddCert(s.caCertificate)
+
+	var (
+		auditLog  = log.NewTarget(io.Discard)
+		errorLog  = log.NewTarget(io.Discard)
+		metrics   = metric.New()
+		adminCert = s.IssueClientCertificate("kestest: admin")
+	)
+	s.policies = &PolicySet{
+		roles: &auth.Roles{
+			Root: Identify(&adminCert),
+		},
+	}
+
+	errorLog.Add(metrics.ErrorEventCounter())
+	auditLog.Add(metrics.AuditEventCounter())
+
+	var serverCert = issueCertificate("kestest: server", s.caCertificate, s.caPrivateKey, x509.ExtKeyUsageServerAuth)
+	s.server = httptest.NewUnstartedServer(xhttp.NewServerMux(&xhttp.ServerConfig{
+		Version:     "v0.0.0-dev",
+		Certificate: xhttp.NewCertificate(serverCert),
+		Manager: &key.Manager{
+			CacheExpiryAny:    30 * time.Second,
+			CacheExpiryUnused: 5 * time.Second,
+			Store:             &mem.Store{},
+		},
+		Roles:    s.policies.roles,
+		Proxy:    nil,
+		AuditLog: auditLog,
+		ErrorLog: errorLog,
+		Metrics:  metrics,
+	}))
+	s.server.TLS = &tls.Config{
+		RootCAs:      rootCAs,
+		ClientCAs:    rootCAs,
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	s.server.StartTLS()
+	s.URL = s.server.URL
+
+	s.client = kes.NewClientWithConfig(s.URL, &tls.Config{
+		Certificates: []tls.Certificate{adminCert},
+		RootCAs:      rootCAs,
+	})
+}
+
+func newCA() (crypto.PrivateKey, *x509.Certificate) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to generate CA private key: %v", err))
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to generate CA certificate serial number: %v", err))
+	}
+
+	var template = x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "kestest Root CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to generate CA certificate: %v", err))
+	}
+	certificate, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to generate CA certificate: %v", err))
+	}
+	return privateKey, certificate
+}
+
+func issueCertificate(name string, caCert *x509.Certificate, caKey crypto.PrivateKey, extKeyUsage ...x509.ExtKeyUsage) tls.Certificate {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to generate private/public key pair: %v", err))
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to generate certificate serial number: %v", err))
+	}
+
+	var template = x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: name,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           extKeyUsage,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		DNSNames:              []string{"localhost"},
+		BasicConstraintsValid: true,
+	}
+
+	rawCertificate, err := x509.CreateCertificate(rand.Reader, &template, caCert, publicKey, caKey)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to create certificate: %v", err))
+	}
+	rawPrivateKey, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to create certificate: %v", err))
+	}
+	certificate, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: rawCertificate,
+	}), pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: rawPrivateKey,
+	}))
+	if err != nil {
+		panic(fmt.Sprintf("kestest: failed to create certificate: %v", err))
+	}
+	return certificate
+}


### PR DESCRIPTION
This commit introduces a new sub-package
`kestest` that contains utilities for
end-to-end KES testing.

It is heavily inspired by the `net/http/httptest`
package and contains a `Server` type that implements
a minimal KES server.

The new `kestest` package makes it possible to
write unit tests covering end-to-end usage scenarios
without a dedicated KES server for testing purposes.

Fixes #164