### PR TITLE
cmd: improve listing and output colorization

### DIFF
--- a/cmd/kes/color-option.go
+++ b/cmd/kes/color-option.go
@@ -1,0 +1,56 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	tui "github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	flag "github.com/spf13/pflag"
+)
+
+// colorOption is a CLI Flag that controls
+// terminal output colorization. It can be
+// set to one of the following values:
+//   · always
+//   · auto  (default)
+//   · never
+type colorOption struct {
+	value string
+}
+
+var _ flag.Value = (*colorOption)(nil)
+
+func (c *colorOption) Colorize() bool {
+	v := strings.ToLower(c.value)
+	return v == "always" || ((v == "auto" || v == "") && isTerm(os.Stdout))
+}
+
+func (c *colorOption) String() string { return c.value }
+
+func (c *colorOption) Set(value string) error {
+	switch strings.ToLower(value) {
+	case "always":
+		if p := tui.ColorProfile(); p == termenv.Ascii {
+			tui.SetColorProfile(termenv.ANSI256)
+		}
+		c.value = value
+		return nil
+	case "auto", "":
+		c.value = value
+		return nil
+	case "never":
+		tui.SetColorProfile(termenv.Ascii)
+		c.value = value
+		return nil
+	default:
+		return errors.New("invalid color option")
+	}
+}
+
+func (c *colorOption) Type() string { return "color option" }

--- a/identity.go
+++ b/identity.go
@@ -156,6 +156,43 @@ func (i *IdentityIterator) WriteTo(w io.Writer) (int64, error) {
 	}
 }
 
+// Values returns up to the next n IdentityInfo values. Subsequent
+// calls will yield further IdentityInfos if there are any.
+//
+// If n > 0, Values returns at most n IdentityInfo structs. In this case,
+// if Values returns an empty slice, it will return an error explaining
+// why. At the end of the listing, the error is io.EOF.
+//
+// If n <= 0, Values returns all remaining IdentityInfo records. In this
+// case, Values always closes the IdentityIterator. When it succeeds, it
+// returns a nil error, not io.EOF.
+func (i *IdentityIterator) Values(n int) ([]IdentityInfo, error) {
+	values := []IdentityInfo{}
+	if n > 0 && i.closed {
+		return values, io.EOF // Return early, don't alloc a slice
+	}
+	if n > 0 {
+		values = make([]IdentityInfo, 0, n)
+	}
+
+	var count int
+	for i.Next() {
+		values = append(values, i.Value())
+		count++
+
+		if n > 0 && count >= n {
+			return values, nil
+		}
+	}
+	if err := i.Close(); err != nil {
+		return values, err
+	}
+	if n > 0 && len(values) == 0 { // As by doc contract
+		return values, io.EOF
+	}
+	return values, nil
+}
+
 // Close closes the IdentityIterator and releases
 // any associated resources
 func (i *IdentityIterator) Close() error {


### PR DESCRIPTION
This commit simplifies the listing code
by introducing the `Values(n int)` method
on the `{Key|Identity|Policy}Iterator`.

Further, this commit adds a color option
flag that controls the colorization of the
output. For example:
```
$ kes key ls --color always | cat
```