### PR TITLE
add OS and CPU arch to status API

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,6 +163,8 @@ func (c *Client) Status(ctx context.Context) (State, error) {
 
 	type Response struct {
 		Version string        `json:"version"`
+		OS      string        `json:"os"`
+		Arch    string        `json:"arch"`
 		UpTime  time.Duration `json:"uptime"`
 
 		CPUs       int    `json:"num_cpu"`

--- a/cmd/kes/status.go
+++ b/cmd/kes/status.go
@@ -150,8 +150,13 @@ func statusCmd(args []string) {
 			latency.Round(time.Millisecond),
 		)
 		fmt.Println(
+			faint.Render(fmt.Sprintf("  %-8s", "OS")),
+			status.OS,
+		)
+		fmt.Println(
 			faint.Render(fmt.Sprintf("  %-8s", "CPUs")),
 			strconv.Itoa(status.UsableCPUs),
+			status.Arch,
 		)
 		fmt.Println(faint.Render(fmt.Sprintf("  %-8s", "Memory")))
 		fmt.Println(

--- a/internal/http/generic-api.go
+++ b/internal/http/generic-api.go
@@ -50,6 +50,8 @@ func status(mux *http.ServeMux, config *ServerConfig) API {
 	)
 	type Response struct {
 		Version string        `json:"version"`
+		OS      string        `json:"os"`
+		Arch    string        `json:"arch"`
 		UpTime  time.Duration `json:"uptime"`
 
 		CPUs       int    `json:"num_cpu"`
@@ -86,6 +88,8 @@ func status(mux *http.ServeMux, config *ServerConfig) API {
 		w.Header().Set("Content-Type", ContentType)
 		json.NewEncoder(w).Encode(Response{
 			Version: sys.BinaryInfo().Version,
+			OS:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
 			UpTime:  time.Since(startTime).Round(time.Second),
 
 			CPUs:       runtime.NumCPU(),

--- a/server.go
+++ b/server.go
@@ -8,17 +8,14 @@ import "time"
 
 // State is a KES server status snapshot.
 type State struct {
-	Version string `json:"version"` // The KES server version
-
-	UpTime time.Duration `json:"uptime"` // The time the KES server has been up and running
-
-	CPUs int `json:"num_cpu"`
-
-	UsableCPUs int `json:"num_cpu_used"`
-
-	HeapAlloc uint64 `json:"num_heap_used"`
-
-	StackAlloc uint64 `json:"num_stack_used"`
+	Version    string        `json:"version"`        // KES server version
+	OS         string        `json:"os"`             // OS running the KES server
+	Arch       string        `json:"arch"`           // CPU architecture the KES server is running on
+	UpTime     time.Duration `json:"uptime"`         // Time the KES server has been up and running
+	CPUs       int           `json:"num_cpu"`        // Number of available logical CPU cores
+	UsableCPUs int           `json:"num_cpu_used"`   // Number of usbale logical CPU cores
+	HeapAlloc  uint64        `json:"num_heap_used"`  // Number of bytes currently allocated on the heap
+	StackAlloc uint64        `json:"num_stack_used"` // Number of bytes currently allocated on the stack
 }
 
 // API describes a KES server API.


### PR DESCRIPTION
This commit exposes the server OS and
CPU architecture via the status API.

```
● 127.0.0.1:7373
  Version  v0.0.0-dev
  Uptime   8 minutes
  Latency  8ms
  OS       darwin
  CPUs     8 arm64
  Memory
  · Heap   1 MiB
  · Stack  640 KiB
```