### PR TITLE
sys: add minimal multi-tenancy support via Enclaves

### DIFF
--- a/internal/auth/identity.go
+++ b/internal/auth/identity.go
@@ -1,0 +1,158 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"net/http"
+	"time"
+
+	"github.com/minio/kes"
+)
+
+// Identify computes the identity of the given HTTP request.
+//
+// If the request was not sent over TLS or no client
+// certificate has been provided, Identify returns
+// IdentityUnknown.
+func Identify(req *http.Request) kes.Identity {
+	if req.TLS == nil {
+		return kes.IdentityUnknown
+	}
+
+	var cert *x509.Certificate
+	for _, c := range req.TLS.PeerCertificates {
+		if c.IsCA {
+			continue // Ignore CA certificates
+		}
+
+		if cert != nil {
+			// There is more than one client certificate
+			// that is not a CA certificate. Hence, we
+			// cannot compute an non-ambiguous identity.
+			// Therefore, we return IdentityUnknown.
+			return kes.IdentityUnknown
+		}
+		cert = c
+	}
+	if cert == nil {
+		return kes.IdentityUnknown
+	}
+
+	h := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return kes.Identity(hex.EncodeToString(h[:]))
+}
+
+// ErrNotAssigned is an error indicating that an identity is
+// not assigned resp. does not exist.
+var ErrNotAssigned = kes.NewError(http.StatusNotFound, "identity not assigned")
+
+// An IdentitySet is a set of identities that are assigned to policies.
+type IdentitySet interface {
+	// Admin returns the identity of the admin.
+	//
+	// The admin is never assigned to any policy
+	// and can perform any operation.
+	Admin(ctx context.Context) (kes.Identity, error)
+
+	// Assign assigns the identity to the given policy.
+	//
+	// It returns an error when the identity is equal
+	// to the admin identity.
+	Assign(ctx context.Context, policy string, identity kes.Identity) error
+
+	// Get returns the IdentityInfo of an assigned identity.
+	//
+	// It returns ErrNotAssigned when there is no IdentityInfo
+	// associated to the given identity.
+	Get(ctx context.Context, identity kes.Identity) (IdentityInfo, error)
+
+	// Delete deletes the given identity from the list of
+	// assigned identites.
+	//
+	// It returns ErrNotAssigned when the identity is not
+	// assigned.
+	Delete(ctx context.Context, identity kes.Identity) error
+
+	// List returns an iterator over all assigned identities.
+	List(ctx context.Context) (IdentityIterator, error)
+}
+
+// An IdentityIterator iterates over a list of identites.
+//   for iterator.Next() {
+//       _ = iterator.Identity() // Get the next identity
+//   }
+//   if err := iterator.Close(); err != nil {
+//   }
+//
+// Once done iterating, an IdentityIterator should be closed.
+//
+// In general, an IdentityIterator does not provide any
+// ordering guarantees. Concurrent changes to the underlying
+// source may not be reflected by the iterator.
+type IdentityIterator interface {
+	// Next moves the iterator to the subsequent identity, if any.
+	// This identity is available until Next is called again.
+	//
+	// It returns true if and only if there is another identity.
+	// Once an error occurs or once there are no more identities,
+	// Next returns false.
+	Next() bool
+
+	// Identity returns the current identity. Identity can be
+	// called multiple times and returns the same value until
+	// Next is called again.
+	Identity() kes.Identity
+
+	// Close closes the iterator and releases resources. It
+	// returns any error encountered while iterating, if any.
+	// Otherwise, it returns any error that occurred while
+	// closing, if any.
+	Close() error
+}
+
+// IdentityInfo describes an assigned identity.
+type IdentityInfo struct {
+	// Policy is the policy the identity is assigned to.
+	Policy string
+
+	// CreatedAt is the point in time when the identity
+	// has been assigned.
+	CreatedAt time.Time
+
+	// CreatedBy is the identity that assigned this
+	// identity to its policy.
+	CreatedBy kes.Identity
+}
+
+// ROIdentitySet wraps i and returns a readonly IdentitySet.
+func ROIdentitySet(i IdentitySet) IdentitySet { return roIdentitySet{set: i} }
+
+type roIdentitySet struct{ set IdentitySet }
+
+var _ IdentitySet = roIdentitySet{} // compiler check
+
+func (r roIdentitySet) Admin(ctx context.Context) (kes.Identity, error) {
+	return r.set.Admin(ctx)
+}
+
+func (r roIdentitySet) Assign(context.Context, string, kes.Identity) error {
+	return kes.NewError(http.StatusNotImplemented, "readonly identity: assigning an identity is not supported")
+}
+
+func (r roIdentitySet) Get(ctx context.Context, identity kes.Identity) (IdentityInfo, error) {
+	return r.set.Get(ctx, identity)
+}
+
+func (r roIdentitySet) Delete(context.Context, kes.Identity) error {
+	return kes.NewError(http.StatusNotImplemented, "readonly identity: deleting an identity is not supported")
+}
+
+func (r roIdentitySet) List(ctx context.Context) (IdentityIterator, error) {
+	return r.set.List(ctx)
+}

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -15,13 +15,6 @@ import (
 )
 
 type TLSProxy struct {
-	// Identify computes the identity from a X.509 certificate
-	// sent by the client or proxy.
-	//
-	// If it is nil a default IdentityFunc computing the
-	// SHA-256 of the certificate's public key will be used.
-	Identify IdentityFunc
-
 	// CertHeader is the HTTP header key used to extract the
 	// client certificate forwarded by a TLS proxy. The TLS
 	// proxy has to include the certificate of the actual
@@ -128,7 +121,7 @@ func (p *TLSProxy) Verify(req *http.Request) error {
 	}
 	req.TLS.PeerCertificates = peerCertificates
 
-	identity := Identify(req, p.Identify)
+	identity := Identify(req)
 	if identity.IsUnknown() {
 		return kes.ErrNotAllowed
 	}

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -41,7 +41,7 @@ func tlsProxy(proxy *auth.TLSProxy, f http.HandlerFunc) http.HandlerFunc {
 			// Update the audit log identity such that
 			// the audit log shows the actual client and
 			// not the TLS proxy.
-			aw.Identity = auth.Identify(r, proxy.Identify)
+			aw.Identity = auth.Identify(r)
 		}
 		f(w, r)
 	}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/minio/kes/internal/auth"
-	"github.com/minio/kes/internal/key"
 	xlog "github.com/minio/kes/internal/log"
 	"github.com/minio/kes/internal/metric"
+	"github.com/minio/kes/internal/sys"
 )
 
 // A ServerConfig structure is used to configure a
@@ -23,12 +23,7 @@ type ServerConfig struct {
 
 	// Store is the key store holding the cryptographic
 	// keys.
-	Store key.Store
-
-	// Roles is the authorization system that
-	// contains identities and the associated
-	// policies.
-	Roles *auth.Roles
+	Vault sys.Vault
 
 	// Proxy is an optional TLS proxy that sits
 	// in-front of this server and forwards client
@@ -57,42 +52,33 @@ type ServerConfig struct {
 // uses the given ServerConfig to implement the KES
 // HTTP API.
 func NewServerMux(config *ServerConfig) *http.ServeMux {
-	var (
-		version  = config.Version
-		store    = config.Store
-		roles    = config.Roles
-		proxy    = config.Proxy
-		auditLog = config.AuditLog
-		errorLog = config.ErrorLog
-		metrics  = config.Metrics
-	)
-	if version == "" {
-		version = "v0.0.0-dev"
+	if config.Version == "" {
+		config.Version = "v0.0.0-dev"
 	}
 
 	const MaxBody = 1 << 20
 	mux := http.NewServeMux()
-	mux.Handle("/v1/key/create/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/create/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleCreateKey(store)))))))))))
-	mux.Handle("/v1/key/import/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/import/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleImportKey(store)))))))))))
-	mux.Handle("/v1/key/delete/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodDelete, validatePath("/v1/key/delete/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleDeleteKey(store)))))))))))
-	mux.Handle("/v1/key/generate/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/generate/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleGenerateKey(store)))))))))))
-	mux.Handle("/v1/key/encrypt/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/encrypt/*", limitRequestBody(MaxBody/2, tlsProxy(proxy, enforcePolicies(roles, handleEncryptKey(store)))))))))))
-	mux.Handle("/v1/key/decrypt/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/key/decrypt/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleDecryptKey(store)))))))))))
-	mux.Handle("/v1/key/list/", timeout(15*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/key/list/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleListKeys(store)))))))))))
+	mux.Handle("/v1/key/create/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/key/create/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleCreateKey(config)))))))))))
+	mux.Handle("/v1/key/import/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/key/import/*", limitRequestBody(MaxBody, tlsProxy(config.Proxy, enforcePolicies(config, handleImportKey(config)))))))))))
+	mux.Handle("/v1/key/delete/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodDelete, validatePath("/v1/key/delete/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleDeleteKey(config)))))))))))
+	mux.Handle("/v1/key/generate/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/key/generate/*", limitRequestBody(MaxBody, tlsProxy(config.Proxy, enforcePolicies(config, handleGenerateKey(config)))))))))))
+	mux.Handle("/v1/key/encrypt/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/key/encrypt/*", limitRequestBody(MaxBody/2, tlsProxy(config.Proxy, enforcePolicies(config, handleEncryptKey(config)))))))))))
+	mux.Handle("/v1/key/decrypt/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/key/decrypt/*", limitRequestBody(MaxBody, tlsProxy(config.Proxy, enforcePolicies(config, handleDecryptKey(config)))))))))))
+	mux.Handle("/v1/key/list/", timeout(15*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/key/list/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleListKeys(config)))))))))))
 
-	mux.Handle("/v1/policy/write/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/policy/write/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleWritePolicy(roles)))))))))))
-	mux.Handle("/v1/policy/read/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/policy/read/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleReadPolicy(roles)))))))))))
-	mux.Handle("/v1/policy/list/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/policy/list/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleListPolicies(roles)))))))))))
-	mux.Handle("/v1/policy/delete/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodDelete, validatePath("/v1/policy/delete/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleDeletePolicy(roles)))))))))))
+	mux.Handle("/v1/policy/write/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/policy/write/*", limitRequestBody(MaxBody, tlsProxy(config.Proxy, enforcePolicies(config, handleWritePolicy(config)))))))))))
+	mux.Handle("/v1/policy/read/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/policy/read/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleReadPolicy(config)))))))))))
+	mux.Handle("/v1/policy/list/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/policy/list/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleListPolicies(config)))))))))))
+	mux.Handle("/v1/policy/delete/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodDelete, validatePath("/v1/policy/delete/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleDeletePolicy(config)))))))))))
 
-	mux.Handle("/v1/identity/assign/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodPost, validatePath("/v1/identity/assign/*/*", limitRequestBody(MaxBody, tlsProxy(proxy, enforcePolicies(roles, handleAssignIdentity(roles)))))))))))
-	mux.Handle("/v1/identity/list/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/identity/list/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleListIdentities(roles)))))))))))
-	mux.Handle("/v1/identity/forget/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodDelete, validatePath("/v1/identity/forget/*", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleForgetIdentity(roles)))))))))))
+	mux.Handle("/v1/identity/assign/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodPost, validatePath("/v1/identity/assign/*/*", limitRequestBody(MaxBody, tlsProxy(config.Proxy, enforcePolicies(config, handleAssignIdentity(config)))))))))))
+	mux.Handle("/v1/identity/list/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/identity/list/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleListIdentities(config)))))))))))
+	mux.Handle("/v1/identity/forget/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodDelete, validatePath("/v1/identity/forget/*", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleForgetIdentity(config)))))))))))
 
-	mux.Handle("/v1/log/audit/trace", metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/log/audit/trace", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleTraceAuditLog(auditLog))))))))))
-	mux.Handle("/v1/log/error/trace", metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/log/error/trace", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleTraceErrorLog(errorLog))))))))))
+	mux.Handle("/v1/log/audit/trace", config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/log/audit/trace", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleTraceAuditLog(config.AuditLog))))))))))
+	mux.Handle("/v1/log/error/trace", config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/log/error/trace", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleTraceErrorLog(config.ErrorLog))))))))))
 
-	mux.Handle("/v1/status", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/v1/status", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleStatus(version, store, errorLog)))))))))))
+	mux.Handle("/v1/status", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/v1/status", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleStatus(config)))))))))))
 
 	// Scrapping /v1/metrics should not change the metrics itself.
 	// Further, scrapping /v1/metrics should, by default, not produce
@@ -101,9 +87,9 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 	// the audit log will contain a lot of events simply pointing to the
 	// monitoring system. Logging an audit event may be something that
 	// can be enabled optionally.
-	mux.Handle("/v1/metrics", timeout(10*time.Second, requireMethod(http.MethodGet, validatePath("/v1/metrics", limitRequestBody(0, tlsProxy(proxy, enforcePolicies(roles, handleMetrics(metrics))))))))
+	mux.Handle("/v1/metrics", timeout(10*time.Second, requireMethod(http.MethodGet, validatePath("/v1/metrics", limitRequestBody(0, tlsProxy(config.Proxy, enforcePolicies(config, handleMetrics(config.Metrics))))))))
 
-	mux.Handle("/version", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, requireMethod(http.MethodGet, validatePath("/version", limitRequestBody(0, tlsProxy(proxy, handleVersion(version)))))))))) // /version is accessible to any identity
-	mux.Handle("/", timeout(10*time.Second, metrics.Count(metrics.Latency(audit(auditLog.Log(), roles, tlsProxy(proxy, http.NotFound))))))
+	mux.Handle("/version", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), requireMethod(http.MethodGet, validatePath("/version", limitRequestBody(0, tlsProxy(config.Proxy, handleVersion(config.Version)))))))))) // /version is accessible to any identity
+	mux.Handle("/", timeout(10*time.Second, config.Metrics.Count(config.Metrics.Latency(audit(config.AuditLog.Log(), tlsProxy(config.Proxy, http.NotFound))))))
 	return mux
 }

--- a/internal/sys/enclave.go
+++ b/internal/sys/enclave.go
@@ -1,0 +1,171 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package sys
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/key"
+)
+
+// NewEnclave returns a new Enclave with the
+// given key store, policy set and identity set.
+func NewEnclave(keys key.Store, policies auth.PolicySet, identities auth.IdentitySet) *Enclave {
+	return &Enclave{
+		keys:       keys,
+		policies:   policies,
+		identities: identities,
+	}
+}
+
+// An Enclave is shielded environment with a Vault that
+// stores keys, policies and identities.
+type Enclave struct {
+	keys key.Store
+
+	policies auth.PolicySet
+
+	identities auth.IdentitySet
+}
+
+func (e *Enclave) Status(ctx context.Context) (key.StoreState, error) { return e.keys.Status(ctx) }
+
+// CreateKey stores the given key if and only if no entry with
+// the given name exists.
+//
+// It returns kes.ErrKeyExists if such an entry exists.
+func (e *Enclave) CreateKey(ctx context.Context, name string, key key.Key) error {
+	return e.keys.Create(ctx, name, key)
+}
+
+// DeleteKey deletes the key associated with the given name.
+func (e *Enclave) DeleteKey(ctx context.Context, name string) error {
+	return e.keys.Delete(ctx, name)
+}
+
+// GetKey returns the key associated with the given name.
+//
+// It returns kes.ErrKeyNotFound if no such entry exists.
+func (e *Enclave) GetKey(ctx context.Context, name string) (key.Key, error) {
+	return e.keys.Get(ctx, name)
+}
+
+// ListKeys returns a new iterator over all keys within the
+// Enclave.
+//
+// The iterator makes no guarantees about whether concurrent changes
+// to the enclave - i.e. creation or deletion of keys - are reflected.
+// It does not provide any ordering guarantees.
+func (e *Enclave) ListKeys(ctx context.Context) (key.Iterator, error) {
+	return e.keys.List(ctx)
+}
+
+// SetPolicy creates or overwrites the policy with the given name.
+func (e *Enclave) SetPolicy(ctx context.Context, name string, policy *auth.Policy) error {
+	return e.policies.Set(ctx, name, policy)
+}
+
+// DeletePolicy deletes the policy associated with the given name.
+func (e *Enclave) DeletePolicy(ctx context.Context, name string) error {
+	return e.policies.Delete(ctx, name)
+}
+
+// GetPolicy returns the policy associated with the given name.
+//
+// It returns kes.ErrPolicyNotFound when no such entry exists.
+func (e *Enclave) GetPolicy(ctx context.Context, name string) (*auth.Policy, error) {
+	return e.policies.Get(ctx, name)
+}
+
+// ListPolicies returns a new iterator over all policies within
+// the Enclave.
+//
+// The iterator makes no guarantees about whether concurrent changes
+// to the enclave - i.e. creation or deletion of policies - are
+// reflected. It does not provide any ordering guarantees.
+func (e *Enclave) ListPolicies(ctx context.Context) (auth.PolicyIterator, error) {
+	return e.policies.List(ctx)
+}
+
+// AssignIdentity assigns the given identity a policy referenced by
+// the policy name.
+func (e *Enclave) AssignIdentity(ctx context.Context, policy string, identities kes.Identity) error {
+	return e.identities.Assign(ctx, policy, identities)
+}
+
+// DeleteIdentity deletes the given identity.
+func (e *Enclave) DeleteIdentity(ctx context.Context, identities kes.Identity) error {
+	return e.identities.Delete(ctx, identities)
+}
+
+// GetIdentity returns metadata about the given identity.
+func (e *Enclave) GetIdentity(ctx context.Context, identity kes.Identity) (auth.IdentityInfo, error) {
+	return e.identities.Get(ctx, identity)
+}
+
+// ListIdentities returns an iterator over all identites within
+// the Enclave.
+//
+// The iterator makes no guarantees about whether concurrent changes
+// to the enclave - i.e. assignment or deletion of identities - are
+// reflected. It does not provide any ordering guarantees.
+func (e *Enclave) ListIdentities(ctx context.Context) (auth.IdentityIterator, error) {
+	return e.identities.List(ctx)
+}
+
+// VerifyRequest verifies the given request is allowed
+// based on the policies and identities within the Enclave.
+func (e *Enclave) VerifyRequest(r *http.Request) error {
+	if r.TLS == nil {
+		return kes.NewError(http.StatusBadRequest, "insecure connection: TLS required")
+	}
+
+	var peerCertificates []*x509.Certificate
+	switch {
+	case len(r.TLS.PeerCertificates) <= 1:
+		peerCertificates = r.TLS.PeerCertificates
+	case len(r.TLS.PeerCertificates) > 1:
+		for _, cert := range r.TLS.PeerCertificates {
+			if cert.IsCA {
+				continue
+			}
+			peerCertificates = append(peerCertificates, cert)
+		}
+	}
+	if len(peerCertificates) == 0 {
+		return kes.NewError(http.StatusBadRequest, "no client certificate is present")
+	}
+	if len(peerCertificates) > 1 {
+		return kes.NewError(http.StatusBadRequest, "too many client certificates are present")
+	}
+
+	var (
+		h        = sha256.Sum256(peerCertificates[0].RawSubjectPublicKeyInfo)
+		identity = kes.Identity(hex.EncodeToString(h[:]))
+	)
+	admin, err := e.identities.Admin(r.Context())
+	if err != nil {
+		return err
+	}
+	if identity == admin {
+		return nil
+	}
+
+	info, err := e.GetIdentity(r.Context(), identity)
+	if err != nil {
+		return err
+	}
+	policy, err := e.GetPolicy(r.Context(), info.Policy)
+	if err != nil {
+		return err
+	}
+	return policy.Verify(r)
+}

--- a/internal/sys/stateless-vault.go
+++ b/internal/sys/stateless-vault.go
@@ -1,0 +1,59 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package sys
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/key"
+)
+
+// NewStatelessVault returns a new Vault with a single Enclave
+// that uses the given key store, policy set and identity set.
+//
+// The Vault is not able to create or delete enclaves.
+func NewStatelessVault(operator kes.Identity, keys key.Store, policies auth.PolicySet, identites auth.IdentitySet) Vault {
+	return &statelessVault{
+		enclave: &Enclave{
+			keys:       keys,
+			policies:   policies,
+			identities: identites,
+		},
+		operator: operator,
+	}
+}
+
+type statelessVault struct {
+	enclave  *Enclave
+	operator kes.Identity
+}
+
+var _ Vault = (*statelessVault)(nil) // compiler check
+
+func (v *statelessVault) Seal(ctx context.Context) error { return nil }
+
+func (v *statelessVault) Unseal(context.Context) error { return nil }
+
+func (v *statelessVault) Operator(_ context.Context) (kes.Identity, error) {
+	return v.operator, nil
+}
+
+func (v *statelessVault) CreateEnclave(_ context.Context, _ string) (*Enclave, error) {
+	return nil, kes.NewError(http.StatusNotImplemented, "creating encalves is not supported")
+}
+
+func (v *statelessVault) GetEnclave(_ context.Context, name string) (*Enclave, error) {
+	if name == "" {
+		return v.enclave, nil
+	}
+	return nil, ErrEnclaveNotFound
+}
+
+func (v *statelessVault) DeleteEnclave(_ context.Context, _ string) error {
+	return kes.NewError(http.StatusNotImplemented, "deleting encalves is not supported")
+}

--- a/internal/sys/vault.go
+++ b/internal/sys/vault.go
@@ -1,0 +1,50 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package sys
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/minio/kes"
+)
+
+var (
+	ErrEnclaveExists = kes.NewError(http.StatusBadRequest, "enclave already exists")
+
+	ErrEnclaveNotFound = kes.NewError(http.StatusNotFound, "enclave does not exist")
+)
+
+type Vault interface {
+	// Seal seals the Vault. Once sealed, any subsequent operation
+	// returns ErrSealed.
+	//
+	// It returns ErrSealed if the Vault is already sealed.
+	Seal(ctx context.Context) error
+
+	// Unseal unseals the Vault.
+	//
+	// It returns no error If the Vault is already unsealed.
+	Unseal(ctx context.Context) error
+
+	// Operator returns the identity of the Vault operator.
+	Operator(context.Context) (kes.Identity, error)
+
+	// CreateEnclave creates and returns a new Enclave if and only if
+	// no Enclave with the given name exists.
+	//
+	// It returns ErrEnclaveExists if an Enclave with the given name
+	// already exists.
+	CreateEnclave(ctx context.Context, name string) (*Enclave, error)
+
+	// GetEnclave returns the Enclave associated with the given name.
+	//
+	// It returns ErrEnclaveNotFound if no Enclave with the given
+	// name exists.
+	GetEnclave(ctx context.Context, name string) (*Enclave, error)
+
+	// DeleteEnclave deletes the Enclave with the given name.
+	DeleteEnclave(ctx context.Context, name string) error
+}

--- a/kestest/policy.go
+++ b/kestest/policy.go
@@ -5,11 +5,16 @@
 package kestest
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"sync"
+	"time"
 
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/auth"
@@ -18,16 +23,36 @@ import (
 // PolicySet holds a set of KES policies and
 // the identity-policy associations.
 type PolicySet struct {
-	roles *auth.Roles
+	admin      kes.Identity
+	policies   map[string]*auth.Policy
+	identities map[kes.Identity]auth.IdentityInfo
 }
 
 // Admin returns the admin Identity that can
 // perform any KES API operation.
-func (p *PolicySet) Admin() kes.Identity { return p.roles.Root }
+func (p *PolicySet) Admin() kes.Identity { return p.admin }
 
 // Add adds the given KES policy to the PolicySet.
 // Any existing policy with the same name is replaced.
-func (p *PolicySet) Add(name string, policy *kes.Policy) { p.roles.Set(name, policy) }
+func (p *PolicySet) Add(name string, policy *kes.Policy) {
+	type Policy struct {
+		Allow []string `json:"allow"`
+		Deny  []string `json:"deny"`
+	}
+	b, err := json.Marshal(policy)
+	if err != nil {
+		panic(err)
+	}
+
+	var jsonPolicy Policy
+	if err = json.Unmarshal(b, &jsonPolicy); err != nil {
+		panic(err)
+	}
+	p.policies[name] = &auth.Policy{
+		Allow: jsonPolicy.Allow,
+		Deny:  jsonPolicy.Deny,
+	}
+}
 
 // Allow adds a new KES policy that allows the given API
 // patterns to the PolicySet.
@@ -49,11 +74,32 @@ func (p *PolicySet) Allow(name string, patterns ...string) {
 // identities, if any.
 func (p *PolicySet) Assign(name string, ids ...kes.Identity) error {
 	for _, id := range ids {
-		if err := p.roles.Assign(name, id); err != nil {
-			return fmt.Errorf("kestest: failed to assign policy %q to %q: %v", name, id, err)
+		if id.IsUnknown() {
+			return fmt.Errorf("kestest: failed to assign policy %q to %q: identity is empty", name, id)
+		}
+		if id == p.Admin() {
+			return fmt.Errorf("kestest: failed to assign policy %q to %q: equal to admin identity", name, id)
+		}
+		p.identities[id] = auth.IdentityInfo{
+			Policy:    name,
+			CreatedAt: time.Now().UTC(),
+			CreatedBy: p.admin,
 		}
 	}
 	return nil
+}
+
+func (p *PolicySet) policySet() auth.PolicySet {
+	return &policySet{
+		policies: p.policies,
+	}
+}
+
+func (p *PolicySet) identitySet() auth.IdentitySet {
+	return &identitySet{
+		admin: p.admin,
+		roles: p.identities,
+	}
 }
 
 // Identify returns the Identity of the TLS certificate.
@@ -72,3 +118,137 @@ func Identify(cert *tls.Certificate) kes.Identity {
 	id := sha256.Sum256(cert.Leaf.RawSubjectPublicKeyInfo)
 	return kes.Identity(hex.EncodeToString(id[:]))
 }
+
+type policySet struct {
+	lock     sync.RWMutex
+	policies map[string]*auth.Policy
+}
+
+func (p *policySet) Set(_ context.Context, name string, policy *auth.Policy) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.policies[name] = policy
+	return nil
+}
+
+func (p *policySet) Get(_ context.Context, name string) (*auth.Policy, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	policy, ok := p.policies[name]
+	if !ok {
+		return nil, kes.ErrPolicyNotFound
+	}
+	return policy, nil
+}
+
+func (p *policySet) Delete(_ context.Context, name string) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	delete(p.policies, name)
+	return nil
+}
+
+func (p *policySet) List(_ context.Context) (auth.PolicyIterator, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	names := make([]string, 0, len(p.policies))
+	for name := range p.policies {
+		names = append(names, name)
+	}
+	return &policyIterator{
+		values: names,
+	}, nil
+}
+
+type policyIterator struct {
+	values  []string
+	current string
+}
+
+func (i *policyIterator) Next() bool {
+	next := len(i.values) > 0
+	if next {
+		i.current = i.values[0]
+	}
+	return next
+}
+
+func (i *policyIterator) Name() string { return i.current }
+
+func (i *policyIterator) Close() error { return nil }
+
+type identitySet struct {
+	admin kes.Identity
+
+	lock  sync.RWMutex
+	roles map[kes.Identity]auth.IdentityInfo
+}
+
+func (i *identitySet) Admin(ctx context.Context) (kes.Identity, error) { return i.admin, nil }
+
+func (i *identitySet) Assign(_ context.Context, policy string, identity kes.Identity) error {
+	if i.admin == identity {
+		return kes.NewError(http.StatusBadRequest, "identity is root")
+	}
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	i.roles[identity] = auth.IdentityInfo{
+		Policy:    policy,
+		CreatedAt: time.Now().UTC(),
+	}
+	return nil
+}
+
+func (i *identitySet) Get(_ context.Context, identity kes.Identity) (auth.IdentityInfo, error) {
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+
+	policy, ok := i.roles[identity]
+	if !ok {
+		return auth.IdentityInfo{}, kes.ErrNotAllowed
+	}
+	return policy, nil
+}
+
+func (i *identitySet) Delete(_ context.Context, identity kes.Identity) error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	delete(i.roles, identity)
+	return nil
+}
+
+func (i *identitySet) List(_ context.Context) (auth.IdentityIterator, error) {
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+
+	values := make([]kes.Identity, 0, len(i.roles))
+	for identity := range i.roles {
+		values = append(values, identity)
+	}
+	return &identityIterator{
+		values: values,
+	}, nil
+}
+
+type identityIterator struct {
+	values  []kes.Identity
+	current kes.Identity
+}
+
+func (i *identityIterator) Next() bool {
+	next := len(i.values) > 0
+	if next {
+		i.current = i.values[0]
+	}
+	return next
+}
+
+func (i *identityIterator) Identity() kes.Identity { return i.current }
+
+func (i *identityIterator) Close() error { return nil }


### PR DESCRIPTION
This commit adds the most minimal multi-tenancy
implementation.

Now, KES contains an internal Vault. The Vault
has one or multiple Enclaves. (For now just one).

Each Enclave has its own key store, policies set
and identity set. A client selects the enclave
using the `?enclave=<name>` query parameter.

For example:
```
https://127.0.0.1:7373/v1/key/create/my-key?enclave=tenant-1
```

However, a stateless KES server will only support a
single Enclave. Therefore, this commit only adds the
most basic Vault implementation.

Future Vault implementations (e.g. a standalone FS
KES server) will use a more sophisticated Vault
implementation that supports seal/unsealing etc.

This commit mainly focuses on changing the current
code base to use a `sys.Vault` and don't change any
client-facing behavior.