### PR TITLE
add bulk decryption API `/v1/key/bulk/decrypt`

### DIFF
--- a/client.go
+++ b/client.go
@@ -252,6 +252,21 @@ func (c *Client) Decrypt(ctx context.Context, name string, ciphertext, context [
 	return enclave.Decrypt(ctx, name, ciphertext, context)
 }
 
+// DecryptAll decrypts all ciphertexts with the named key at the
+// KES server. It either returns all decrypted plaintexts or the
+// first decryption error.
+//
+// DecryptAll returns ErrKeyNotFound if the specified key does not
+// exist. It returns ErrDecrypt if any ciphertext has been modified
+// or a different context value was used.
+func (c *Client) DecryptAll(ctx context.Context, name string, ciphertexts ...CCP) ([]PCP, error) {
+	enclave := Enclave{
+		endpoints: c.Endpoints,
+		client:    retry(c.HTTPClient),
+	}
+	return enclave.DecryptAll(ctx, name, ciphertexts...)
+}
+
 // ListKeys lists all names of cryptographic keys that match the given
 // pattern. It returns a KeyIterator that iterates over all matched key
 // names.

--- a/client_test.go
+++ b/client_test.go
@@ -5,8 +5,6 @@
 package kes
 
 import (
-	"bytes"
-	"encoding/base64"
 	"testing"
 )
 
@@ -47,52 +45,4 @@ func TestEndpoint(t *testing.T) {
 			t.Fatalf("Test %d: endpoint url mismatch: got '%s' - want '%s'", i, url, test.URL)
 		}
 	}
-}
-
-var dekEncodeDecodeTests = []struct {
-	Key DEK
-}{
-	{
-		Key: DEK{},
-	},
-	{
-		Key: DEK{
-			Plaintext:  nil,
-			Ciphertext: mustDecodeB64("eyJhZWFkIjoiQUVTLTI1Ni1HQ00tSE1BQy1TSEEtMjU2IiwiaXYiOiJ3NmhLUFVNZXVtejZ5UlVZL29pTFVBPT0iLCJub25jZSI6IktMSEU3UE1jRGo2N2UweHkiLCJieXRlcyI6Ik1wUkhjQWJaTzZ1Sm5lUGJGcnpKTkxZOG9pdkxwTmlUcTNLZ0hWdWNGYkR2Y0RlbEh1c1lYT29zblJWVTZoSXIifQ=="),
-		},
-	},
-	{
-		Key: DEK{
-			Plaintext:  mustDecodeB64("GM2UvLXp/X8lzqq0mibFC0LayDCGlmTHQhYLj7qAy7Q="),
-			Ciphertext: mustDecodeB64("eyJhZWFkIjoiQUVTLTI1Ni1HQ00tSE1BQy1TSEEtMjU2IiwiaXYiOiJ3NmhLUFVNZXVtejZ5UlVZL29pTFVBPT0iLCJub25jZSI6IktMSEU3UE1jRGo2N2UweHkiLCJieXRlcyI6Ik1wUkhjQWJaTzZ1Sm5lUGJGcnpKTkxZOG9pdkxwTmlUcTNLZ0hWdWNGYkR2Y0RlbEh1c1lYT29zblJWVTZoSXIifQ=="),
-		},
-	},
-}
-
-func TestEncodeDecodeDEK(t *testing.T) {
-	for i, test := range dekEncodeDecodeTests {
-		text, err := test.Key.MarshalText()
-		if err != nil {
-			t.Fatalf("Test %d: failed to marshal DEK: %v", i, err)
-		}
-
-		var key DEK
-		if err = key.UnmarshalText(text); err != nil {
-			t.Fatalf("Test %d: failed to unmarshal DEK: %v", i, err)
-		}
-		if key.Plaintext != nil {
-			t.Fatalf("Test %d: unmarshaled DEK contains non-nil plaintext", i)
-		}
-		if !bytes.Equal(key.Ciphertext, test.Key.Ciphertext) {
-			t.Fatalf("Test %d: ciphertext mismatch: got %x - want %x", i, key.Ciphertext, test.Key.Ciphertext)
-		}
-	}
-}
-
-func mustDecodeB64(s string) []byte {
-	b, err := base64.StdEncoding.DecodeString(s)
-	if err != nil {
-		panic(err)
-	}
-	return b
 }

--- a/internal/http/api.go
+++ b/internal/http/api.go
@@ -81,6 +81,7 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 	config.APIs = append(config.APIs, generateKey(mux, config))
 	config.APIs = append(config.APIs, encryptKey(mux, config))
 	config.APIs = append(config.APIs, decryptKey(mux, config))
+	config.APIs = append(config.APIs, bulkDecryptKey(mux, config))
 	config.APIs = append(config.APIs, listKey(mux, config))
 
 	config.APIs = append(config.APIs, describePolicy(mux, config))


### PR DESCRIPTION
This commit adds a new bulk API:
```
/v1/key/bulk/decrypt
```

Now, a client can request the corresponding
plaintext / context pairs for multiple
ciphertext / context pairs in a single call.

Before, a client had to send each plaintext / context
pair to the server using the `/v1/key/decrypt` API.

The new bulk API expects an array of ciphertext / context
pairs. Each context is still optional but must match
the context used during encryption:
```json
[
  {
    "ciphertext": "...",
    "context":"..."
  },
  {
    "ciphertext":"..."
  },
  {
    "ciphertext":"...",
    "context":"..."
  }
]
```

It will respond either with an array of plaintexts
or the first decryption error. It only returns
plaintexts if and only if it decrypted
all ciphertexts successfully.
```json
[
  {
    "plaintext": "...",
  },
  {
    "plaintext":"..."
  },
  {
    "plaintext":"...",
  }
]
```

At the moment, the `/v1/key/bulk/decrypt` API limits
the number of ciphertext / context pairs to `1000`
within a single API call.