### PR TITLE
azure: add support for Azure managed identities

### DIFF
--- a/server-config.yaml
+++ b/server-config.yaml
@@ -266,4 +266,9 @@ keystore:
         tenant_id: ""      # The ID of the tenant the client belongs to - i.e. a UUID.
         client_id: ""      # The ID of the client - i.e. a UUID.
         client_secret: ""  # The value of the client secret.
+      # Azure managed identity used to
+      # authenticate to Azure KeyVault
+      # with Azure managed credentials.
+      managed_identity:
+        client_id: ""      # The Azure managed identity of the client - i.e. a UUID.
 


### PR DESCRIPTION
This commit adds support for Azure managed identities.
An application running inside Azure can use an Azure
managed identity to access Azure services instead
of managing the access credentials itself.

Azure managed identities are the Azure implementation
of service attached credentials that are mounted at the
application when it gets started.

Fixes #167