### PR TITLE
cmd: add `kes policy info` command

### DIFF
--- a/client.go
+++ b/client.go
@@ -353,6 +353,16 @@ func (c *Client) SetPolicy(ctx context.Context, name string, policy *Policy) err
 	return enclave.SetPolicy(ctx, name, policy)
 }
 
+// DescribePolicy returns the PolicyInfo for the given policy.
+// It returns ErrPolicyNotFound if no such policy exists.
+func (c *Client) DescribePolicy(ctx context.Context, name string) (*PolicyInfo, error) {
+	enclave := Enclave{
+		endpoints: c.Endpoints,
+		client:    retry(c.HTTPClient),
+	}
+	return enclave.DescribePolicy(ctx, name)
+}
+
 // GetPolicy returns the policy with the given name.
 // It returns ErrPolicyNotFound if no such policy
 // exists.

--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -513,11 +513,10 @@ func lsIdentityCmd(args []string) {
 		pattern = cmd.Arg(0)
 	}
 
-	client := newClient(insecureSkipVerify)
-
 	ctx, cancelCtx := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancelCtx()
 
+	client := newClient(insecureSkipVerify)
 	identities, err := client.ListIdentities(ctx, pattern)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -526,6 +525,7 @@ func lsIdentityCmd(args []string) {
 		cli.Fatalf("failed to list identities: %v", err)
 	}
 	defer identities.Close()
+
 	if jsonFlag {
 		if _, err = identities.WriteTo(os.Stdout); err != nil {
 			cli.Fatal(err)


### PR DESCRIPTION
This commit adds the `kes policy info` command.
It prints information about a KES policy.

Further, this commit adds the SDK function
`DescribePolicy` that calls the `/v1/policy/describe`
API which already exists.

```
$ kes policy info minio
Name        minio
Date        2022-06-22 11:40:08
Created by  3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22
```