### PR TITLE
Bump go1.17 to 1.18 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as build
+FROM golang:1.18-alpine as build
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 


### PR DESCRIPTION
The minimum requirement is go 1.18, Build is failing on go 1.17!