### PR TITLE
fips: simplify TLS configuration

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -237,8 +237,10 @@ func serverCmd(args []string) {
 			Metrics:  metrics,
 		}),
 		TLSConfig: &tls.Config{
-			MinVersion:     tls.VersionTLS12,
-			GetCertificate: certificate.GetCertificate,
+			MinVersion:       tls.VersionTLS12,
+			GetCertificate:   certificate.GetCertificate,
+			CipherSuites:     fips.TLSCiphers(),
+			CurvePreferences: fips.TLSCurveIDs(),
 		},
 		ErrorLog: errorLog.Log(),
 
@@ -247,31 +249,6 @@ func serverCmd(args []string) {
 		IdleTimeout:       90 * time.Second,
 	}
 
-	// Limit the supported cipher suites to the secure TLS 1.2/1.3 subset - i.e. only ECDHE key exchange and only AEAD ciphers.
-	if fips.Enabled {
-		server.TLSConfig.CipherSuites = []uint16{
-			tls.TLS_AES_128_GCM_SHA256, // TLS 1.3
-			tls.TLS_AES_256_GCM_SHA384,
-
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // TLS 1.2
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		}
-	} else {
-		server.TLSConfig.CipherSuites = []uint16{
-			tls.TLS_AES_128_GCM_SHA256, // TLS 1.3
-			tls.TLS_AES_256_GCM_SHA384,
-			tls.TLS_CHACHA20_POLY1305_SHA256,
-
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // TLS 1.2
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-		}
-	}
 	switch strings.ToLower(mtlsAuthFlag) {
 	case "on":
 		server.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert

--- a/internal/fips/api.go
+++ b/internal/fips/api.go
@@ -4,6 +4,8 @@
 
 package fips
 
+import "crypto/tls"
+
 // Enabled indicates whether cryptographic primitives,
 // like AES or SHA-256, are implemented using a FIPS 140
 // certified module.
@@ -11,3 +13,49 @@ package fips
 // If FIPS-140 is enabled no non-NIST/FIPS approved
 // primitives must be used.
 const Enabled = enabled
+
+// TLSCiphers returns a list of supported TLS transport
+// cipher suite IDs.
+func TLSCiphers() []uint16 {
+	if Enabled {
+		return []uint16{
+			tls.TLS_AES_128_GCM_SHA256, // TLS 1.3
+			tls.TLS_AES_256_GCM_SHA384,
+
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // TLS 1.2
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		}
+	}
+	return []uint16{
+		tls.TLS_AES_128_GCM_SHA256, // TLS 1.3
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // TLS 1.2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	}
+}
+
+// TLSCurveIDs returns a list of supported elliptic curve IDs
+// in preference order.
+func TLSCurveIDs() []tls.CurveID {
+	if Enabled {
+		return []tls.CurveID{
+			tls.CurveP256,
+			tls.CurveP384, // Contant time since Go 1.18
+			tls.CurveP521, // Constat time since Go 1.18
+		}
+	}
+	return []tls.CurveID{
+		tls.X25519,
+		tls.CurveP256,
+		tls.CurveP384, // Contant time since Go 1.18
+		tls.CurveP521, // Contant time since Go 1.18
+	}
+}


### PR DESCRIPTION
This commit adds two new functions to the `fips` package:
 - `TLSCiphers()`
 - `TLSCurveIDs()`

The first one returns a list of supported TLS cipher suite IDs.
The list will differ depending upon running in FIPS-mode or not.
However, Go's TLS stack will still negotiate the "best" cipher
for the particular connection.

The second one returns a list of supported elliptic curve IDs
used by the TLS stack for ECDHE key exchange. The curve IDs are
returned in preference order and the Go TLS stack should choose
the first curve supported by the client.
In case of TLS 1.3, the curve used by the client may be used directly
(if supported) since one-way roundtrip.

The P-384 and P-521 curves are enabled now since the Go standard library
supports constant time implementations for these curves.