### PR TITLE
improve timer usage by re-using them

### DIFF
--- a/internal/http/retry.go
+++ b/internal/http/retry.go
@@ -186,6 +186,9 @@ func (r *Retry) Do(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
 	resp, err := r.Client.Do(req)
 	for N > 0 && (isTemporary(err) || (resp != nil && resp.StatusCode >= http.StatusInternalServerError)) {
 		N--
@@ -199,17 +202,15 @@ func (r *Retry) Do(req *http.Request) (*http.Response, error) {
 			delay = Delay + time.Duration(rand.Int63n(Jitter.Milliseconds()))*time.Millisecond
 		}
 
-		timer := time.NewTimer(delay)
+		timer.Reset(delay)
 		select {
 		case <-req.Context().Done():
-			timer.Stop()
 			return nil, &url.Error{
 				Op:  req.Method,
 				URL: req.URL.String(),
 				Err: req.Context().Err(),
 			}
 		case <-timer.C:
-			timer.Stop()
 		}
 
 		// If there is a body we have to reset it. Otherwise, we may send

--- a/internal/http/tls.go
+++ b/internal/http/tls.go
@@ -89,12 +89,15 @@ func (c *Certificate) ReloadAfter(ctx context.Context, interval time.Duration) {
 		return
 	}
 
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
 	var lastReloadErr error
 	for {
-		timer := time.NewTimer(interval)
+		timer.Reset(interval) // Set reload interval.
+
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return
 		case <-timer.C:
 		}


### PR DESCRIPTION
timers can trickle memory alloc quite
sharply over a period of time for days.

Since the memory build up is so slow,
the buildup is not easily visible,
additionally there is a cost to always
invoking runtime timer in a loop.

This PR is an attempt to address this
by reusing the timer by creating it
once and making sure to use the right
amount of "Reset()" to wait for expected
lengths.

Additionally fixes a timer leak in
ReloadAfter() certificate reload function.