### PR TITLE
yml: fix regression parsing policy definitions

### DIFF
--- a/internal/yml/server-config.go
+++ b/internal/yml/server-config.go
@@ -31,7 +31,7 @@ type ServerConfig struct {
 	Policies map[string]struct {
 		Allow      []string   `yaml:"allow"` // Use 'string' type; We don't replace API allow patterns with env. vars
 		Deny       []string   `yaml:"deny"`  // Use 'string' type; We don't replace API deny patterns with env. vars
-		Identities []Identity `yaml:"identity"`
+		Identities []Identity `yaml:"identities"`
 	} `yaml:"policy"`
 
 	Cache struct {

--- a/internal/yml/server-config_v0.13.5.go
+++ b/internal/yml/server-config_v0.13.5.go
@@ -174,12 +174,12 @@ func (c *serverConfigV0135) migrate() *ServerConfig {
 	type Policy struct {
 		Allow      []string   `yaml:"allow"`
 		Deny       []string   `yaml:"deny"`
-		Identities []Identity `yaml:"identity"`
+		Identities []Identity `yaml:"identities"`
 	}
 	config.Policies = make(map[string]struct {
 		Allow      []string   `yaml:"allow"`
 		Deny       []string   `yaml:"deny"`
-		Identities []Identity `yaml:"identity"`
+		Identities []Identity `yaml:"identities"`
 	}, len(c.Policies))
 	for name, policy := range c.Policies {
 		config.Policies[name] = Policy{

--- a/internal/yml/server-config_v0.14.0.go
+++ b/internal/yml/server-config_v0.14.0.go
@@ -179,12 +179,12 @@ func (c *serverConfigV0140) migrate() *ServerConfig {
 	type Policy struct {
 		Allow      []string   `yaml:"allow"`
 		Deny       []string   `yaml:"deny"`
-		Identities []Identity `yaml:"identity"`
+		Identities []Identity `yaml:"identities"`
 	}
 	config.Policies = make(map[string]struct {
 		Allow      []string   `yaml:"allow"`
 		Deny       []string   `yaml:"deny"`
-		Identities []Identity `yaml:"identity"`
+		Identities []Identity `yaml:"identities"`
 	}, len(c.Policies))
 	for name, policy := range c.Policies {
 		config.Policies[name] = Policy{

--- a/internal/yml/server-config_v0.17.0.go
+++ b/internal/yml/server-config_v0.17.0.go
@@ -22,7 +22,7 @@ type serverConfigV0170 struct {
 	Policies map[string]struct {
 		Allow      []string   `yaml:"allow"` // Use 'string' type; We don't replace API allow patterns with env. vars
 		Deny       []string   `yaml:"deny"`  // Use 'string' type; We don't replace API deny patterns with env. vars
-		Identities []Identity `yaml:"identity"`
+		Identities []Identity `yaml:"identities"`
 	} `yaml:"policy"`
 
 	Cache struct {


### PR DESCRIPTION
This commit fixes a regression introduced by
a229d68.

Identities assigned to a policy in the YAML
config file have been ignored in the following
case:
```
policy:
   - my-policy:
       allow:
         - /v1/key/create/*
       identity:
         - ${MY_CLIENT_IDENTITY}
```

Before, the config file parsing expected
`identities` - not `identity`. After a229d68
`identities` has been ignored. This commit
fixes this by reverting to the previous behavior
of only honoring `identities`.

Fixes #180 