### PR TITLE
status: expose backend KMS status

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -236,14 +236,13 @@ func server(args []string) {
 	var server = http.Server{
 		Addr: config.Address.Value(),
 		Handler: xhttp.NewServerMux(&xhttp.ServerConfig{
-			Version:     version,
-			Certificate: certificate,
-			Manager:     manager,
-			Roles:       roles,
-			Proxy:       proxy,
-			AuditLog:    auditLog,
-			ErrorLog:    errorLog,
-			Metrics:     metrics,
+			Version:  version,
+			Manager:  manager,
+			Roles:    roles,
+			Proxy:    proxy,
+			AuditLog: auditLog,
+			ErrorLog: errorLog,
+			Metrics:  metrics,
 		}),
 		TLSConfig: &tls.Config{
 			MinVersion:     tls.VersionTLS12,

--- a/internal/azure/key-vault.go
+++ b/internal/azure/key-vault.go
@@ -60,6 +60,19 @@ var (
 	errListKey   = kes.NewError(http.StatusBadGateway, "bad gateway: failed to list keys")
 )
 
+// Status returns the current state of the Azure KeyVault instance.
+// In particular, whether it is reachable and the network latency.
+func (kv *KeyVault) Status(ctx context.Context) (key.StoreState, error) {
+	state, err := key.DialStore(ctx, kv.Endpoint)
+	if err != nil {
+		return key.StoreState{}, err
+	}
+	if state.State == key.StoreReachable {
+		state.State = key.StoreAvailable
+	}
+	return state, nil
+}
+
 // Create creates the given key-value pair as KeyVault secret.
 //
 // Since KeyVault does not support an atomic create resp.

--- a/internal/fortanix/keystore.go
+++ b/internal/fortanix/keystore.go
@@ -171,6 +171,19 @@ func (s *KeyStore) Authenticate(ctx context.Context) error {
 	return nil
 }
 
+// Status returns the current state of the Fortanix SDKMS instance.
+// In particular, whether it is reachable and the network latency.
+func (s *KeyStore) Status(ctx context.Context) (key.StoreState, error) {
+	state, err := key.DialStore(ctx, s.Endpoint)
+	if err != nil {
+		return key.StoreState{}, err
+	}
+	if state.State == key.StoreReachable {
+		state.State = key.StoreAvailable
+	}
+	return state, nil
+}
+
 // Create stors the given key at the Fortanix SDKMS if and only
 // if no entry with the given name exists.
 //

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/key"
@@ -37,6 +38,23 @@ type Store struct {
 }
 
 var _ key.Store = (*Store)(nil)
+
+// Status returns the current state of the FS key store.
+func (s *Store) Status(_ context.Context) (key.StoreState, error) {
+	var (
+		start   = time.Now()
+		_, err  = os.Stat(s.Dir)
+		latency = time.Since(start)
+		state   = key.StoreAvailable
+	)
+	if err != nil {
+		state = key.StoreUnreachable
+	}
+	return key.StoreState{
+		State:   state,
+		Latency: latency,
+	}, nil
+}
 
 // Create stores the key in a new file in the KeyStore
 // directory if and only if no file with the given name

--- a/internal/gcp/secret-manager.go
+++ b/internal/gcp/secret-manager.go
@@ -88,6 +88,19 @@ func Connect(ctx context.Context, c *Config) (*SecretManager, error) {
 	}, nil
 }
 
+// Status returns the current state of the GCP SecretManager instance.
+// In particular, whether it is reachable and the network latency.
+func (s *SecretManager) Status(ctx context.Context) (key.StoreState, error) {
+	state, err := key.DialStore(ctx, s.config.Endpoint)
+	if err != nil {
+		return key.StoreState{}, err
+	}
+	if state.State == key.StoreReachable {
+		state.State = key.StoreAvailable
+	}
+	return state, nil
+}
+
 // Create stores the given key-value pair at GCP secret manager
 // if and only if it doesn't exists. If such an entry already exists
 // it returns kes.ErrKeyExists.

--- a/internal/gemalto/key-secure.go
+++ b/internal/gemalto/key-secure.go
@@ -129,6 +129,19 @@ func (s *KeySecure) Authenticate() (err error) {
 	return nil
 }
 
+// Status returns the current state of the Gemalto KeySecure instance.
+// In particular, whether it is reachable and the network latency.
+func (s *KeySecure) Status(ctx context.Context) (key.StoreState, error) {
+	state, err := key.DialStore(ctx, s.Endpoint)
+	if err != nil {
+		return key.StoreState{}, err
+	}
+	if state.State == key.StoreReachable {
+		state.State = key.StoreAvailable
+	}
+	return state, nil
+}
+
 // Create creates the given key-value pair at Gemalto if and only
 // if the given key does not exist. If such an entry already exists
 // it returns kes.ErrKeyExists.

--- a/internal/generic/client.go
+++ b/internal/generic/client.go
@@ -58,6 +58,19 @@ var (
 	errListKey   = kes.NewError(http.StatusBadGateway, "bad gateway: failed to list keys")
 )
 
+// Status returns the current state of the generic KeyStore instance.
+// In particular, whether it is reachable and the network latency.
+func (s *Store) Status(ctx context.Context) (key.StoreState, error) {
+	state, err := key.DialStore(ctx, s.Endpoint)
+	if err != nil {
+		return key.StoreState{}, err
+	}
+	if state.State == key.StoreReachable {
+		state.State = key.StoreAvailable
+	}
+	return state, nil
+}
+
 // Create creates the given key-value pair at the generic KeyStore if
 // and only if the given key does not exist. If such an entry already
 // exists it returns kes.ErrKeyExists.

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -21,9 +21,6 @@ type ServerConfig struct {
 	// If empty, it defaults to v0.0.0-dev.
 	Version string
 
-	// Certificate is TLS server certificate.
-	Certificate *Certificate
-
 	// Manager is the key manager that fetches
 	// keys from a key store and stores them
 	// in a local in-memory cache.
@@ -62,14 +59,13 @@ type ServerConfig struct {
 // HTTP API.
 func NewServerMux(config *ServerConfig) *http.ServeMux {
 	var (
-		version     = config.Version
-		certificate = config.Certificate
-		manager     = config.Manager
-		roles       = config.Roles
-		proxy       = config.Proxy
-		auditLog    = config.AuditLog
-		errorLog    = config.ErrorLog
-		metrics     = config.Metrics
+		version  = config.Version
+		manager  = config.Manager
+		roles    = config.Roles
+		proxy    = config.Proxy
+		auditLog = config.AuditLog
+		errorLog = config.ErrorLog
+		metrics  = config.Metrics
 	)
 	if version == "" {
 		version = "v0.0.0-dev"
@@ -97,7 +93,7 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 	mux.Handle("/v1/log/audit/trace", metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/log/audit/trace", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleTraceAuditLog(auditLog))))))))))
 	mux.Handle("/v1/log/error/trace", metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/log/error/trace", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleTraceErrorLog(errorLog))))))))))
 
-	mux.Handle("/v1/status", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/status", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleStatus(version, certificate, errorLog)))))))))))
+	mux.Handle("/v1/status", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/status", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleStatus(version, manager, errorLog)))))))))))
 
 	// Scrapping /v1/metrics should not change the metrics itself.
 	// Further, scrapping /v1/metrics should, by default, not produce

--- a/internal/key/store.go
+++ b/internal/key/store.go
@@ -2,11 +2,19 @@ package key
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/url"
+	"time"
 )
 
 // Store is a key store that persists keys that
 // are referenced by a unique name.
 type Store interface {
+	// Status returns the current state of the
+	// Store.
+	Status(context.Context) (StoreState, error)
+
 	// Create stores the given key at the key store if
 	// and only if no entry with the given name exists.
 	//
@@ -59,4 +67,103 @@ type Iterator interface {
 	// Err returns the first error, if any, encountered
 	// while iterating over the set of keys.
 	Err() error
+}
+
+// StoreState describes the state of a Store.
+type StoreState struct {
+	// State is the state of the Store. A Store
+	// can either be reachable or unreachable.
+	State StoreStatus
+
+	// Latency is the time elapsed to reach
+	// the Store.
+	Latency time.Duration
+}
+
+const (
+	// StoreAvailable is the state of a Store
+	// that is reachable and can serve requests.
+	StoreAvailable StoreStatus = "available"
+
+	// StoreReachable is the state of a Store
+	// that is reachable but may not be able
+	// to serve requests.
+	// For example, a Store may be reachable
+	// over the network but needs to be
+	// initialized or unsealed to serve requests.
+	StoreReachable StoreStatus = "reachable"
+
+	// StoreUnreachable is the state of a Store
+	// that is not reachable.
+	StoreUnreachable StoreStatus = "unreachable"
+)
+
+// StoreStatus describes that the state of a Store.
+type StoreStatus string
+
+func (s StoreStatus) String() string { return string(s) }
+
+// DialStore dials to the Store at the given endpoint
+// and returns a StoreState describing the Store status.
+//
+// If it succeeds to dial the Store it returns a StoreState
+// with the StoreReachable status - never the StoreAvailable
+// status.
+//
+// If endpoint does not contain any URL scheme, DialStore
+// uses the https URL scheme as default.
+func DialStore(ctx context.Context, endpoint string) (StoreState, error) {
+	const (
+		HTTPS       = "https://"
+		DefaultPort = "443"
+	)
+
+	URL, err := url.Parse(endpoint)
+	if err != nil {
+		return StoreState{}, err
+	}
+	if URL.Hostname() == "" {
+		// If the URL does not contain a hostname
+		// the raw endpoint does not contain a
+		// scheme. For example: localhost:443
+		// instead of https://localhost:443.
+		//
+		// In this case, we prepend the
+		// https:// scheme to obtain the
+		// hostname and port later on.
+		URL, err = url.Parse(HTTPS + endpoint)
+		if err != nil {
+			return StoreState{}, err
+		}
+	}
+
+	var (
+		host = URL.Hostname()
+		port = URL.Port()
+	)
+	if port == "" {
+		port = DefaultPort
+	}
+
+	var (
+		d     net.Dialer
+		start = time.Now()
+	)
+	c, err := d.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+	latency := time.Since(start)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return StoreState{
+			State:   StoreUnreachable,
+			Latency: latency,
+		}, nil
+	}
+	if err != nil {
+		return StoreState{}, err
+	}
+	defer c.Close()
+
+	return StoreState{
+		State:   StoreReachable,
+		Latency: latency,
+	}, nil
 }

--- a/internal/mem/mem.go
+++ b/internal/mem/mem.go
@@ -22,6 +22,15 @@ type Store struct {
 
 var _ key.Store = (*Store)(nil)
 
+// Status returns the state of the in-memory key store which is
+// always healthy.
+func (s *Store) Status(_ context.Context) (key.StoreState, error) {
+	return key.StoreState{
+		State:   key.StoreAvailable,
+		Latency: 0,
+	}, nil
+}
+
 // Create adds the given key to the store if and only if
 // no entry for the given name exists. If an entry already
 // exists it returns kes.ErrKeyExists.

--- a/kestest/server.go
+++ b/kestest/server.go
@@ -115,8 +115,7 @@ func (s *Server) start() {
 
 	var serverCert = issueCertificate("kestest: server", s.caCertificate, s.caPrivateKey, x509.ExtKeyUsageServerAuth)
 	s.server = httptest.NewUnstartedServer(xhttp.NewServerMux(&xhttp.ServerConfig{
-		Version:     "v0.0.0-dev",
-		Certificate: xhttp.NewCertificate(serverCert),
+		Version: "v0.0.0-dev",
 		Manager: &key.Manager{
 			CacheExpiryAny:    30 * time.Second,
 			CacheExpiryUnused: 5 * time.Second,


### PR DESCRIPTION
This commit changes the `/v1/status` API by:
 - adding a backend KMS status
 - removing the TLS certificate information

The KMS status is generic for all KMS backends
and describes whether the backend KMS is reachable
or unreachable as well as the network latency between
KES and the backend KMS instance.

The TLS certificate information got removed from the
status API since this information can be gathered by
the client itself (by looking at the TLS certificate).

Exposing this information in the status API is particularly
useful and just bloats the API.