### PR TITLE
add `/v1/identity/self/describe` API

### DIFF
--- a/client.go
+++ b/client.go
@@ -327,6 +327,29 @@ func (c *Client) AssignPolicy(ctx context.Context, policy string, identity Ident
 	return enclave.AssignPolicy(ctx, policy, identity)
 }
 
+// DescribeIdentity returns an IdentityInfo describing the given identity.
+func (c *Client) DescribeIdentity(ctx context.Context, identity Identity) (*IdentityInfo, error) {
+	enclave := Enclave{
+		endpoints: c.Endpoints,
+		client:    retry(c.HTTPClient),
+	}
+	return enclave.DescribeIdentity(ctx, identity)
+}
+
+// DescribeSelf returns an IdentityInfo describing the identity
+// making the API request. It also returns the assigned policy,
+// if any.
+//
+// DescribeSelf allows an application to obtain identity and
+// policy information about itself.
+func (c *Client) DescribeSelf(ctx context.Context) (*IdentityInfo, *Policy, error) {
+	enclave := Enclave{
+		endpoints: c.Endpoints,
+		client:    retry(c.HTTPClient),
+	}
+	return enclave.DescribeSelf(ctx)
+}
+
 // DeleteIdentity removes the identity. Once removed, any
 // operation issued by this identity will fail with
 // ErrNotAllowed.

--- a/identity.go
+++ b/identity.go
@@ -33,10 +33,11 @@ func (id Identity) String() string { return string(id) }
 
 // IdentityInfo describes a KES identity.
 type IdentityInfo struct {
-	Identity  Identity  `json:"identity"`
-	Policy    string    `json:"policy"`     // Name of the associated policy
-	CreatedAt time.Time `json:"created_at"` // Point in time when the identity was created
-	CreatedBy Identity  `json:"created_by"` // Identity that created the identity
+	Identity  Identity
+	IsAdmin   bool      // Indicates whether the identity has admin privileges
+	Policy    string    // Name of the associated policy
+	CreatedAt time.Time // Point in time when the identity was created
+	CreatedBy Identity  // Identity that created the identity
 }
 
 // IdentityIterator iterates over a stream of IdentityInfo objects.
@@ -77,6 +78,7 @@ func (i *IdentityIterator) CreatedBy() Identity { return i.current.CreatedBy }
 func (i *IdentityIterator) Next() bool {
 	type Response struct {
 		Identity  Identity  `json:"identity"`
+		IsAdmin   bool      `json:"admin"`
 		Policy    string    `json:"policy"`
 		CreatedAt time.Time `json:"created_at"`
 		CreatedBy Identity  `json:"created_by"`
@@ -117,6 +119,7 @@ func (i *IdentityIterator) Next() bool {
 func (i *IdentityIterator) WriteTo(w io.Writer) (int64, error) {
 	type Response struct {
 		Identity  Identity  `json:"identity"`
+		Admin     bool      `json:"admin"`
 		Policy    string    `json:"policy,omitempty"`
 		CreatedAt time.Time `json:"created_at,omitempty"`
 		CreatedBy Identity  `json:"created_by,omitempty"`

--- a/internal/auth/identity.go
+++ b/internal/auth/identity.go
@@ -15,6 +15,10 @@ import (
 	"github.com/minio/kes"
 )
 
+// ErrIdentityNotFound is returned by an IdentitySet if a specified
+// identity does not exist.
+var ErrIdentityNotFound = kes.NewError(http.StatusNotFound, "identity does not exist")
+
 // Identify computes the identity of the given HTTP request.
 //
 // If the request was not sent over TLS or no client
@@ -48,10 +52,6 @@ func Identify(req *http.Request) kes.Identity {
 	return kes.Identity(hex.EncodeToString(h[:]))
 }
 
-// ErrNotAssigned is an error indicating that an identity is
-// not assigned resp. does not exist.
-var ErrNotAssigned = kes.NewError(http.StatusNotFound, "identity not assigned")
-
 // An IdentitySet is a set of identities that are assigned to policies.
 type IdentitySet interface {
 	// Admin returns the identity of the admin.
@@ -68,7 +68,7 @@ type IdentitySet interface {
 
 	// Get returns the IdentityInfo of an assigned identity.
 	//
-	// It returns ErrNotAssigned when there is no IdentityInfo
+	// It returns ErrIdentityNotFound when there is no IdentityInfo
 	// associated to the given identity.
 	Get(ctx context.Context, identity kes.Identity) (IdentityInfo, error)
 
@@ -120,6 +120,10 @@ type IdentityIterator interface {
 type IdentityInfo struct {
 	// Policy is the policy the identity is assigned to.
 	Policy string
+
+	// IsAdmin indicates whether the identity has admin
+	// privileges.
+	IsAdmin bool
 
 	// CreatedAt is the point in time when the identity
 	// has been assigned.

--- a/internal/http/api.go
+++ b/internal/http/api.go
@@ -91,6 +91,7 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 	config.APIs = append(config.APIs, deletePolicy(mux, config))
 
 	config.APIs = append(config.APIs, describeIdentity(mux, config))
+	config.APIs = append(config.APIs, selfDescribeIdentity(mux, config))
 	config.APIs = append(config.APIs, listIdentity(mux, config))
 	config.APIs = append(config.APIs, deleteIdentity(mux, config))
 

--- a/internal/sys/enclave.go
+++ b/internal/sys/enclave.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"net/http"
 
 	"github.com/minio/kes"
@@ -165,6 +166,9 @@ func (e *Enclave) VerifyRequest(r *http.Request) error {
 	}
 
 	info, err := e.GetIdentity(r.Context(), identity)
+	if errors.Is(err, auth.ErrIdentityNotFound) {
+		return kes.ErrNotAllowed
+	}
 	if err != nil {
 		return err
 	}

--- a/kestest/server_test.go
+++ b/kestest/server_test.go
@@ -1,4 +1,5 @@
 // Copyright 2022 - MinIO, Inc. All rights reserved.
+
 // Use of this source code is governed by the AGPLv3
 // license that can be found in the LICENSE file.
 
@@ -7,6 +8,9 @@ package kestest_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -229,10 +233,103 @@ func TestSetPolicy(t *testing.T) {
 	}
 }
 
+var selfDescribeTests = []struct {
+	Policy kes.Policy
+}{
+	{ // 0
+		Policy: kes.Policy{},
+	},
+	{ // 1
+		Policy: kes.Policy{Allow: []string{}, Deny: []string{}},
+	},
+	{ // 2
+		Policy: kes.Policy{
+			Allow: []string{
+				"/v1/key/create/my-key-*",
+				"/v1/key/generate/my-key-*",
+				"/v1/key/decrypt/my-key-*",
+				"/v1/key/delete/my-key-*",
+			},
+			Deny: []string{
+				"/v1/key/delete/my-key-prod-*",
+			},
+		},
+	},
+}
+
+func TestSelfDescribe(t *testing.T) {
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	server := kestest.NewServer()
+	defer server.Close()
+
+	client := server.Client()
+	info, policy, err := client.DescribeSelf(ctx)
+	if err != nil {
+		t.Fatalf("Failed to self-describe client: %v", err)
+	}
+	if !info.IsAdmin {
+		t.Fatalf("Identity hasn't admin privileges: got '%s' - want '%s'", info.Identity, server.Policy().Admin())
+	}
+	if admin := server.Policy().Admin(); info.Identity != admin {
+		t.Fatalf("Identity hasn't admin privileges: got '%s' - want '%s'", info.Identity, server.Policy().Admin())
+	}
+	if len(policy.Allow) != 0 || len(policy.Deny) != 0 {
+		t.Fatalf("Admin identity has a policy: %v", policy)
+	}
+
+	for i, test := range selfDescribeTests {
+		cert := server.IssueClientCertificate("self-describe test")
+		client = kes.NewClientWithConfig(server.URL, &tls.Config{
+			RootCAs:      server.CAs(),
+			Certificates: []tls.Certificate{cert},
+		})
+		policyName := "Test-" + strconv.Itoa(i)
+		server.Policy().Add(policyName, &test.Policy)
+		server.Policy().Assign(policyName, kestest.Identify(&cert))
+
+		info, policy, err = client.DescribeSelf(ctx)
+		if err != nil {
+			t.Fatalf("Test %d: failed to self-describe client: %v", i, err)
+		}
+		if info.IsAdmin {
+			t.Fatalf("Test %d: identity has admin privileges", i)
+		}
+		if info.Policy != policyName {
+			t.Fatalf("Test %d: policy name mismatch: got '%s' - want '%s'", i, info.Policy, policyName)
+		}
+		if id := kestest.Identify(&cert); info.Identity != id {
+			t.Fatalf("Test %d: identity mismatch: got '%v' - want '%v'", i, info.Identity, id)
+		}
+		if !equal(policy.Allow, test.Policy.Allow) {
+			t.Fatalf("Test %d: allow policy mismatch: got '%v' - want '%v'", i, policy.Allow, test.Policy.Allow)
+		}
+		if !equal(policy.Deny, test.Policy.Deny) {
+			t.Fatalf("Test %d: deny policy mismatch: got '%v' - want '%v'", i, policy.Deny, test.Policy.Deny)
+		}
+	}
+}
+
 func testingContext(t *testing.T) (context.Context, context.CancelFunc) {
 	deadline, ok := t.Deadline()
 	if ok {
 		return context.WithDeadline(context.Background(), deadline)
 	}
 	return context.WithCancel(context.Background())
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sort.Strings(a)
+	sort.Strings(b)
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This commit adds a new server API endpoint:
```
/v1/identity/self/describe
```

The server already exposes an API for obtaining
information about an identity:
```
/v1/identity/describe
```
The later one allows a client to query information
about arbitrary identities - as long as the client
has sufficient policy permissions to do so.

In contrast, the new `/v1/identity/self/describe`
API allows any client to request identity and policy
permissions of **itself**.

It does not allow any client to obtain identity / policy
information about any identity other the one making the
request.

With this API, a client can self-inspect its policy permissions.
For example, a client can first check whether it has sufficient
API permissions before sending a request.