### PR TITLE
cache: add offline caching of keys 

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -207,9 +207,10 @@ func server(args []string) {
 		stdlog.Fatalf("Error: %v", err)
 	}
 	manager := &key.Manager{
-		CacheExpiryAny:    config.Cache.Expiry.Any.Value(),
-		CacheExpiryUnused: config.Cache.Expiry.Unused.Value(),
-		Store:             store,
+		CacheExpiryAny:     config.Cache.Expiry.Any.Value(),
+		CacheExpiryUnused:  config.Cache.Expiry.Unused.Value(),
+		CacheExpiryOffline: config.Cache.Expiry.Offline.Value(),
+		Store:              store,
 	}
 
 	for _, k := range config.Keys {
@@ -302,6 +303,7 @@ func server(args []string) {
 		}
 	}()
 	go certificate.ReloadAfter(ctx, 5*time.Minute) // 5min is a quite reasonable reload interval
+	go key.LogStoreStatus(ctx, manager.Store, 1*time.Minute, errorLog.Log())
 
 	// The following code prints a server startup message similar to:
 	//

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -41,12 +41,11 @@ var _ key.Store = (*Store)(nil)
 
 // Status returns the current state of the FS key store.
 func (s *Store) Status(_ context.Context) (key.StoreState, error) {
-	var (
-		start   = time.Now()
-		_, err  = os.Stat(s.Dir)
-		latency = time.Since(start)
-		state   = key.StoreAvailable
-	)
+	state := key.StoreAvailable
+
+	start := time.Now()
+	_, err := os.Stat(s.Dir)
+	latency := time.Since(start)
 	if err != nil {
 		state = key.StoreUnreachable
 	}

--- a/internal/yml/server-config.go
+++ b/internal/yml/server-config.go
@@ -36,8 +36,9 @@ type ServerConfig struct {
 
 	Cache struct {
 		Expiry struct {
-			Any    Duration `yaml:"any"`
-			Unused Duration `yaml:"unused"`
+			Any     Duration `yaml:"any"`
+			Unused  Duration `yaml:"unused"`
+			Offline Duration `yaml:"offline"`
 		} `yaml:"expiry"`
 	} `yaml:"cache"`
 

--- a/internal/yml/server-config_v0.13.5.go
+++ b/internal/yml/server-config_v0.13.5.go
@@ -26,8 +26,9 @@ type serverConfigV0135 struct {
 
 	Cache struct {
 		Expiry struct {
-			Any    Duration `yaml:"any"`
-			Unused Duration `yaml:"unused"`
+			Any     Duration `yaml:"any"`
+			Unused  Duration `yaml:"unused"`
+			Offline Duration `yaml:"offline"`
 		} `yaml:"expiry"`
 	} `yaml:"cache"`
 

--- a/internal/yml/server-config_v0.14.0.go
+++ b/internal/yml/server-config_v0.14.0.go
@@ -26,8 +26,9 @@ type serverConfigV0140 struct {
 
 	Cache struct {
 		Expiry struct {
-			Any    Duration `yaml:"any"`
-			Unused Duration `yaml:"unused"`
+			Any     Duration `yaml:"any"`
+			Unused  Duration `yaml:"unused"`
+			Offline Duration `yaml:"offline"`
 		} `yaml:"expiry"`
 	} `yaml:"cache"`
 

--- a/internal/yml/server-config_v0.17.0.go
+++ b/internal/yml/server-config_v0.17.0.go
@@ -27,8 +27,9 @@ type serverConfigV0170 struct {
 
 	Cache struct {
 		Expiry struct {
-			Any    Duration `yaml:"any"`
-			Unused Duration `yaml:"unused"`
+			Any     Duration `yaml:"any"`
+			Unused  Duration `yaml:"unused"`
+			Offline Duration `yaml:"offline"`
 		} `yaml:"expiry"`
 	} `yaml:"cache"`
 

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -99,6 +99,17 @@ cache:
     #
     # If not set, KES will default to an expiry of 30 seconds.
     unused: 20s
+    # Period after which any cache entries in the offline cache
+    # are discarded.
+    # It determines how long the KES server can serve stateless
+    # requests when the KMS key store has become unavailable -
+    # e.g. due to a network outage.
+    #
+    # If not set, KES will disable the offline cache.
+    #
+    # Offline caching should only be enabled when trying to
+    # reduce the impact of the KMS key store being unavailable.
+    offline: 0s
 
 # The console logging configuration. In general, the KES server
 # distinguishes between (operational) errors and audit events.


### PR DESCRIPTION
This commit adds offline caching of keys.

KES keeps keys - fetched from the KMS key
store - in a in-memory cache to increase
performance and reduce the request rate
to the central KMS.
Entries in the cache expiry after a configurable
time period and get removed by a cache GC.

Usually it is recommended to keep the cache
expiry periods quite low - e.g.:
 - Any:    5m0s
 - Unused:  20s

In particular, low cache expiry values reduce
the time window KES can operate without interacting
with the central KMS when serving stateless
requests; e.g. generating a new data encryption key.
Note that KES can never server stateful requests,
like creating or deleting a key, without the KMS.

Especially in distributed setups, two KES servers
will sync eventually once their cache entires have
expired. For example, one KES server receives a
request to delete a key from the KMS key store.
The second KES server will not notice that this key
got deleted until its corresponding cache entry
has expired.
Low cache expiry values reduce the time window
when multiple KES servers are not synchronized.

However, low cache expiry values require that the
KMS is highly available. As soon as a cache entry
expires, KES needs to reach out to the KMS to
fetch the key again.
If the KMS is not available, KES will not be able
continue serving stateless requests.

It may be desirable to keep keys longer in the cache
to reduce the impact of the central KMS being down
and continue serving stateless requests - but only
when the KMS is actually down. When the KMS is
available, KES should expiry keys relatively quickly
and only cache them longer when the KMS is not reachable.

This commit adds this ability by another cache expiry
configuration:
```yaml
cache:
  expiry:
    any:       5m0s
    unused:     30s
    offline: 1h0m0s
```

Now, KES will cache keys for one hour if and only
if the KMS is not available. As soon as the KMS
is reachable again, KES clears the cache to sync
with the central KMS again.

If no `offline` expiry is set, KES will not cache
keys when the KMS is down. It will simply not
use an offline cache.