### PR TITLE
metric: add CPU and co-routine metric

### DIFF
--- a/client.go
+++ b/client.go
@@ -523,6 +523,8 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 		MetricErrorEvents   = "kes_log_error_events"
 		MetricResponseTime  = "kes_http_response_time"
 		MetricSystemUpTme   = "kes_system_up_time"
+		MetricSystemCPUs    = "kes_system_num_cpu"
+		MetricSystemThreads = "kes_system_num_threads"
 	)
 
 	var (
@@ -573,6 +575,10 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 			delete(metric.LatencyHistogram, 0) // Delete the artificial zero entry
 		case kind == dto.MetricType_GAUGE && name == MetricSystemUpTme:
 			metric.UpTime = time.Duration(rawMetric.GetGauge().GetValue()) * time.Second
+		case kind == dto.MetricType_GAUGE && name == MetricSystemCPUs:
+			metric.CPUs = int(rawMetric.GetGauge().GetValue())
+		case kind == dto.MetricType_GAUGE && name == MetricSystemThreads:
+			metric.Threads = int(rawMetric.GetGauge().GetValue())
 		}
 	}
 	return metric, nil

--- a/metric.go
+++ b/metric.go
@@ -41,6 +41,14 @@ type Metric struct {
 	LatencyHistogram map[time.Duration]uint64 `json:"kes_http_response_time"`
 
 	UpTime time.Duration `json:"kes_system_up_time"` // The time the KES server has been up and running
+
+	// The number of logical CPU cores usable by the server.
+	CPUs int `json:"kes_system_num_cpu"`
+
+	// The number of concurrent co-routines/threads that currently exists.
+	//
+	// It may not correspond to the number of OS threads.
+	Threads int `json:"kes_system_num_threads"`
 }
 
 // RequestN returns the total number of received requests.


### PR DESCRIPTION
This commit adds two more KES server
metrics:
 - The number of logical CPUs
 - The number of concurrent co-routines

These two metrics allows more insight
into CPU utilization. 