### PR TITLE
CI: remove `golang-ci` issue excludes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,9 +24,6 @@ linters:
 
 issues:
   exclude-use-default: false
-  exclude:
-      - error strings should not be capitalized or end with punctuation or a newline
-      - should have comment           # TODO(aead): Remove once all exported ident. have comments!
 
 service:
   golangci-lint-version: 1.43.0 # use the fixed version to not introduce new linters unexpectedly

--- a/internal/auth/proxy.go
+++ b/internal/auth/proxy.go
@@ -17,6 +17,16 @@ import (
 	"github.com/minio/kes"
 )
 
+// A TLSProxy handles HTTP requests sent by a client through
+// a TLS proxy sitting between the client and the server.
+//
+// It verifies that the request actually came from a known
+// TLS proxy, extracts the client information attached by
+// proxy and modifies request based on the client information.
+//
+// In particular, it extracts the forwarded client IP, if any,
+// and adjusts the request TLS state with the forwarded client
+// certificate.
 type TLSProxy struct {
 	// CertHeader is the HTTP header key used to extract the
 	// client certificate forwarded by a TLS proxy. The TLS

--- a/internal/cli/alignment.go
+++ b/internal/cli/alignment.go
@@ -10,8 +10,13 @@ import (
 )
 
 const (
+	// AlignLeft aligns text to the left.
 	AlignLeft Alignment = iota
+
+	// AlignCenter aligns text to the middle.
 	AlignCenter
+
+	// AlignRight aligns text to the right.
 	AlignRight
 )
 

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -13,6 +13,9 @@ import (
 
 var errPrefix = color.RedString("Error: ")
 
+// Fatal formats writes an error prefix and the operands
+// to OS stderr. Then, Fatal terminates the program by
+// calling os.Exit(1).
 func Fatal(v ...interface{}) {
 	fmt.Fprint(os.Stderr, errPrefix)
 	fmt.Fprint(os.Stderr, v...)
@@ -20,6 +23,9 @@ func Fatal(v ...interface{}) {
 	os.Exit(1)
 }
 
+// Fatalf formats writes an error prefix and the operands,
+// formated according to the format specifier, to OS stderr.
+// Then, Fatalf terminates the program by calling os.Exit(1).
 func Fatalf(format string, v ...interface{}) {
 	fmt.Fprintf(os.Stderr, errPrefix+format+"\n", v...)
 	os.Exit(1)

--- a/internal/gcp/config.go
+++ b/internal/gcp/config.go
@@ -59,18 +59,30 @@ func (c Credentials) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// A Config structure is used to configure a GCP SecretManager
+// client.
 type Config struct {
+	// Endpoint is the GCP SecretManager endpoint.
 	Endpoint string
 
+	// ProjectID is the ID of the GCP project.
 	ProjectID string
 
+	// Credentials are the GCP credentials to
+	// access the SecretManager.
 	Credentials Credentials
 
+	// ErrorLog is an optional logger for errors
+	// that may occur when interacting with GCP
+	// SecretManager.
 	ErrorLog *log.Logger
 
 	lock sync.RWMutex
 }
 
+// Clone returns a shallow clone of c or nil if c is
+// nil. It is safe to clone a Config that is being used
+// concurrently.
 func (c *Config) Clone() *Config {
 	if c == nil {
 		return nil

--- a/internal/generic/client.go
+++ b/internal/generic/client.go
@@ -215,6 +215,8 @@ func (s *Store) List(ctx context.Context) (key.Iterator, error) {
 	}, nil
 }
 
+// Authenticate authentictes to the generic plugin server.
+// It returns any authentication error encountered, if any.
 func (s *Store) Authenticate() error {
 	config := &tls.Config{
 		MinVersion: tls.VersionTLS13,

--- a/internal/http/api.go
+++ b/internal/http/api.go
@@ -20,11 +20,12 @@ import (
 	"github.com/minio/kes/internal/sys"
 )
 
+// API describes a KES server API.
 type API struct {
-	Method  string
-	Path    string
-	MaxBody int64
-	Timeout time.Duration
+	Method  string        // The HTTP method
+	Path    string        // The URI API path.
+	MaxBody int64         // The max. body size the API accepts
+	Timeout time.Duration // The duration after which an API request times out.
 }
 
 // A ServerConfig structure is used to configure a

--- a/internal/http/flush.go
+++ b/internal/http/flush.go
@@ -63,6 +63,7 @@ func (w FlushWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// Flush sends any buffered data to the client.
 func (w FlushWriter) Flush() {
 	if w.f != nil {
 		w.f.Flush()

--- a/internal/sys/enclave.go
+++ b/internal/sys/enclave.go
@@ -36,6 +36,12 @@ type Enclave struct {
 	identities auth.IdentitySet
 }
 
+// Status returns the current state of the key store.
+//
+// If Status fails to reach the Store - e.g.
+// due to a network error - it returns a
+// StoreState with StoreUnreachable and no
+// error.
 func (e *Enclave) Status(ctx context.Context) (key.StoreState, error) { return e.keys.Status(ctx) }
 
 // CreateKey stores the given key if and only if no entry with

--- a/internal/sys/vault.go
+++ b/internal/sys/vault.go
@@ -10,6 +10,12 @@ import (
 	"github.com/minio/kes"
 )
 
+// A Vault manages a set of Enclaves.
+//
+// It is either in a sealed or unsealed state. When the
+// Vault is sealed it does not process any requests except
+// unseal requests. Once unsealed, Vault provides access
+// to existing enclaves.
 type Vault interface {
 	// Seal seals the Vault. Once sealed, any subsequent operation
 	// returns ErrSealed.

--- a/internal/vault/config.go
+++ b/internal/vault/config.go
@@ -11,7 +11,13 @@ import (
 )
 
 const (
+	// APIv1 is the Vault K/V secret engine API version 1.
+	// The v1 K/V secret engine does not support version'ed
+	// secrets.
 	APIv1 = "v1"
+
+	// APIv2 is the Vault K/V secret engine API version 2.
+	// The v1 K/V secret engine supports version'ed secrets.
 	APIv2 = "v2"
 )
 

--- a/internal/yml/types.go
+++ b/internal/yml/types.go
@@ -36,8 +36,11 @@ var ( // compiler check
 // Value returns the KES identity.
 func (i *Identity) Value() kes.Identity { return i.value }
 
+// MarshalYAML returns the Identity's YAML representation.
 func (i Identity) MarshalYAML() (interface{}, error) { return i.raw, nil }
 
+// UnmarshalYAML uses the unmarhsal function to unmarshal
+// a YAML block into the Identity.
 func (i *Identity) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var raw string
 	if err := unmarshal(&raw); err != nil {
@@ -70,10 +73,14 @@ var ( // compiler check
 // Value returns the plain string value.
 func (s *String) Value() string { return s.value }
 
+// Set sets the String value to v.
 func (s *String) Set(v string) { s.value = v }
 
+// MarshalYAML returns the String's YAML representation.
 func (s String) MarshalYAML() (interface{}, error) { return s.raw, nil }
 
+// UnmarshalYAML uses the unmarhsal function to unmarshal
+// a YAML block into the String.
 func (s *String) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var raw string
 	if err := unmarshal(&raw); err != nil {
@@ -107,8 +114,11 @@ var ( // compiler check
 // Value returns the time duration value.
 func (d *Duration) Value() time.Duration { return d.value }
 
+// MarshalYAML returns the Duration's YAML representation.
 func (d Duration) MarshalYAML() (interface{}, error) { return d.raw, nil }
 
+// UnmarshalYAML uses the unmarhsal function to unmarshal
+// a YAML block into the Duration.
 func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var raw string
 	if err := unmarshal(&raw); err != nil {

--- a/kestest/server.go
+++ b/kestest/server.go
@@ -81,6 +81,7 @@ func (s *Server) IssueClientCertificate(name string) tls.Certificate {
 	return issueCertificate(name, s.caCertificate, s.caPrivateKey, x509.ExtKeyUsageClientAuth)
 }
 
+// CAs returns the Server's root CAs.
 func (s *Server) CAs() *x509.CertPool {
 	if s.caCertificate == nil || s.caPrivateKey == nil {
 		s.caPrivateKey, s.caCertificate = newCA()


### PR DESCRIPTION
This commit enables all excluded issue-checks.
The excluded error format warning was unnecessary
anyway.
Further, all reported undocumented APIs are now
documented.