### PR TITLE
adjust exported error messages

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -16,8 +16,8 @@ var newErrorTests = []struct {
 }{
 	{Code: http.StatusBadRequest, Message: "", Err: NewError(http.StatusBadRequest, "")},
 	{Code: http.StatusNotFound, Message: "key does not exist", Err: ErrKeyNotFound},
-	{Code: http.StatusBadRequest, Message: "key does already exist", Err: ErrKeyExists},
-	{Code: http.StatusForbidden, Message: "prohibited by policy", Err: ErrNotAllowed},
+	{Code: http.StatusBadRequest, Message: "key already exists", Err: ErrKeyExists},
+	{Code: http.StatusForbidden, Message: "not authorized: insufficient permissions", Err: ErrNotAllowed},
 }
 
 func TestNewError(t *testing.T) {


### PR DESCRIPTION
This commit adjusts the exported errors
to be more descriptive. For example,
`ErrNotAllowed` can not just occur when
a policy disallows the request.

This commit ensures that errors sent by
a previous KES server version are translated
properly. However, it's still a breaking change.