### PR TITLE
cmd: fix identity command indentation

### DIFF
--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -40,7 +40,7 @@ const identityCmdUsage = `Usage:
     kes identity <command>
 
 Commands:
-	new                      Create a new KES identity
+    new                      Create a new KES identity
     of                       Compute a KES identity
     ls                       List KES identities
     rm                       Remove a KES identity


### PR DESCRIPTION
This commit fixes a indentation issue
in the `kes identity new` command.
```
kes identity
Usage:
    kes identity <command>

Commands:
	new                      Create a new KES identity
    of                       Compute a KES identity
    ls                       List KES identities
    rm                       Remove a KES identity

Options:
    -h, --help               Print command line options
```

Fixes #211