### PR TITLE
fix printed admin identity on startup

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -342,7 +342,7 @@ func server(args []string) {
 	quietFlag.Println()
 
 	if r, err := hex.DecodeString(config.Admin.Identity.Value().String()); err == nil && len(r) == sha256.Size {
-		quietFlag.Println(blue.Sprint("Admin:   "), config.Admin.Identity)
+		quietFlag.Println(blue.Sprint("Admin:   "), config.Admin.Identity.Value())
 	} else {
 		quietFlag.Println(blue.Sprint("Admin:   "), "_     [ disabled ]")
 	}


### PR DESCRIPTION
This commit fixes the server startup
message that displays the admin identity.

It restores the previous behavior of printing
the identity value. Currently, the server
prints the identity value twice.

This bug has been introduced by a229d68fd.