### PR TITLE
add client-side functionality to detect server APIs

### DIFF
--- a/server.go
+++ b/server.go
@@ -12,3 +12,11 @@ type State struct {
 
 	UpTime time.Duration // The time the KES server has been up and running
 }
+
+// API describes a KES server API.
+type API struct {
+	Method  string        // The HTTP method
+	Path    string        // The API path without its arguments. For example: "/v1/status"
+	MaxBody int64         // The max. size of request bodies accepted
+	Timeout time.Duration // Amount of time after which request will time out
+}


### PR DESCRIPTION
This commit adds the client-side functionality to
fetch the server APIs. A client can now use
```
client.APIs(context.Context) ([]API, error)
```

It returns a list of server APIs. A client may
use this to determine whether the KES server
supports a particular API without complex
version negotiation logic.

Further, a graceful clients can fetch API information
like timeouts or max. request body sizes dynamically.