### PR TITLE
include client IP address in audit log

### DIFF
--- a/internal/http/audit.go
+++ b/internal/http/audit.go
@@ -6,6 +6,7 @@ package http
 
 import (
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -23,7 +24,9 @@ type AuditResponseWriter struct {
 	// on the first invocation of Write resp. WriteHeader.
 	Logger *log.Logger
 
-	URL      url.URL      // The request URL
+	URL url.URL // The request URL
+	IP  net.IP  // The client IP address
+
 	Identity kes.Identity // The client's X.509 identity
 	Time     time.Time    // The time when we receive the request
 
@@ -49,6 +52,7 @@ func (w *AuditResponseWriter) WriteHeader(statusCode int) {
 		event := kes.AuditEvent{
 			Time: w.Time,
 			Request: kes.AuditEventRequest{
+				IP:       w.IP,
 				Path:     w.URL.Path,
 				Identity: w.Identity.String(),
 			},

--- a/log.go
+++ b/log.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"time"
 )
 
@@ -256,6 +257,7 @@ func (a *AuditEvent) String() string {
 // In particular, it contains the identity of the
 // client and other audit-related information.
 type AuditEventRequest struct {
+	IP       net.IP `json:"ip"`
 	Path     string `json:"path"`
 	Identity string `json:"identity"`
 }
@@ -263,8 +265,12 @@ type AuditEventRequest struct {
 // String returns the AuditEventRequest's string representation
 // which is valid JSON.
 func (a *AuditEventRequest) String() string {
-	const format = `{"path":"%s","identity":"%s"}`
-	return fmt.Sprintf(format, a.Path, a.Identity)
+	if len(a.IP) == 0 {
+		const format = `{"path":"%s","identity":"%s"}`
+		return fmt.Sprintf(format, a.Path, a.Identity)
+	}
+	const format = `{"ip":"%s","path":"%s","identity":"%s"}`
+	return fmt.Sprintf(format, a.IP.String(), a.Path, a.Identity)
 }
 
 // AuditEventResponse contains the audit information


### PR DESCRIPTION
With this commit the KES server adds the
client IP address to the audit events.

```
{
  "time": "2022-02-09T23:13:22+01:00",
  "request": {
    "ip": "127.0.0.1",
    "path": "/v1/log/audit/trace",
    "identity": "3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22"
  },
  "response": {
    "code": 200,
    "time": 45000
  }
}
```