### PR TITLE
cli: add support for encrypted private keys

### DIFF
--- a/internal/fips/fips.go
+++ b/internal/fips/fips.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build fips && linux && amd64
-// +build fips,linux,amd64
 
 package fips
 

--- a/internal/fips/nofips.go
+++ b/internal/fips/nofips.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !fips
-// +build !fips
 
 package fips
 


### PR DESCRIPTION
This commit adds support for encrypted private keys.
Now, the KES CLI can ask for a password and decrypt
an encrypted private key.

Since most PKI/TLS tooling on the internet still defaults
to the (insecure) RFC 1423 methods, this functionality
should be considered a mid-term solution.