### PR TITLE
metric: expose usable CPUs

### DIFF
--- a/client.go
+++ b/client.go
@@ -524,6 +524,7 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 		MetricResponseTime      = "kes_http_response_time"
 		MetricSystemUpTme       = "kes_system_up_time"
 		MetricSystemCPUs        = "kes_system_num_cpu"
+		MetricSystemUsableCPUs  = "kes_system_num_cpu_used"
 		MetricSystemThreads     = "kes_system_num_threads"
 		MetricSystemHeapUsed    = "kes_system_mem_heap_used"
 		MetricSystemHeapObjects = "kes_system_mem_heap_objects"
@@ -580,6 +581,8 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 			metric.UpTime = time.Duration(rawMetric.GetGauge().GetValue()) * time.Second
 		case kind == dto.MetricType_GAUGE && name == MetricSystemCPUs:
 			metric.CPUs = int(rawMetric.GetGauge().GetValue())
+		case kind == dto.MetricType_GAUGE && name == MetricSystemUsableCPUs:
+			metric.UsableCPUs = int(rawMetric.GetGauge().GetValue())
 		case kind == dto.MetricType_GAUGE && name == MetricSystemThreads:
 			metric.Threads = int(rawMetric.GetGauge().GetValue())
 		case kind == dto.MetricType_GAUGE && name == MetricSystemHeapUsed:

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -77,7 +77,13 @@ func New() *Metrics {
 			Namespace: "kes",
 			Subsystem: "system",
 			Name:      "num_cpu",
-			Help:      "The number of logical CPUs usable by the server.",
+			Help:      "The number of logical CPUs available on the system. It may be larger than the number of usable CPUs.",
+		}),
+		numUsableCPUs: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "kes",
+			Subsystem: "system",
+			Name:      "num_cpu_used",
+			Help:      "The number of logical CPUs usable by the server. It may be smaller than the number of available CPUs.",
 		}),
 		numThreads: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "kes",
@@ -115,6 +121,7 @@ func New() *Metrics {
 	metrics.registry.MustRegister(metrics.auditLogEvents)
 	metrics.registry.MustRegister(metrics.upTimeInSeconds)
 	metrics.registry.MustRegister(metrics.numCPUs)
+	metrics.registry.MustRegister(metrics.numUsableCPUs)
 	metrics.registry.MustRegister(metrics.numThreads)
 	metrics.registry.MustRegister(metrics.memHeapUsed)
 	metrics.registry.MustRegister(metrics.memHeapObjects)
@@ -140,6 +147,7 @@ type Metrics struct {
 	startTime       time.Time // Used to compute the up time as upTime = now - startTime
 	upTimeInSeconds prometheus.Gauge
 	numCPUs         prometheus.Gauge
+	numUsableCPUs   prometheus.Gauge
 	numThreads      prometheus.Gauge
 
 	memHeapUsed    prometheus.Gauge
@@ -155,6 +163,7 @@ func (m *Metrics) EncodeTo(encoder expfmt.Encoder) error {
 
 	m.upTimeInSeconds.Set(time.Since(m.startTime).Truncate(10 * time.Millisecond).Seconds())
 	m.numCPUs.Set(float64(runtime.NumCPU()))
+	m.numUsableCPUs.Set(float64(runtime.GOMAXPROCS(0)))
 	m.numThreads.Set(float64(runtime.NumGoroutine()))
 	m.memHeapUsed.Set(float64(memStats.HeapAlloc))
 	m.memHeapObjects.Set(float64(memStats.HeapObjects))

--- a/metric.go
+++ b/metric.go
@@ -42,8 +42,22 @@ type Metric struct {
 
 	UpTime time.Duration `json:"kes_system_up_time"` // The time the KES server has been up and running
 
-	// The number of logical CPU cores usable by the server.
+	// The number of logical CPU cores available on the system.
+	//
+	// The number of available CPU cores may be larger than
+	// the number of cores usable by the server.
+	//
+	// If CPUs == UsableCPUs then the server can use the entire
+	// computing power available on the system.
 	CPUs int `json:"kes_system_num_cpu"`
+
+	// The number of logical CPU cores usable by the server.
+	//
+	// The number of usable CPU cores may be smaller than
+	// the number of available CPUs on the system. For
+	// instance, a set of CPU cores may be reserved for
+	// other tasks.
+	UsableCPUs int `json:"kes_system_num_cpu_used"`
 
 	// The number of concurrent co-routines/threads that currently exists.
 	//


### PR DESCRIPTION
This commit exposes the number of
usable CPUs - in addition to the
number of available CPU cores.

The number of available CPU cores
shows how many logical CPU cores
are present on the system.

However, the KES server may only
use a subset of these CPUs.
For example when `GOMAXPORCS` is set.

The number of usable CPU cores,
exposed by this commit, shows how
many logical CPU cores can be used
by the KES server.
It may be less then or equal to the
number of available CPUs.