### PR TITLE
cli: use correct policy name instead of command name

### DIFF
--- a/cmd/kes/policy.go
+++ b/cmd/kes/policy.go
@@ -87,7 +87,7 @@ func addPolicy(args []string) {
 	}
 
 	var (
-		name  = args[0]
+		name  = cli.Arg(0)
 		input = os.Stdin
 	)
 	if cli.NArg() == 2 && cli.Arg(1) != "-" {


### PR DESCRIPTION
This commit fixes a bug in the `kes policy add` command.
Before, the command would create a policy with the name
`add` instead of whatever policy name has been specified.