### PR TITLE
use build information from `runtime/debug`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v3
@@ -29,7 +29,7 @@ jobs:
       env:
         GO111MODULE: on
       run: |
-         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
          $(go env GOPATH)/bin/golangci-lint run --config ./.golangci.yml
          go vet ./...
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,15 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -27,7 +27,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --skip-publish --skip-sign --rm-dist --snapshot

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,9 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
+      - '-tags="version={{.Version}}"'
     ldflags:
-      - "-s -w -X main.version={{.Version}}"
+      - "-s -w"
 
 archives:
   -

--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -16,13 +16,10 @@ import (
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/cli"
 	xhttp "github.com/minio/kes/internal/http"
+	"github.com/minio/kes/internal/sys"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/term"
 )
-
-// Use e.g.: go build -ldflags "-X main.version=v1.0.0"
-// to set the binary version.
-var version = "0.0.0-dev"
 
 type commands = map[string]func([]string)
 
@@ -89,7 +86,8 @@ func main() {
 		cli.Fatalf("%q is not a kes command. See 'kes --help'", cmd.Arg(1))
 	}
 	if showVersion {
-		fmt.Println("kes version", version)
+		buildInfo := sys.BinaryInfo()
+		fmt.Printf("kes %s (commit=%s)\n", buildInfo.Version, buildInfo.CommitID)
 		return
 	}
 	cmd.Usage()

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -230,7 +230,6 @@ func serverCmd(args []string) {
 	server := http.Server{
 		Addr: config.Address.Value(),
 		Handler: xhttp.NewServerMux(&xhttp.ServerConfig{
-			Version:  version,
 			Vault:    sys.NewStatelessVault(config.Admin.Identity.Value(), cache, policySet, identitySet),
 			Proxy:    proxy,
 			AuditLog: auditLog,

--- a/cmd/kes/update.go
+++ b/cmd/kes/update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/cheggaaa/pb/v3"
 	"github.com/minio/kes/internal/cli"
+	"github.com/minio/kes/internal/sys"
 	"github.com/minio/selfupdate"
 	flag "github.com/spf13/pflag"
 )
@@ -121,6 +122,7 @@ func updateInplace() error {
 		return err
 	}
 
+	version := sys.BinaryInfo().Version
 	current, err := semver.Make(version)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/kes
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go v0.65.0

--- a/internal/fortanix/keystore.go
+++ b/internal/fortanix/keystore.go
@@ -43,7 +43,6 @@ func (k APIKey) String() string { return "Basic " + string(k) }
 // KeyStore is a key store that persists and fetches
 // cryptographic keys from a Fortanix SDKMS.
 type KeyStore struct {
-
 	// Endpoint is the Fortanix SDKMS instance endpoint.
 	Endpoint string
 

--- a/internal/http/api.go
+++ b/internal/http/api.go
@@ -31,10 +31,6 @@ type API struct {
 // A ServerConfig structure is used to configure a
 // KES server.
 type ServerConfig struct {
-	// Version is the KES server version.
-	// If empty, it defaults to v0.0.0-dev.
-	Version string
-
 	// Certificate is TLS server certificate.
 	Certificate *Certificate
 

--- a/internal/http/generic-api.go
+++ b/internal/http/generic-api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/minio/kes/internal/sys"
 	"github.com/prometheus/common/expfmt"
 )
 
@@ -26,7 +27,7 @@ func version(mux *http.ServeMux, config *ServerConfig) API {
 			return
 		}
 		json.NewEncoder(w).Encode(Response{
-			Version: config.Version,
+			Version: sys.BinaryInfo().Version,
 		})
 	}
 	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
@@ -75,7 +76,7 @@ func status(mux *http.ServeMux, config *ServerConfig) API {
 
 		w.Header().Set("Content-Type", ContentType)
 		json.NewEncoder(w).Encode(Response{
-			Version: config.Version,
+			Version: sys.BinaryInfo().Version,
 			UpTime:  time.Since(startTime).Round(time.Second),
 		})
 	}

--- a/internal/sys/build.go
+++ b/internal/sys/build.go
@@ -1,0 +1,77 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package sys
+
+import (
+	"runtime/debug"
+	"strings"
+	"sync"
+
+	"github.com/blang/semver/v4"
+)
+
+// BuildInfo contains build information
+// about a Go binary.
+type BuildInfo struct {
+	Version  string
+	CommitID string
+}
+
+// BinaryInfo returns the BuildInfo of the
+// binary itself.
+//
+// It returns some default information
+// when no build information has been
+// compiled into the binary.
+func BinaryInfo() BuildInfo {
+	readBinaryOnce.Do(func() { binaryInfo = readBinaryInfo() })
+	return binaryInfo
+}
+
+func readBinaryInfo() BuildInfo {
+	const (
+		DefaultVersion  = "v0.0.0-dev"
+		DefaultCommitID = "<unknown>"
+	)
+	binaryInfo := BuildInfo{
+		Version:  DefaultVersion,
+		CommitID: DefaultCommitID,
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return binaryInfo
+	}
+
+	const (
+		TagKey         = "-tags"
+		GitRevisionKey = "vcs.revision"
+
+		VersionTag = "version="
+	)
+	for _, setting := range info.Settings {
+		if strings.HasPrefix(setting.Key, TagKey) {
+			keys := strings.Split(setting.Value, ",")
+			for _, key := range keys {
+				if strings.HasPrefix(key, VersionTag) {
+					v := strings.TrimPrefix(key, VersionTag)
+					if _, err := semver.ParseTolerant(v); err == nil {
+						binaryInfo.Version = v
+					}
+					break
+				}
+			}
+		}
+		if setting.Key == GitRevisionKey {
+			binaryInfo.CommitID = setting.Value
+		}
+	}
+	return binaryInfo
+}
+
+var (
+	readBinaryOnce sync.Once
+	binaryInfo     BuildInfo // protected by the sync.Once above
+)

--- a/kestest/server.go
+++ b/kestest/server.go
@@ -121,7 +121,6 @@ func (s *Server) start() {
 
 	serverCert := issueCertificate("kestest: server", s.caCertificate, s.caPrivateKey, x509.ExtKeyUsageServerAuth)
 	s.server = httptest.NewUnstartedServer(xhttp.NewServerMux(&xhttp.ServerConfig{
-		Version:  "v0.0.0-dev",
 		Vault:    sys.NewStatelessVault(Identify(&adminCert), store, s.policies.policySet(), s.policies.identitySet()),
 		Proxy:    nil,
 		AuditLog: auditLog,


### PR DESCRIPTION
This commit adds binary build information
exposed by the `runtime/debug` information
introduced by `Go 1.18`.

Since Go 1.18, the Go compiler compiles
build information into the binary.

This information is accessible using
`go version -m <binary-file>`

Now, KES uses this build info to expose
the binary version, commit ID, ...

Therefore, KES looks at the build tags,
specifically the `-tags` flag:

```
go build -trimpath -tags "version={version}" -o ~/go/bin/kes github.com/minio/kes/cmd/kes
```