### PR TITLE
support `+build` build tag comments

### DIFF
--- a/internal/fips/fips.go
+++ b/internal/fips/fips.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build fips && linux && amd64
+// +build fips,linux,amd64
 
 package fips
 

--- a/internal/fips/nofips.go
+++ b/internal/fips/nofips.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build !fips
+// +build !fips
 
 package fips
 


### PR DESCRIPTION
This commit adds support for the
`+build` directive that was used
in older Go versions.

This change is needed for building
with Go1.16.6 due to a major issue
in Go1.17.x.