### PR TITLE
build: fix semver release information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
-      - '-tags="version={{.Version}}"'
+      - --tags=version=v{{.Version}}
     ldflags:
       - "-s -w"
 


### PR DESCRIPTION
This commit fixes a bug in the release process.
Before, goreleaser included the tag `"version=x.y.z"`
(including the quotes).

This caused the KES build info to not report any version
information.

For example the KES release `v0.19.4` includes the tag:
```
build	-tags="\"version=0.19.4\""
```
However, `kes -v` reports a dev version.

Now, goreleaser includes the semver version information
correctly without any quotes.