### PR TITLE
cmd: add `kes identity info` command

### DIFF
--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -41,13 +41,14 @@ const identityCmdUsage = `Usage:
     kes identity <command>
 
 Commands:
-    new                      Create a new KES identity
-    of                       Compute a KES identity
-    ls                       List KES identities
-    rm                       Remove a KES identity
+    new                      Create a new KES identity.
+    of                       Compute a KES identity from a certificate.
+    info                     Get information about a KES identity.
+    ls                       List KES identities.
+    rm                       Remove a KES identity.
 
 Options:
-    -h, --help               Print command line options
+    -h, --help               Print command line options.
 `
 
 func identityCmd(args []string) {
@@ -55,10 +56,11 @@ func identityCmd(args []string) {
 	cmd.Usage = func() { fmt.Fprint(os.Stderr, identityCmdUsage) }
 
 	subCmds := commands{
-		"new": newIdentityCmd,
-		"of":  ofIdentityCmd,
-		"ls":  lsIdentityCmd,
-		"rm":  rmIdentityCmd,
+		"new":  newIdentityCmd,
+		"of":   ofIdentityCmd,
+		"info": infoIdentityCmd,
+		"ls":   lsIdentityCmd,
+		"rm":   rmIdentityCmd,
 	}
 
 	if len(args) < 2 {
@@ -322,6 +324,144 @@ func ofIdentityCmd(args []string) {
 				Name:     filename,
 				Identity: identity,
 			})
+		}
+	}
+}
+
+const infoIdentityCmdUsage = `Usage:
+    kes identity info [options] [<identity>]
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+        --json               Print identity information in JSON format.
+        --color <when>       Specify when to use colored output. The automatic
+                             mode only enables colors if an interactive terminal
+                             is detected - colors are automatically disabled if
+                             the output goes to a pipe.
+                             Possible values: *auto*, never, always.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes identity info
+    $ kes identity info 3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22
+`
+
+func infoIdentityCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprintf(os.Stderr, infoIdentityCmdUsage) }
+
+	var (
+		jsonFlag           bool
+		colorFlag          colorOption
+		insecureSkipVerify bool
+	)
+	cmd.BoolVar(&jsonFlag, "json", false, "Print policy information in JSON format")
+	cmd.Var(&colorFlag, "color", "Specify when to use colored output")
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes policy ls --help'", err)
+	}
+
+	if cmd.NArg() > 1 {
+		cli.Fatal("too many arguments. See 'kes identity info --help'")
+	}
+
+	ctx, cancelCtx := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancelCtx()
+
+	var faint, identityStyle, policyStyle, dotAllowStyle, dotDenyStyle tui.Style
+	if colorFlag.Colorize() {
+		const (
+			ColorIdentity tui.Color = "#2e42d1"
+			ColorPolicy   tui.Color = "#d1bd2e"
+			ColorDotAllow tui.Color = "#00d700"
+			ColorDotDeny  tui.Color = "#d70000"
+		)
+		faint = faint.Faint(true).Bold(true)
+		identityStyle = identityStyle.Foreground(ColorIdentity)
+		policyStyle = policyStyle.Foreground(ColorPolicy)
+		dotAllowStyle = dotAllowStyle.Foreground(ColorDotAllow)
+		dotDenyStyle = dotDenyStyle.Foreground(ColorDotDeny)
+	}
+
+	client := newClient(insecureSkipVerify)
+	if cmd.NArg() == 0 {
+		info, policy, err := client.DescribeSelf(ctx)
+		if err != nil {
+			cli.Fatal(err)
+		}
+		year, month, day := info.CreatedAt.Date()
+		hour, min, sec := info.CreatedAt.Clock()
+
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Identity")),
+			identityStyle.Render(info.Identity.String()),
+		)
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Created At")),
+			fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec),
+		)
+		if info.IsAdmin {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Role")), "Admin")
+		} else {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Role")), "User")
+		}
+		if !info.CreatedBy.IsUnknown() {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Created By")), info.CreatedBy)
+		}
+		if info.Policy != "" {
+			year, month, day := policy.Info.CreatedAt.Date()
+			hour, min, sec := policy.Info.CreatedAt.Clock()
+
+			fmt.Println()
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Policy")), policyStyle.Render(info.Policy))
+			fmt.Println(
+				faint.Render(fmt.Sprintf("%-11s", "Created At")),
+				fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec),
+			)
+			if len(policy.Allow) > 0 {
+				fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Allow")))
+				for _, allow := range policy.Allow {
+					fmt.Println(fmt.Sprintf("%-11s", " "), dotAllowStyle.Render("·"), allow)
+				}
+			}
+			if len(policy.Deny) > 0 {
+				fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Deny")))
+				for _, deny := range policy.Deny {
+					fmt.Println(fmt.Sprintf("%-11s", " "), dotDenyStyle.Render("·"), deny)
+				}
+			}
+		}
+	} else {
+		info, err := client.DescribeIdentity(ctx, kes.Identity(cmd.Arg(0)))
+		if err != nil {
+			cli.Fatal(err)
+		}
+		year, month, day := info.CreatedAt.Date()
+		hour, min, sec := info.CreatedAt.Clock()
+
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Identity")),
+			identityStyle.Render(info.Identity.String()),
+		)
+		if info.Policy != "" {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Policy")), policyStyle.Render(info.Policy))
+		}
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Created At")),
+			fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec),
+		)
+		if info.IsAdmin {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Role")), "Admin")
+		} else {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Role")), "User")
+		}
+		if !info.CreatedBy.IsUnknown() {
+			fmt.Println(faint.Render(fmt.Sprintf("%-11s", "Created By")), info.CreatedBy)
 		}
 	}
 }

--- a/enclave.go
+++ b/enclave.go
@@ -531,8 +531,10 @@ func (e *Enclave) DescribeSelf(ctx context.Context) (*IdentityInfo, *Policy, err
 		MaxResponseSize = 1 << 20 // 1 MiB
 	)
 	type InlinePolicy struct {
-		Allow []string `json:"allow"`
-		Deny  []string `json:"deny"`
+		Allow     []string  `json:"allow"`
+		Deny      []string  `json:"deny"`
+		CreatedAt time.Time `json:"created_at"`
+		CreatedBy Identity  `json:"created_by"`
 	}
 	type Response struct {
 		Identity   Identity     `json:"identity"`
@@ -564,6 +566,11 @@ func (e *Enclave) DescribeSelf(ctx context.Context) (*IdentityInfo, *Policy, err
 	policy := &Policy{
 		Allow: response.Policy.Allow,
 		Deny:  response.Policy.Deny,
+		Info: PolicyInfo{
+			Name:      response.PolicyName,
+			CreatedAt: response.Policy.CreatedAt,
+			CreatedBy: response.Policy.CreatedBy,
+		},
 	}
 	return info, policy, nil
 }

--- a/internal/http/identity-api.go
+++ b/internal/http/identity-api.go
@@ -88,17 +88,17 @@ func selfDescribeIdentity(mux *http.ServeMux, config *ServerConfig) API {
 		Timeout = 15 * time.Second
 	)
 	type InlinePolicy struct {
-		Allow []string
-		Deny  []string
-	}
-	type Response struct {
-		Identity kes.Identity `json:"identity"`
-
-		IsAdmin    bool   `json:"admin"`
-		PolicyName string `json:"policy_name,omitempty"`
-
+		Allow     []string     `json:"allow,omitempty"`
+		Deny      []string     `json:"deny,omitempty"`
 		CreatedAt time.Time    `json:"created_at,omitempty"`
 		CreatedBy kes.Identity `json:"created_by,omitempty"`
+	}
+	type Response struct {
+		Identity   kes.Identity `json:"identity"`
+		IsAdmin    bool         `json:"admin,omitempty"`
+		PolicyName string       `json:"policy_name,omitempty"`
+		CreatedAt  time.Time    `json:"created_at,omitempty"`
+		CreatedBy  kes.Identity `json:"created_by,omitempty"`
 
 		Policy InlinePolicy `json:"policy"`
 	}
@@ -144,8 +144,10 @@ func selfDescribeIdentity(mux *http.ServeMux, config *ServerConfig) API {
 			CreatedAt:  info.CreatedAt,
 			CreatedBy:  info.CreatedBy,
 			Policy: InlinePolicy{
-				Allow: policy.Allow,
-				Deny:  policy.Deny,
+				Allow:     policy.Allow,
+				Deny:      policy.Deny,
+				CreatedAt: policy.CreatedAt,
+				CreatedBy: policy.CreatedBy,
 			},
 		})
 	}


### PR DESCRIPTION
This commit adds the `kes identity info` command.
If no identity argument is passed, `info` fetches
information about the client identity itself via
the `/v1/identity/self/describe` API. The output
mainly differs for admins and regular users.

```
$ kes identity info
Identity    c40bca7bfa2e4e92cd61f56580b9b7f2e5c356b6443ca6960df877ecce2e8016
Created At  2022-06-28 10:39:33
Role        User
Created By  3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22

Policy      minio
Created At  2022-06-28 10:30:21
Allow
            · /v1/key/create/*
            · /v1/key/generate/*
            · /v1/key/decrypt/*
            · /v1/key/bulk/decrypt/*
Deny
            · /v1/key/decrypt/my-internal*
```

```
$ kes identity info
Identity    3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22
Created At  2022-06-20 12:32:28
Role        Admin
```

If an identity argument is passed, `info` fetches
information about the specified identity:
```
$ kes identity info c40bca7bfa2e4e92cd61f56580b9b7f2e5c356b6443ca6960df877ecce2e8016
Identity    c40bca7bfa2e4e92cd61f56580b9b7f2e5c356b6443ca6960df877ecce2e8016
Policy      minio
Created At  2022-06-28 10:39:33
Role        User
Created By  3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22
```

***

Further, the `/v1/identity/self/describe` API now also returns the
policy created_at and created_by information if a policy is assigned.