### PR TITLE
key: switch to binary-encoded DEKs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,8 @@ linters:
 
 issues:
   exclude-use-default: false
+  exclude:
+      - "var-naming: don't use ALL_CAPS in Go names; use CamelCase"
 
 service:
   golangci-lint-version: 1.43.0 # use the fixed version to not introduce new linters unexpectedly

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.30.0
-	github.com/secure-io/sio-go v0.3.1
 	github.com/spf13/pflag v1.0.5
+	github.com/tinylib/msgp v1.1.6
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
+github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -388,8 +390,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/secure-io/sio-go v0.3.1 h1:dNvY9awjabXTYGsTF1PiCySl9Ltofk9GA3VdWlo7rRc=
-github.com/secure-io/sio-go v0.3.1/go.mod h1:+xbkjDzPjwh4Axd07pRKSNriS9SCiYksWnZqdnfpQxs=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -407,11 +407,14 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
+github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -426,7 +429,6 @@ golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480/go.mod h1:WFFai1msRO1wXaE
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -496,6 +498,7 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -514,6 +517,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -558,6 +562,7 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -625,6 +630,7 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/cpu/aes.go
+++ b/internal/cpu/aes.go
@@ -1,0 +1,46 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package cpu
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/cpu"
+)
+
+// HasAESGCM returns true if and only if the CPU
+// provides native hardware instructions for AES-GCM.
+func HasAESGCM() bool {
+	// Go 1.14 introduced an AES-GCM asm implementation for PPC64-le.
+	// PPC64 always provides hardware support for AES-GCM.
+	// Ref: https://go.dev/src/crypto/aes/gcm_ppc64le.go
+	if runtime.GOARCH == "ppc64le" {
+		return true
+	}
+
+	if !cpu.Initialized {
+		return false
+	}
+	if cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ {
+		return true
+	}
+
+	// ARM CPUs may provide AES and PMULL instructions
+	// as well. However, the Go STL does not provide
+	// an ARM asm implementation. It provides only an
+	// ARM64 implementation.
+	if cpu.ARM64.HasAES && cpu.ARM64.HasPMULL {
+		return true
+	}
+
+	// On S390X, AES-GCM is only enabled when all
+	// AES CPU features (CBC, CTR and GHASH / GCM)
+	// are available.
+	// Ref: https://golang.org/src/crypto/aes/cipher_s390x.go#L39
+	if cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM) {
+		return true
+	}
+	return false
+}

--- a/internal/gcp/secret-manager.go
+++ b/internal/gcp/secret-manager.go
@@ -130,10 +130,14 @@ func (s *SecretManager) Create(ctx context.Context, name string, key key.Key) er
 		return err
 	}
 
+	encodedKey, err := key.MarshalText()
+	if err != nil {
+		return err
+	}
 	_, err = s.client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
 		Parent: secret.Name,
 		Payload: &secretmanagerpb.SecretPayload{
-			Data: []byte(key.String()),
+			Data: encodedKey,
 		},
 	})
 	if err != nil {
@@ -160,7 +164,7 @@ func (s *SecretManager) Get(ctx context.Context, name string) (key.Key, error) {
 		return key.Key{}, err
 	}
 
-	k, err := key.Parse(string(result.Payload.Data))
+	k, err := key.Parse(result.Payload.Data)
 	if err != nil {
 		s.logf("gcp: failed to parse key %q: %v", name, err)
 		return key.Key{}, err

--- a/internal/generic/client.go
+++ b/internal/generic/client.go
@@ -78,8 +78,13 @@ func (s *Store) Create(ctx context.Context, name string, key key.Key) error {
 	type Request struct {
 		Bytes []byte `json:"bytes"`
 	}
+	encodedKey, err := key.MarshalText()
+	if err != nil {
+		s.logf("generic: failed to encode key '%s': %v", name, err)
+		return err
+	}
 	body, err := json.Marshal(Request{
-		Bytes: []byte(key.String()),
+		Bytes: encodedKey,
 	})
 	if err != nil {
 		s.logf("generic: failed to create key %q: %v", name, err)
@@ -180,7 +185,7 @@ func (s *Store) Get(ctx context.Context, name string) (key.Key, error) {
 		return key.Key{}, errGetKey
 	}
 
-	k, err := key.Parse(string(response.Bytes))
+	k, err := key.Parse(response.Bytes)
 	if err != nil {
 		s.logf("generic: failed to parse key %q: %v", name, err)
 		return key.Key{}, err

--- a/internal/http/key-api.go
+++ b/internal/http/key-api.go
@@ -6,14 +6,17 @@ package http
 
 import (
 	"encoding/json"
+	"math/rand"
 	"net/http"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/cpu"
+	"github.com/minio/kes/internal/fips"
 	"github.com/minio/kes/internal/key"
-	"github.com/secure-io/sio-go/sioutil"
 )
 
 func createKey(mux *http.ServeMux, config *ServerConfig) API {
@@ -53,7 +56,18 @@ func createKey(mux *http.ServeMux, config *ServerConfig) API {
 			return
 		}
 
-		key := key.New(sioutil.MustRandom(key.Size))
+		var algorithm key.Algorithm
+		if fips.Enabled || cpu.HasAESGCM() {
+			algorithm = key.AES256_GCM_SHA256
+		} else {
+			algorithm = key.XCHACHA20_POLY1305
+		}
+
+		key, err := key.Random(algorithm, auth.Identify(r))
+		if err != nil {
+			Error(w, err)
+			return
+		}
 		if err = enclave.CreateKey(r.Context(), name, key); err != nil {
 			Error(w, err)
 			return
@@ -77,7 +91,8 @@ func importKey(mux *http.ServeMux, config *ServerConfig) API {
 		Timeout = 15 * time.Second
 	)
 	type Request struct {
-		Bytes []byte `json:"bytes"`
+		Bytes     []byte `json:"bytes"`
+		Algorithm string `json:"algorithm"`
 	}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w = audit(w, r, config.AuditLog.Log())
@@ -114,11 +129,30 @@ func importKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		if len(req.Bytes) != key.Size {
+
+		var algorithm key.Algorithm
+		switch key.Algorithm(req.Algorithm) {
+		case key.AES256_GCM_SHA256:
+			algorithm = key.AES256_GCM_SHA256
+		case key.XCHACHA20_POLY1305:
+			algorithm = key.XCHACHA20_POLY1305
+		case key.AlgorithmGeneric:
+			algorithm = key.AlgorithmGeneric
+		default:
+			Error(w, kes.NewError(http.StatusBadRequest, "invalid algorithm"))
+			return
+		}
+
+		if len(req.Bytes) != algorithm.KeySize() {
 			Error(w, kes.NewError(http.StatusBadRequest, "invalid key size"))
 			return
 		}
-		if err = enclave.CreateKey(r.Context(), name, key.New(req.Bytes)); err != nil {
+		key, err := key.New(algorithm, req.Bytes, auth.Identify(r))
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.CreateKey(r.Context(), name, key); err != nil {
 			Error(w, err)
 			return
 		}
@@ -240,8 +274,8 @@ func generateKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		dataKey, err := sioutil.Random(32)
-		if err != nil {
+		dataKey := make([]byte, 32)
+		if _, err = rand.Read(dataKey); err != nil {
 			Error(w, err)
 			return
 		}

--- a/internal/key/algorithm.go
+++ b/internal/key/algorithm.go
@@ -1,0 +1,40 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package key
+
+// Algorithm is a cryptographic algorithm that requires
+// a cryptographic key.
+type Algorithm string
+
+const (
+	// AlgorithmGeneric is a generic value that indicates
+	// that the key can be used with multiple algorithms.
+	AlgorithmGeneric Algorithm = ""
+
+	// AES256_GCM_SHA256 is an algorithm that uses HMAC-SHA256
+	// for key derivation and AES256-GCM for en/decryption.
+	AES256_GCM_SHA256 Algorithm = "AES256-GCM_SHA256"
+
+	// XCHACHA20_POLY1305 is an algorithm that uses HChaCha20
+	// for key derivation and ChaCha20-Poly1305 for en/decryption.
+	XCHACHA20_POLY1305 Algorithm = "XCHACHA20-POLY1305"
+)
+
+// String returns the Algorithm's string representation.
+func (a Algorithm) String() string { return string(a) }
+
+// KeySize returns the Algorithm's key size.
+func (a Algorithm) KeySize() int {
+	switch a {
+	case AES256_GCM_SHA256:
+		return 256 / 8
+	case XCHACHA20_POLY1305:
+		return 256 / 8
+	case AlgorithmGeneric:
+		return 256 / 8 // For generic/unknown keys, return 256 bit.
+	default:
+		return -1
+	}
+}

--- a/internal/key/ciphertext.go
+++ b/internal/key/ciphertext.go
@@ -1,0 +1,163 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package key
+
+import (
+	"encoding/json"
+
+	"github.com/minio/kes"
+	"github.com/tinylib/msgp/msgp"
+)
+
+// decodeCiphertext parses the given bytes as
+// ciphertext. If it fails to unmarshal the
+// given bytes, decodeCiphertext returns
+// ErrDecrypt.
+func decodeCiphertext(bytes []byte) (ciphertext, error) {
+	if len(bytes) == 0 {
+		return ciphertext{}, kes.ErrDecrypt
+	}
+
+	var c ciphertext
+	switch bytes[0] {
+	case 0x95: // msgp first byte
+		if err := c.UnmarshalBinary(bytes); err != nil {
+			return ciphertext{}, kes.ErrDecrypt
+		}
+	case 0x7b: // JSON first byte
+		if err := c.UnmarshalJSON(bytes); err != nil {
+			return ciphertext{}, kes.ErrDecrypt
+		}
+	default:
+		if err := c.UnmarshalBinary(bytes); err != nil {
+			if err = c.UnmarshalJSON(bytes); err != nil {
+				return ciphertext{}, kes.ErrDecrypt
+			}
+		}
+	}
+	return c, nil
+}
+
+// ciphertext is a structure that contains the encrypted
+// bytes and all relevant information to decrypt these
+// bytes again with a cryptographic key.
+type ciphertext struct {
+	Algorithm Algorithm
+	ID        string
+	IV        []byte
+	Nonce     []byte
+	Bytes     []byte
+}
+
+// MarshalBinary returns the ciphertext's binary representation.
+func (c *ciphertext) MarshalBinary() ([]byte, error) {
+	// We encode a ciphertext simply as message-pack
+	// flat array.
+	const Items = 5
+
+	var b []byte
+	b = msgp.AppendArrayHeader(b, Items)
+	b = msgp.AppendString(b, c.Algorithm.String())
+	b = msgp.AppendString(b, c.ID)
+	b = msgp.AppendBytes(b, c.IV)
+	b = msgp.AppendBytes(b, c.Nonce)
+	b = msgp.AppendBytes(b, c.Bytes)
+	return b, nil
+}
+
+// UnmarshalBinary parses b as binary-encoded ciphertext.
+func (c *ciphertext) UnmarshalBinary(b []byte) error {
+	const (
+		Items     = 5
+		IVSize    = 16
+		NonceSize = 12
+	)
+
+	items, b, err := msgp.ReadArrayHeaderBytes(b)
+	if err != nil {
+		return kes.ErrDecrypt
+	}
+	if items != Items {
+		return kes.ErrDecrypt
+	}
+	algorithm, b, err := msgp.ReadStringBytes(b)
+	if err != nil {
+		return kes.ErrDecrypt
+	}
+	id, b, err := msgp.ReadStringBytes(b)
+	if err != nil {
+		return kes.ErrDecrypt
+	}
+	var iv [IVSize]byte
+	b, err = msgp.ReadExactBytes(b, iv[:])
+	if err != nil {
+		return kes.ErrDecrypt
+	}
+	var nonce [NonceSize]byte
+	b, err = msgp.ReadExactBytes(b, nonce[:])
+	if err != nil {
+		return kes.ErrDecrypt
+	}
+	bytes, b, err := msgp.ReadBytesZC(b)
+	if err != nil {
+		return kes.ErrDecrypt
+	}
+	if len(b) != 0 {
+		return kes.ErrDecrypt
+	}
+
+	c.Algorithm = Algorithm(algorithm)
+	c.ID = id
+	c.IV = iv[:]
+	c.Nonce = nonce[:]
+	c.Bytes = clone(bytes...)
+	return nil
+}
+
+// UnmarshalJSON parses the given text as JSON-encoded
+// ciphertext.
+//
+// UnmarshalJSON provides backward-compatible unmarsahaling
+// of existing ciphertext. In the past, ciphertexts were
+// JSON-encoded. Now, ciphertexts are binary-encoded.
+// Therefore, there is no MarshalJSON implementation.
+func (c *ciphertext) UnmarshalJSON(text []byte) error {
+	const (
+		IVSize    = 16
+		NonceSize = 12
+
+		AES256GCM        = "AES-256-GCM-HMAC-SHA-256"
+		CHACHA20POLY1305 = "ChaCha20Poly1305"
+	)
+
+	type JSON struct {
+		Algorithm string `json:"aead"`
+		ID        string `json:"id,omitempty"`
+		IV        []byte `json:"iv"`
+		Nonce     []byte `json:"nonce"`
+		Bytes     []byte `json:"bytes"`
+	}
+	var value JSON
+	if err := json.Unmarshal(text, &value); err != nil {
+		return kes.ErrDecrypt
+	}
+
+	if value.Algorithm != AES256GCM && value.Algorithm != CHACHA20POLY1305 {
+		return kes.ErrDecrypt
+	}
+	if len(value.IV) != IVSize {
+		return kes.ErrDecrypt
+	}
+	if len(value.Nonce) != NonceSize {
+		return kes.ErrDecrypt
+	}
+
+	c.Algorithm = Algorithm(value.Algorithm)
+	c.ID = value.ID
+	c.IV = value.IV
+	c.Nonce = value.Nonce
+	c.Bytes = value.Bytes
+	return nil
+}

--- a/internal/key/key_test.go
+++ b/internal/key/key_test.go
@@ -6,56 +6,71 @@ package key
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/hex"
-	"net/http"
 	"testing"
+	"time"
 
 	"github.com/minio/kes"
-	"github.com/secure-io/sio-go/sioutil"
 )
 
-var keyStringTests = []struct {
-	Key    Key
-	String string
-}{
-	{Key: Key{}, String: `{"bytes":""}`},
-	{Key: mustDecodeKey("0000000000000000000000000000000000000000000000000000000000000001"), String: `{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE="}`},
-	{Key: mustDecodeKey("27caa63b2115d9c7b6ca8002fb9b7463b0923ff853329a4bed71e9027c9cfb41"), String: `{"bytes":"J8qmOyEV2ce2yoAC+5t0Y7CSP/hTMppL7XHpAnyc+0E="}`},
-}
-
-func TestKeyString(t *testing.T) {
-	for i, test := range keyStringTests {
-		if s := test.Key.String(); s != test.String {
-			t.Fatalf("Test %d: got %s - want %s", i, s, test.String)
-		}
-	}
-}
-
 var parseTests = []struct {
-	Key        Key
-	String     string
+	Raw string
+
+	Bytes     []byte
+	Algorithm Algorithm
+	CreatedAt time.Time
+	CreatedBy kes.Identity
+
 	ShouldFail bool
 }{
-	{Key: New(make([]byte, 32)), String: `{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`},
-	{Key: mustDecodeKey("0000000000000000000000000000000000000000000000000000000000000001"), String: `{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE="}`},
-	{Key: mustDecodeKey("27caa63b2115d9c7b6ca8002fb9b7463b0923ff853329a4bed71e9027c9cfb41"), String: `{"bytes":"J8qmOyEV2ce2yoAC+5t0Y7CSP/hTMppL7XHpAnyc+0E="}`},
-	{String: `"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, ShouldFail: true}, // Missing: {
-	{String: `{bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, ShouldFail: true}, // Missing first: "
-	{String: `{"bytes""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, ShouldFail: true}, // Missing: :
-	{String: `"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="`, ShouldFail: true},  // Missing final }
+	{Raw: `{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, Bytes: make([]byte, 32)},
+	{Raw: `{"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE="}`, Bytes: append(make([]byte, 31), 1)},
+	{Raw: `{"bytes":"J8qmOyEV2ce2yoAC+5t0Y7CSP/hTMppL7XHpAnyc+0E="}`, Bytes: mustDecodeHex("27caa63b2115d9c7b6ca8002fb9b7463b0923ff853329a4bed71e9027c9cfb41")},
+
+	{
+		Raw:       `{"bytes":"J8qmOyEV2ce2yoAC+5t0Y7CSP/hTMppL7XHpAnyc+0E=","algorithm":"AES256-GCM_SHA256","created_at":"2009-11-10T23:00:00Z","created_by":"40235905b7b83e0537a002db523cd019d6709b899adc249c957860cd00fa9f78"}`,
+		Bytes:     mustDecodeHex("27caa63b2115d9c7b6ca8002fb9b7463b0923ff853329a4bed71e9027c9cfb41"),
+		Algorithm: AES256_GCM_SHA256,
+		CreatedAt: mustDecodeTime("2009-11-10T23:00:00Z"),
+		CreatedBy: "40235905b7b83e0537a002db523cd019d6709b899adc249c957860cd00fa9f78",
+	},
+	{
+		Raw:       `{"bytes":"9ew6BCae3+13sniOUwttEJ62amg98YXc0OW0WBhNiCY=","algorithm":"XCHACHA20-POLY1305","created_at":"2009-11-10T23:00:00Z","created_by":"189d9de5331e3ee8abe9e4bd40d474ad621d79ccf83a711f6ac68050eb15a52a"}`,
+		Bytes:     mustDecodeHex("f5ec3a04269edfed77b2788e530b6d109eb66a683df185dcd0e5b458184d8826"),
+		Algorithm: XCHACHA20_POLY1305,
+		CreatedAt: mustDecodeTime("2009-11-10T23:00:00Z"),
+		CreatedBy: "189d9de5331e3ee8abe9e4bd40d474ad621d79ccf83a711f6ac68050eb15a52a",
+	},
+
+	{Raw: `"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, ShouldFail: true}, // Missing: {
+	{Raw: `{bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, ShouldFail: true}, // Missing first: "
+	{Raw: `{"bytes""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`, ShouldFail: true}, // Missing: :
+	{Raw: `"bytes":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="`, ShouldFail: true},  // Missing final }
 }
 
 func TestParse(t *testing.T) {
 	for i, test := range parseTests {
-		key, err := Parse(test.String)
+		key, err := Parse([]byte(test.Raw))
 		if err != nil && !test.ShouldFail {
-			t.Fatalf("Test %d: Failed to parse string: %v", i, err)
+			t.Fatalf("Test %d: Failed to parse key: %v", i, err)
 		}
 		if err == nil && test.ShouldFail {
-			t.Fatalf("Test %d: Parsing should have failed but it succeeded", i)
+			t.Fatalf("Test %d: Parsing should have failed but succeeded", i)
 		}
-		if err == nil && !key.Equal(test.Key) {
-			t.Fatalf("Test %d: got %x - want %x", i, key.bytes, test.Key.bytes)
+		if err == nil {
+			if !bytes.Equal(key.bytes, test.Bytes) {
+				t.Fatalf("Test %d: got %x - want %x", i, key.bytes, test.Bytes)
+			}
+			if key.Algorithm() != test.Algorithm {
+				t.Fatalf("Test %d: algorithm mismatch: got %v - want %v", i, key.Algorithm(), test.Algorithm)
+			}
+			if key.CreatedAt() != test.CreatedAt {
+				t.Fatalf("Test %d: created at mismatch: got %v - want %v", i, key.CreatedAt(), test.CreatedAt)
+			}
+			if key.CreatedBy() != test.CreatedBy {
+				t.Fatalf("Test %d: created by mismatch: got %v - want %v", i, key.CreatedBy(), test.CreatedBy)
+			}
 		}
 	}
 }
@@ -74,98 +89,131 @@ var keyWrapTests = []struct {
 }
 
 func TestKeyWrap(t *testing.T) {
-	key := New(sioutil.MustRandom(256 / 8))
-	for i, test := range keyWrapTests {
-		data := make([]byte, test.KeyLen)
-		ciphertext, err := key.Wrap(data, test.AssociatedData)
+	algorithms := []Algorithm{AES256_GCM_SHA256, XCHACHA20_POLY1305}
+	for _, a := range algorithms {
+		key, err := Random(a, "")
 		if err != nil {
-			t.Logf("Test %d: Secret: %x\n", i, key.bytes)
-			t.Fatalf("Test %d: Failed to wrap data: %v", i, err)
+			t.Fatalf("Failed to create key: %v", err)
 		}
-		plaintext, err := key.Unwrap(ciphertext, test.AssociatedData)
-		if err != nil {
-			t.Logf("Test %d: Secret: %x\n", i, key.bytes)
-			t.Fatalf("Test %d: Failed to unwrap data: %v", i, err)
-		}
-		if !bytes.Equal(data, plaintext) {
-			t.Logf("Test %d: Secret: %x\n", i, key.bytes)
-			t.Fatalf("Test %d: Original plaintext does not match unwrapped plaintext", i)
+		for i, test := range keyWrapTests {
+			data := make([]byte, test.KeyLen)
+			ciphertext, err := key.Wrap(data, test.AssociatedData)
+			if err != nil {
+				t.Logf("Test %d: Algorithm: %v , Secret: %x\n", i, key.Algorithm(), key.bytes)
+				t.Fatalf("Test %d: Failed to wrap data: %v", i, err)
+			}
+			plaintext, err := key.Unwrap(ciphertext, test.AssociatedData)
+			if err != nil {
+				t.Logf("Test %d: Algorithm: %v , Secret: %x\n", i, key.Algorithm(), key.bytes)
+				t.Fatalf("Test %d: Failed to unwrap data: %v", i, err)
+			}
+			if !bytes.Equal(data, plaintext) {
+				t.Logf("Test %d: Secret: %x\n", i, key.bytes)
+				t.Fatalf("Test %d: Original plaintext does not match unwrapped plaintext", i)
+			}
 		}
 	}
 }
 
 var keyUnwrapTests = []struct {
+	Algorithm      Algorithm
 	Ciphertext     string
 	AssociatedData []byte
-	ShouldFail     bool
-	Err            error
+
+	ShouldFail bool
+	Err        error
 }{
 	{ // 0
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 	},
 	{ // 1
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"ChaCha20Poly1305","iv":"s3fSZ6vk5m+DfQA8yZWeUg==","nonce":"8/kHMnCMs3h9NZ2a","bytes":"cw22HjLq/4cx8507SW4hhSrYbDiMuRao4b5+GE+XfbE="}`,
 		AssociatedData: nil,
 	},
 	{ // 2
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"ChaCha20Poly1305","id":"66687aadf862bd776c8fc18b8e9f8e20","iv":"EC0eZp7Pqt+LnkOae5xaAg==","nonce":"X1ejXKmH/ugFZPkk","bytes":"wIGBTDs6aOvsqJfekZ0PYRT/OHyFX2TXqeNwl1SLXOI="}`,
 		AssociatedData: nil,
 	},
 	{ // 3
+		Algorithm:      AES256_GCM_SHA256,
+		Ciphertext:     string(mustDecodeB64("lbFBRVMyNTYtR0NNX1NIQTI1NtkgNjY2ODdhYWRmODYyYmQ3NzZjOGZjMThiOGU5ZjhlMjDEEExv7LAd4oz0SaHZrX5LBufEDEKME1ow1CDfUFrqv8QgJuy7Sw+jVqz99TK1HV851LT3K4mwwDv46TB2ngWkAJQ=")),
+		AssociatedData: nil,
+	},
+	{ // 4
+		Algorithm:      XCHACHA20_POLY1305,
+		Ciphertext:     string(mustDecodeB64("lbJYQ0hBQ0hBMjAtUE9MWTEzMDXZIDY2Njg3YWFkZjg2MmJkNzc2YzhmYzE4YjhlOWY4ZTIwxBBAr+aptD4x2+qfOhiErbnkxAxYs8RmNC1JJXD1hiHEIJ2KqM0jjkME7ndx8nyVseesN83Np0rM5ejVUun+fNFu")),
+		AssociatedData: nil,
+	},
+
+	{ // 5
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // Invalid algorithm
-		Err:            kes.NewError(http.StatusUnprocessableEntity, "unsupported cryptographic algorithm"),
+		Err:            kes.ErrDecrypt,
 	},
-	{ // 4
+	{ // 6
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"EjOY4JKqjIrPmQ5z1KSR8zlhggY=","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid IV length
-		Err:            kes.NewError(http.StatusBadRequest, "invalid iv size"),
+		Err:            kes.ErrDecrypt,
 	},
-	{ // 5
+	{ // 7
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"ChaCha20Poly1305","iv":"s3fSZ6vk5m+DfQA8yZWeUg==","nonce":"SXAbms731/c=","bytes":"cw22HjLq/4cx8507SW4hhSrYbDiMuRao4b5+GE+XfbE="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid nonce length
-		Err:            kes.NewError(http.StatusBadRequest, "invalid nonce size"),
+		Err:            kes.ErrDecrypt,
 	},
-	{ // 6
+	{ // 8
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"efY+4kYF9n8=","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid nonce length
-		Err:            kes.NewError(http.StatusBadRequest, "invalid nonce size"),
+		Err:            kes.ErrDecrypt,
 	},
-	{ // 7
+	{ // 9
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256","iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"QTza1g5oX3f9cGJMbY1xJwWPj1F7R2VnNl6XpFKYQy0="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // ciphertext not authentic
 		Err:            kes.ErrDecrypt,
 	},
-	{ // 8
+	{ // 10
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"ChaCha20Poly1305","iv":"s3fSZ6vk5m+DfQA8yZWeUg==","nonce":"8/kHMnCMs3h9NZ2a","bytes":"TTi8pkO+Jh1JWAHvPxZeUk/iVoBPUCE4ZSVGBy3fW2s="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // ciphertext not authentic
 		Err:            kes.ErrDecrypt,
 	},
-	{ // 9
+	{ // 11
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256" "iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid JSON
-		Err:            kes.NewError(http.StatusBadRequest, "invalid ciphertext"),
+		Err:            kes.ErrDecrypt,
 	},
-	{ // 10
+	{ // 12
+		Algorithm:      AlgorithmGeneric,
 		Ciphertext:     `{"aead":"AES-256-GCM-HMAC-SHA-256", "id":"00010203040506070809101112131415", "iv":"xLxIN3tSCkg2xMafuvwUwg==","nonce":"gu0mGwUkwcvMEoi5","bytes":"WVgRjeIJm3w50C/l+y7y2i6mbNg5NCAqN1zvOYWZKmc="}`,
 		AssociatedData: nil,
 		ShouldFail:     true, // invalid key ID
-		Err:            kes.NewError(http.StatusBadRequest, "invalid ciphertext: key ID mismatch"),
+		Err:            kes.ErrDecrypt,
 	},
 }
 
 func TestKeyUnwrap(t *testing.T) {
-	key := New(make([]byte, 32))
 	Plaintext := make([]byte, 16)
 	for i, test := range keyUnwrapTests {
+		key, err := New(test.Algorithm, make([]byte, test.Algorithm.KeySize()), "")
+		if err != nil {
+			t.Fatalf("Test %d: Failed to create key: %v", i, err)
+		}
 		plaintext, err := key.Unwrap([]byte(test.Ciphertext), test.AssociatedData)
 		if err != nil && !test.ShouldFail {
 			t.Fatalf("Test %d: Failed to unwrap ciphertext: %v", i, err)
@@ -182,6 +230,14 @@ func TestKeyUnwrap(t *testing.T) {
 	}
 }
 
+func mustDecodeTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
 func mustDecodeHex(s string) []byte {
 	b, err := hex.DecodeString(s)
 	if err != nil {
@@ -190,4 +246,10 @@ func mustDecodeHex(s string) []byte {
 	return b
 }
 
-func mustDecodeKey(s string) Key { return New(mustDecodeHex(s)) }
+func mustDecodeB64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}


### PR DESCRIPTION
This commit moves from JSON-encoded
DEKs to binary-encoded DEKs.

Previously, generated JSON-encoded
DEKs can still be decrypted. Newly,
generated DEKs are now encoded in
a binary message-pack format.

This decreases the size of DEKs
roughly about 35%.

Further, this commit adds
algorithm-specific keys. In general,
a crypto. key should be specific for
one crypto. algorithm. For example,
`AES256-GCM_SHA256`.

A key that is specific for a particular
algorithm cannot be used in other algorithms.