### PR TITLE
tls: add support for TLS reverse proxies to stateful server

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -411,6 +411,27 @@ func statefullServer(path string, serverConfig serverConfig) {
 	}
 	certificate.ErrorLog = errorLog
 
+	clientAuth := tls.RequireAnyClientCert
+	if init.VerifyClientCerts.Value() {
+		clientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	var proxy *auth.TLSProxy
+	if len(init.ProxyIdentities) != 0 {
+		proxy = &auth.TLSProxy{
+			CertHeader: http.CanonicalHeaderKey(init.ProxyClientCert.Value()),
+		}
+		if clientAuth == tls.RequireAndVerifyClientCert || clientAuth == tls.VerifyClientCertIfGiven {
+			proxy.VerifyOptions = new(x509.VerifyOptions)
+		}
+		for _, identity := range init.ProxyIdentities {
+			if !identity.Value().IsUnknown() {
+				proxy.Add(identity.Value())
+			}
+		}
+	}
+	fmt.Println(proxy)
+
 	vault, err := fs.Open(path, errorLog.Log())
 	if err != nil {
 		cli.Fatalf("failed to initialize vault: %v", err)
@@ -420,16 +441,11 @@ func statefullServer(path string, serverConfig serverConfig) {
 	errorLog.Add(metrics.ErrorEventCounter())
 	auditLog.Add(metrics.AuditEventCounter())
 
-	clientAuth := tls.RequireAnyClientCert
-	if init.VerifyClientCerts.Value() {
-		clientAuth = tls.RequireAndVerifyClientCert
-	}
-
 	server := http.Server{
 		Addr: serverConfig.Address,
 		Handler: xhttp.NewServerMux(&xhttp.ServerConfig{
 			Vault:    vault,
-			Proxy:    nil,
+			Proxy:    proxy,
 			AuditLog: auditLog,
 			ErrorLog: errorLog,
 			Metrics:  metrics,

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fatih/color"
+	tui "github.com/charmbracelet/lipgloss"
 )
 
-var errPrefix = color.RedString("Error: ")
+var errPrefix = tui.NewStyle().Foreground(tui.Color("#ac0000")).Render("Error: ")
 
 // Fatal writes an error prefix and the operands
 // to OS stderr. Then, Fatal terminates the program by

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -28,6 +28,13 @@ type InitConfig struct {
 		Certificate yml.String `yaml:"cert"`
 		Password    yml.String `yaml:"password"`
 
+		Proxy struct {
+			Identity []yml.Identity `yaml:"identity"`
+			Header   struct {
+				ClientCert yml.String `yaml:"cert"`
+			} `yaml:"header"`
+		} `yaml:"proxy"`
+
 		Client struct {
 			VerifyCerts yml.Bool `yaml:"verify_cert"`
 		} `yaml:"client"`

--- a/internal/sys/fs/init.go
+++ b/internal/sys/fs/init.go
@@ -42,6 +42,10 @@ type InitConfig struct {
 	Password yml.String
 
 	VerifyClientCerts yml.Bool
+
+	ProxyIdentities []yml.Identity
+
+	ProxyClientCert yml.String
 }
 
 // ReadInitConfig reads and parses the InitConfig YAML representation
@@ -62,7 +66,13 @@ func ReadInitConfig(filename string) (*InitConfig, error) {
 			PrivateKey  yml.String `yaml:"key"`
 			Certificate yml.String `yaml:"cert"`
 			Password    yml.String `yaml:"password"`
-			Client      struct {
+			Proxy       struct {
+				Identity []yml.Identity `yaml:"identity"`
+				Header   struct {
+					ClientCert yml.String `yaml:"cert"`
+				} `yaml:"header"`
+			} `yaml:"proxy"`
+			Client struct {
 				VerifyCerts yml.Bool `yaml:"verify_cert"`
 			} `yaml:"client"`
 		} `yaml:"tls"`
@@ -83,6 +93,8 @@ func ReadInitConfig(filename string) (*InitConfig, error) {
 		Certificate:       config.TLS.Certificate,
 		Password:          config.TLS.Password,
 		VerifyClientCerts: config.TLS.Client.VerifyCerts,
+		ProxyIdentities:   config.TLS.Proxy.Identity,
+		ProxyClientCert:   config.TLS.Proxy.Header.ClientCert,
 	}, nil
 }
 
@@ -104,7 +116,13 @@ func WriteInitConfig(filename string, config *InitConfig) error {
 			PrivateKey  yml.String `yaml:"key"`
 			Certificate yml.String `yaml:"cert"`
 			Password    yml.String `yaml:"password"`
-			Client      struct {
+			Proxy       struct {
+				Identity []yml.Identity `yaml:"identity"`
+				Header   struct {
+					ClientCert yml.String `yaml:"cert"`
+				} `yaml:"header"`
+			} `yaml:"proxy"`
+			Client struct {
 				VerifyCerts yml.Bool `yaml:"verify_cert"`
 			} `yaml:"client"`
 		} `yaml:"tls"`
@@ -118,6 +136,8 @@ func WriteInitConfig(filename string, config *InitConfig) error {
 	c.TLS.Certificate = config.Certificate
 	c.TLS.Password = config.Password
 	c.TLS.Client.VerifyCerts = config.VerifyClientCerts
+	c.TLS.Proxy.Identity = config.ProxyIdentities
+	c.TLS.Proxy.Header.ClientCert = config.ProxyClientCert
 	return yaml.NewEncoder(f).Encode(c)
 }
 


### PR DESCRIPTION
This commit adds support for a TLS reverse proxy for stateful
servers. The TLS proxy has to behave like for a stateless server.

For more information around TLS reverse proxies and KES see:
https://github.com/minio/kes/wiki/TLS-Proxy