### PR TITLE
cmd: improve `kes status`

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,6 +164,11 @@ func (c *Client) Status(ctx context.Context) (State, error) {
 	type Response struct {
 		Version string        `json:"version"`
 		UpTime  time.Duration `json:"uptime"`
+
+		CPUs       int    `json:"num_cpu"`
+		UsableCPUs int    `json:"num_cpu_used"`
+		HeapAlloc  uint64 `json:"mem_heap_used"`
+		StackAlloc uint64 `json:"mem_stack_used"`
 	}
 	var response Response
 	if err = json.NewDecoder(limitBody(resp, MaxResponseSize)).Decode(&response); err != nil {

--- a/server.go
+++ b/server.go
@@ -8,9 +8,17 @@ import "time"
 
 // State is a KES server status snapshot.
 type State struct {
-	Version string // The KES server version
+	Version string `json:"version"` // The KES server version
 
-	UpTime time.Duration // The time the KES server has been up and running
+	UpTime time.Duration `json:"uptime"` // The time the KES server has been up and running
+
+	CPUs int `json:"num_cpu"`
+
+	UsableCPUs int `json:"num_cpu_used"`
+
+	HeapAlloc uint64 `json:"num_heap_used"`
+
+	StackAlloc uint64 `json:"num_stack_used"`
 }
 
 // API describes a KES server API.


### PR DESCRIPTION
This commit improves the `kes status` command.
It exposes the number of CPUs and heap/stack memory
usage via the status API.

The `kes status` command now prints this CPU and memory
info.
```
● play.min.io:7373
  Version  0.19.2
  Uptime   2 days 4 hours
  Latency  562ms
  CPUs     4
  Memory
  · Heap   2 MiB
  · Stack  708 KiB
```

Further, this commit adds two flags to the `kes status` command:
 - `--api`
 - `--short`

The `--short` shows only summary information:
```
● play.min.io:7373
```

The `--api` flag lists all server APIs additionally to the
status information:
```
● play.min.io:7373
  Version  0.19.2
  Uptime   2 days 4 hours
  Latency  562ms
  CPUs     4
  Memory
  · Heap   2 MiB
  · Stack  708 KiB

  Method  API                          Timeout
  GET     /version                     15s
  GET     /v1/status                   15s
  GET     /v1/metrics                  15s
  GET     /v1/api                      15s
  POST    /v1/key/create/              15s
  POST    /v1/key/import/              15s
  DELETE  /v1/key/delete/              15s
  POST    /v1/key/generate/            15s
  POST    /v1/key/encrypt/             15s
  POST    /v1/key/decrypt/             15s
  POST    /v1/key/bulk/decrypt/        15s
  GET     /v1/key/list/                15s
  GET     /v1/policy/describe/         15s
  POST    /v1/policy/assign/           15s
  GET     /v1/policy/read/             15s
  POST    /v1/policy/write/            15s
  GET     /v1/policy/list/             15s
  DELETE  /v1/policy/delete/           15s
  GET     /v1/identity/describe/       15s
  GET     /v1/identity/self/describe   15s
  GET     /v1/identity/list/           15s
  DELETE  /v1/identity/delete/         15s
  GET     /v1/log/error                Inf
  GET     /v1/log/audit                Inf
  POST    /v1/enclave/create/          15s
  DELETE  /v1/enclave/delete/          15s
```