### PR TITLE
remove HTTP trailers from `v1/identity/list` API

### DIFF
--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -147,14 +147,12 @@ func listIdentity(args []string) {
 		}
 		stdlog.Fatalf("Error: failed to list identities matching %q: %v", pattern, err)
 	}
+	defer identities.Close()
 
 	if isTerm(os.Stdout) {
-		sortedIdentities := make([]kes.IdentityDescription, 0, 100)
+		sortedIdentities := make([]kes.IdentityInfo, 0, 100)
 		for identities.Next() {
 			sortedIdentities = append(sortedIdentities, identities.Value())
-		}
-		if err = identities.Err(); err != nil {
-			stdlog.Fatalf("Error: failed to list identities matching %q: %v", pattern, err)
 		}
 		if err = identities.Close(); err != nil {
 			stdlog.Fatalf("Error: failed to list identities matching %q: %v", pattern, err)
@@ -170,9 +168,6 @@ func listIdentity(args []string) {
 		encoder := json.NewEncoder(os.Stdout)
 		for identities.Next() {
 			encoder.Encode(identities.Value())
-		}
-		if err = identities.Err(); err != nil {
-			stdlog.Fatalf("Error: failed to list identities matching %q: %v", pattern, err)
 		}
 		if err = identities.Close(); err != nil {
 			stdlog.Fatalf("Error: failed to list identities matching %q: %v", pattern, err)

--- a/enclave.go
+++ b/enclave.go
@@ -448,8 +448,8 @@ func (e *Enclave) ListIdentities(ctx context.Context, pattern string) (*Identity
 		return nil, parseErrorResponse(resp)
 	}
 	return &IdentityIterator{
-		response: resp,
-		decoder:  json.NewDecoder(resp.Body),
+		decoder: json.NewDecoder(resp.Body),
+		closer:  resp.Body,
 	}, nil
 }
 

--- a/error.go
+++ b/error.go
@@ -6,11 +6,8 @@ package kes
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 )
 
@@ -110,31 +107,4 @@ func parseErrorResponse(resp *http.Response) error {
 		return err
 	}
 	return NewError(resp.StatusCode, sb.String())
-}
-
-func parseErrorTrailer(trailer http.Header) error {
-	if _, ok := trailer["Status"]; !ok {
-		return errors.New("kes: unexpected EOF: no HTTP status trailer")
-	}
-	status, err := strconv.Atoi(trailer.Get("Status"))
-	if err != nil {
-		return fmt.Errorf("kes: invalid HTTP trailer - Status: %q", trailer.Get("Status"))
-	}
-	if status == http.StatusOK {
-		return nil
-	}
-
-	errMessage := trailer.Get("Error")
-	if errMessage == "" {
-		return NewError(status, "")
-	}
-
-	type Response struct {
-		Message string `json:"message"`
-	}
-	var response Response
-	if err = json.Unmarshal([]byte(errMessage), &response); err != nil {
-		return err
-	}
-	return NewError(status, response.Message)
 }


### PR DESCRIPTION
This commit removes the HTTP trailer mechanism used
to signal errors. Instead, errors are now communicated
as API messages.

Further, this commit extends the listing API with additional
identity information like `CreatedAt` or `CreatedBy`.