### PR TITLE
separate stateful and stateless server implementation

### DIFF
--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -179,12 +179,14 @@ func startGateway(gConfig gatewayConfig) {
 
 	server := http.Server{
 		Addr: config.Address.Value(),
-		Handler: xhttp.NewServerMux(&xhttp.ServerConfig{
-			Vault:    sys.NewStatelessVault(config.Admin.Identity.Value(), cache, policySet, identitySet),
-			Proxy:    proxy,
-			AuditLog: auditLog,
-			ErrorLog: errorLog,
-			Metrics:  metrics,
+		Handler: xhttp.NewGatewayMux(&xhttp.GatewayConfig{
+			Keys:       cache,
+			Policies:   policySet,
+			Identities: identitySet,
+			Proxy:      proxy,
+			AuditLog:   auditLog,
+			ErrorLog:   errorLog,
+			Metrics:    metrics,
 		}),
 		TLSConfig: &tls.Config{
 			MinVersion:       tls.VersionTLS12,

--- a/internal/http/gateway-api.go
+++ b/internal/http/gateway-api.go
@@ -1,0 +1,195 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/sys"
+	"github.com/prometheus/common/expfmt"
+)
+
+func gatewayVersion(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method  = http.MethodGet
+		APIPath = "/version"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	type Response struct {
+		Version string `json:"version"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		json.NewEncoder(w).Encode(Response{
+			Version: sys.BinaryInfo().Version,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewayStatus(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/status"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Response struct {
+		Version string        `json:"version"`
+		OS      string        `json:"os"`
+		Arch    string        `json:"arch"`
+		UpTime  time.Duration `json:"uptime"`
+
+		CPUs       int    `json:"num_cpu"`
+		UsableCPUs int    `json:"num_cpu_used"`
+		HeapAlloc  uint64 `json:"mem_heap_used"`
+		StackAlloc uint64 `json:"mem_stack_used"`
+	}
+	startTime := time.Now().UTC()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		var memStats runtime.MemStats
+		runtime.ReadMemStats(&memStats)
+
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			Version: sys.BinaryInfo().Version,
+			OS:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
+			UpTime:  time.Since(startTime).Round(time.Second),
+
+			CPUs:       runtime.NumCPU(),
+			UsableCPUs: runtime.GOMAXPROCS(0),
+			HeapAlloc:  memStats.HeapAlloc,
+			StackAlloc: memStats.StackSys,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewayMetrics(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method  = http.MethodGet
+		APIPath = "/v1/metrics"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		contentType := expfmt.Negotiate(r.Header)
+		w.Header().Set("Content-Type", string(contentType))
+		w.WriteHeader(http.StatusOK)
+		config.Metrics.EncodeTo(expfmt.NewEncoder(w, contentType))
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, handler)))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewayListAPIs(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/api"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Response struct {
+		Method  string `json:"method"`
+		Path    string `json:"path"`
+		MaxBody int64  `json:"max_body"`
+		Timeout int64  `json:"timeout"` // Timeout in seconds
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		responses := make([]Response, 0, len(config.APIs))
+		for _, api := range config.APIs {
+			responses = append(responses, Response{
+				Method:  api.Method,
+				Path:    api.Path,
+				MaxBody: api.MaxBody,
+				Timeout: int64(api.Timeout.Truncate(time.Second).Seconds()),
+			})
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(responses)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}

--- a/internal/http/gateway-identity-api.go
+++ b/internal/http/gateway-identity-api.go
@@ -1,0 +1,243 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+)
+
+func gatewayDescribeIdentity(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/identity/describe/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Response struct {
+		IsAdmin   bool         `json:"admin,omitempty"`
+		Policy    string       `json:"policy"`
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err := validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+		info, err := config.Identities.Get(r.Context(), kes.Identity(name))
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			IsAdmin:   info.IsAdmin,
+			Policy:    info.Policy,
+			CreatedAt: info.CreatedAt,
+			CreatedBy: info.CreatedBy,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewaySelfDescribeIdentity(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method  = http.MethodGet
+		APIPath = "/v1/identity/self/describe"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	type InlinePolicy struct {
+		Allow     []string     `json:"allow,omitempty"`
+		Deny      []string     `json:"deny,omitempty"`
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+	}
+	type Response struct {
+		Identity   kes.Identity `json:"identity"`
+		IsAdmin    bool         `json:"admin,omitempty"`
+		PolicyName string       `json:"policy_name,omitempty"`
+		CreatedAt  time.Time    `json:"created_at,omitempty"`
+		CreatedBy  kes.Identity `json:"created_by,omitempty"`
+
+		Policy InlinePolicy `json:"policy"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		identity := auth.Identify(r)
+		info, err := config.Identities.Get(r.Context(), identity)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+
+		policy := new(auth.Policy)
+		if !info.IsAdmin {
+			policy, err = config.Policies.Get(r.Context(), info.Policy)
+			if err != nil {
+				Error(w, err)
+				return
+			}
+		}
+		json.NewEncoder(w).Encode(Response{
+			Identity:   identity,
+			PolicyName: info.Policy,
+			IsAdmin:    info.IsAdmin,
+			CreatedAt:  info.CreatedAt,
+			CreatedBy:  info.CreatedBy,
+			Policy: InlinePolicy{
+				Allow:     policy.Allow,
+				Deny:      policy.Deny,
+				CreatedAt: policy.CreatedAt,
+				CreatedBy: policy.CreatedBy,
+			},
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewayListIdentities(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/identity/list/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/x-ndjson"
+	)
+	type Response struct {
+		Identity  kes.Identity `json:"identity"`
+		IsAdmin   bool         `json:"admin"`
+		Policy    string       `json:"policy"`
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+
+		Err string `json:"error,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		pattern := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err := validatePattern(pattern); err != nil {
+			Error(w, err)
+			return
+		}
+		iterator, err := config.Identities.List(r.Context())
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		var (
+			encoder    = json.NewEncoder(w)
+			hasWritten bool
+		)
+		for iterator.Next() {
+			if ok, _ := path.Match(pattern, iterator.Identity().String()); !ok {
+				continue
+			}
+			info, err := config.Identities.Get(r.Context(), iterator.Identity())
+			if err != nil {
+				encoder.Encode(Response{Err: err.Error()})
+				return
+			}
+			if !hasWritten {
+				w.Header().Set("Content-Type", ContentType)
+			}
+			err = encoder.Encode(Response{
+				Identity:  iterator.Identity(),
+				IsAdmin:   info.IsAdmin,
+				Policy:    info.Policy,
+				CreatedAt: info.CreatedAt,
+				CreatedBy: info.CreatedBy,
+			})
+			if err != nil {
+				return
+			}
+			hasWritten = true
+		}
+		if err = iterator.Close(); err != nil {
+			if hasWritten {
+				encoder.Encode(Response{Err: err.Error()})
+			} else {
+				Error(w, err)
+			}
+			return
+		}
+		if !hasWritten {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}

--- a/internal/http/gateway-key-api.go
+++ b/internal/http/gateway-key-api.go
@@ -19,7 +19,7 @@ import (
 	"github.com/minio/kes/internal/key"
 )
 
-func createKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayCreateKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method  = http.MethodPost
 		APIPath = "/v1/key/create/"
@@ -38,20 +38,14 @@ func createKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
@@ -68,7 +62,7 @@ func createKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		if err = enclave.CreateKey(r.Context(), name, key); err != nil {
+		if err = config.Keys.Create(r.Context(), name, key); err != nil {
 			Error(w, err)
 			return
 		}
@@ -83,7 +77,7 @@ func createKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func importKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayImportKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method  = http.MethodPost
 		APIPath = "/v1/key/import/"
@@ -106,26 +100,20 @@ func importKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
 
 		var req Request
-		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			Error(w, err)
 			return
 		}
@@ -152,7 +140,7 @@ func importKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		if err = enclave.CreateKey(r.Context(), name, key); err != nil {
+		if err = config.Keys.Create(r.Context(), name, key); err != nil {
 			Error(w, err)
 			return
 		}
@@ -167,7 +155,7 @@ func importKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func deleteKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayDeleteKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method  = http.MethodDelete
 		APIPath = "/v1/key/delete/"
@@ -186,25 +174,18 @@ func deleteKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
-
-		if err = enclave.DeleteKey(r.Context(), name); err != nil {
+		if err := config.Keys.Delete(r.Context(), name); err != nil {
 			Error(w, err)
 			return
 		}
@@ -219,7 +200,7 @@ func deleteKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func generateKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayGenerateKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/generate/"
@@ -246,30 +227,24 @@ func generateKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
 
 		var req Request
-		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			Error(w, err)
 			return
 		}
-		key, err := enclave.GetKey(r.Context(), name)
+		key, err := config.Keys.Get(r.Context(), name)
 		if err != nil {
 			Error(w, err)
 			return
@@ -299,7 +274,7 @@ func generateKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func encryptKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayEncryptKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/encrypt/"
@@ -326,30 +301,24 @@ func encryptKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
 
 		var req Request
-		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			Error(w, err)
 			return
 		}
-		key, err := enclave.GetKey(r.Context(), name)
+		key, err := config.Keys.Get(r.Context(), name)
 		if err != nil {
 			Error(w, err)
 			return
@@ -373,7 +342,7 @@ func encryptKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func decryptKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayDecryptKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/decrypt/"
@@ -400,30 +369,24 @@ func decryptKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
 
 		var req Request
-		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			Error(w, err)
 			return
 		}
-		key, err := enclave.GetKey(r.Context(), name)
+		key, err := config.Keys.Get(r.Context(), name)
 		if err != nil {
 			Error(w, err)
 			return
@@ -447,7 +410,7 @@ func decryptKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func bulkDecryptKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayBulkDecryptKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/bulk/decrypt/"
@@ -475,24 +438,18 @@ func bulkDecryptKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
+		if err := validateName(name); err != nil {
 			Error(w, err)
 			return
 		}
-		key, err := enclave.GetKey(r.Context(), name)
+		key, err := config.Keys.Get(r.Context(), name)
 		if err != nil {
 			Error(w, err)
 			return
@@ -534,7 +491,7 @@ func bulkDecryptKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func listKey(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayListKey(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodGet
 		APIPath     = "/v1/key/list/"
@@ -558,24 +515,18 @@ func listKey(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
 
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
 		pattern := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validatePattern(pattern); err != nil {
+		if err := validatePattern(pattern); err != nil {
 			Error(w, err)
 			return
 		}
-		iterator, err := enclave.ListKeys(r.Context())
+		iterator, err := config.Keys.List(r.Context())
 		if err != nil {
 			Error(w, err)
 			return

--- a/internal/http/gateway-log-api.go
+++ b/internal/http/gateway-log-api.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/minio/kes/internal/auth"
 	xlog "github.com/minio/kes/internal/log"
 )
 
-func logErrorEvents(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayErrorLog(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodGet
 		APIPath     = "/v1/log/error"
@@ -30,17 +31,11 @@ func logErrorEvents(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
-
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
 
 		w.Header().Set("Content-Type", ContentType)
 		w.WriteHeader(http.StatusOK)
@@ -60,7 +55,7 @@ func logErrorEvents(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func logAuditEvents(mux *http.ServeMux, config *ServerConfig) API {
+func gatewayAuditLog(mux *http.ServeMux, config *GatewayConfig) API {
 	const (
 		Method      = http.MethodGet
 		APIPath     = "/v1/log/audit"
@@ -79,17 +74,11 @@ func logAuditEvents(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
-
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
 
 		w.Header().Set("Content-Type", ContentType)
 		w.WriteHeader(http.StatusOK)

--- a/internal/http/gateway-policy-api.go
+++ b/internal/http/gateway-policy-api.go
@@ -1,0 +1,214 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+)
+
+func gatewayDescribePolicy(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/policy/describe/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Response struct {
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err := validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+		policy, err := config.Policies.Get(r.Context(), name)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			CreatedAt: policy.CreatedAt,
+			CreatedBy: policy.CreatedBy,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, config.Metrics.Count(config.Metrics.Latency(handler))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewayReadPolicy(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/policy/read/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Response struct {
+		Allow     []string     `json:"allow,omitempty"`
+		Deny      []string     `json:"deny,omitempty"`
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err := validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+		policy, err := config.Policies.Get(r.Context(), name)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			Allow:     policy.Allow,
+			Deny:      policy.Deny,
+			CreatedAt: policy.CreatedAt,
+			CreatedBy: policy.CreatedBy,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func gatewayListPolicy(mux *http.ServeMux, config *GatewayConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/policy/list/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/x-ndjson"
+	)
+	type Response struct {
+		Name      string       `json:"name"`
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+
+		Err string `json:"error,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		pattern := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err := validatePattern(pattern); err != nil {
+			Error(w, err)
+			return
+		}
+		iterator, err := config.Policies.List(r.Context())
+		if err != nil {
+			Error(w, err)
+			return
+		}
+
+		var hasWritten bool
+		encoder := json.NewEncoder(w)
+		w.Header().Set("Content-Type", ContentType)
+		for iterator.Next() {
+			if ok, _ := path.Match(pattern, iterator.Name()); !ok {
+				continue
+			}
+
+			policy, err := config.Policies.Get(r.Context(), iterator.Name())
+			if err != nil {
+				encoder.Encode(Response{Err: err.Error()})
+				return
+			}
+			err = encoder.Encode(Response{
+				Name:      iterator.Name(),
+				CreatedAt: policy.CreatedAt,
+				CreatedBy: policy.CreatedBy,
+			})
+			if err != nil {
+				return
+			}
+			hasWritten = true
+		}
+		if err = iterator.Close(); err != nil {
+			encoder.Encode(Response{Err: err.Error()})
+			return
+		}
+		if !hasWritten {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}

--- a/internal/http/gateway.go
+++ b/internal/http/gateway.go
@@ -1,0 +1,73 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/key"
+	xlog "github.com/minio/kes/internal/log"
+	"github.com/minio/kes/internal/metric"
+)
+
+// A GatewayConfig structure is used to configure a
+// KES gateway.
+type GatewayConfig struct {
+	Certificate *Certificate
+
+	Proxy *auth.TLSProxy
+
+	AuditLog *xlog.Target
+
+	ErrorLog *xlog.Target
+
+	Metrics *metric.Metrics
+
+	Keys key.Store
+
+	Policies auth.PolicySet
+
+	Identities auth.IdentitySet
+
+	APIs []API
+}
+
+// NewGatewayMux returns a new KES gateway handler that
+// uses the given GatewayConfig to implement the KES
+// HTTP API.
+func NewGatewayMux(config *GatewayConfig) *http.ServeMux {
+	mux := http.NewServeMux()
+	config.APIs = append(config.APIs, gatewayVersion(mux, config))
+	config.APIs = append(config.APIs, gatewayStatus(mux, config))
+	config.APIs = append(config.APIs, gatewayMetrics(mux, config))
+	config.APIs = append(config.APIs, gatewayListAPIs(mux, config))
+
+	config.APIs = append(config.APIs, gatewayCreateKey(mux, config))
+	config.APIs = append(config.APIs, gatewayImportKey(mux, config))
+	config.APIs = append(config.APIs, gatewayDeleteKey(mux, config))
+	config.APIs = append(config.APIs, gatewayGenerateKey(mux, config))
+	config.APIs = append(config.APIs, gatewayEncryptKey(mux, config))
+	config.APIs = append(config.APIs, gatewayDecryptKey(mux, config))
+	config.APIs = append(config.APIs, gatewayBulkDecryptKey(mux, config))
+	config.APIs = append(config.APIs, gatewayListKey(mux, config))
+
+	config.APIs = append(config.APIs, gatewayDescribePolicy(mux, config))
+	config.APIs = append(config.APIs, gatewayReadPolicy(mux, config))
+	config.APIs = append(config.APIs, gatewayListPolicy(mux, config))
+
+	config.APIs = append(config.APIs, gatewayDescribeIdentity(mux, config))
+	config.APIs = append(config.APIs, gatewaySelfDescribeIdentity(mux, config))
+	config.APIs = append(config.APIs, gatewayListIdentities(mux, config))
+
+	config.APIs = append(config.APIs, gatewayErrorLog(mux, config))
+	config.APIs = append(config.APIs, gatewayAuditLog(mux, config))
+
+	mux.HandleFunc("/", timeout(10*time.Second, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not implemented", http.StatusNotImplemented)
+	}))
+	return mux
+}

--- a/internal/http/server-api.go
+++ b/internal/http/server-api.go
@@ -1,3 +1,7 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
 package http
 
 import (
@@ -10,7 +14,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
-func version(mux *http.ServeMux, config *ServerConfig) API {
+func serverVersion(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodGet
 		APIPath = "/version"
@@ -40,7 +44,7 @@ func version(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func status(mux *http.ServeMux, config *ServerConfig) API {
+func serverStatus(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method      = http.MethodGet
 		APIPath     = "/v1/status"
@@ -107,7 +111,7 @@ func status(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func metrics(mux *http.ServeMux, config *ServerConfig) API {
+func serverMetrics(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodGet
 		APIPath = "/v1/metrics"
@@ -152,7 +156,7 @@ func metrics(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func listAPIs(mux *http.ServeMux, config *ServerConfig) API {
+func serverListAPIs(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method      = http.MethodGet
 		APIPath     = "/v1/api"

--- a/internal/http/server-enclave-api.go
+++ b/internal/http/server-enclave-api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/minio/kes/internal/auth"
 )
 
-func createEnclave(mux *http.ServeMux, config *ServerConfig) API {
+func serverCreateEnclave(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodPost
 		APIPath = "/v1/enclave/create/"
@@ -83,7 +83,7 @@ func createEnclave(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func deleteEnclave(mux *http.ServeMux, config *ServerConfig) API {
+func serverDeleteEnclave(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodDelete
 		APIPath = "/v1/enclave/delete/"

--- a/internal/http/server-identity-api.go
+++ b/internal/http/server-identity-api.go
@@ -15,15 +15,17 @@ import (
 	"github.com/minio/kes/internal/auth"
 )
 
-func describePolicy(mux *http.ServeMux, config *ServerConfig) API {
+func serverDescribeIdentity(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method      = http.MethodGet
-		APIPath     = "/v1/policy/describe/"
+		APIPath     = "/v1/identity/describe/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
 		ContentType = "application/json"
 	)
 	type Response struct {
+		IsAdmin   bool         `json:"admin,omitempty"`
+		Policy    string       `json:"policy"`
 		CreatedAt time.Time    `json:"created_at,omitempty"`
 		CreatedBy kes.Identity `json:"created_by,omitempty"`
 	}
@@ -56,83 +58,18 @@ func describePolicy(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		policy, err := enclave.GetPolicy(r.Context(), name)
+		info, err := enclave.GetIdentity(r.Context(), kes.Identity(name))
 		if err != nil {
 			Error(w, err)
 			return
 		}
 		w.Header().Set("Content-Type", ContentType)
 		json.NewEncoder(w).Encode(Response{
-			CreatedAt: policy.CreatedAt,
-			CreatedBy: policy.CreatedBy,
+			IsAdmin:   info.IsAdmin,
+			Policy:    info.Policy,
+			CreatedAt: info.CreatedAt,
+			CreatedBy: info.CreatedBy,
 		})
-	}
-	mux.HandleFunc(APIPath, timeout(Timeout, config.Metrics.Count(config.Metrics.Latency(handler))))
-	return API{
-		Method:  Method,
-		Path:    APIPath,
-		MaxBody: MaxBody,
-		Timeout: Timeout,
-	}
-}
-
-func assignPolicy(mux *http.ServeMux, config *ServerConfig) API {
-	const (
-		Method  = http.MethodPost
-		APIPath = "/v1/policy/assign/"
-		MaxBody = 1024 // 1 KB
-		Timeout = 15 * time.Second
-	)
-	type Request struct {
-		Identity kes.Identity `json:"identity"`
-	}
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w = audit(w, r, config.AuditLog.Log())
-
-		if r.Method != Method {
-			w.Header().Set("Accept", Method)
-			Error(w, errMethodNotAllowed)
-			return
-		}
-		if err := normalizeURL(r.URL, APIPath); err != nil {
-			Error(w, err)
-			return
-		}
-		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
-
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
-			Error(w, err)
-			return
-		}
-
-		var req Request
-		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
-			Error(w, err)
-			return
-		}
-		if req.Identity.IsUnknown() {
-			Error(w, kes.NewError(http.StatusBadRequest, "identity is unknown"))
-			return
-		}
-		if self := auth.Identify(r); self == req.Identity {
-			Error(w, kes.NewError(http.StatusForbidden, "identity cannot assign policy to itself"))
-			return
-		}
-		if err = enclave.AssignPolicy(r.Context(), name, req.Identity); err != nil {
-			Error(w, err)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
 	}
 	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
 	return API{
@@ -143,20 +80,28 @@ func assignPolicy(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func readPolicy(mux *http.ServeMux, config *ServerConfig) API {
+func serverSelfDescribeIdentity(mux *http.ServeMux, config *ServerConfig) API {
 	const (
-		Method      = http.MethodGet
-		APIPath     = "/v1/policy/read/"
-		MaxBody     = 0
-		Timeout     = 15 * time.Second
-		ContentType = "application/json"
+		Method  = http.MethodGet
+		APIPath = "/v1/identity/self/describe"
+		MaxBody = 0
+		Timeout = 15 * time.Second
 	)
-	type Response struct {
+	type InlinePolicy struct {
 		Allow     []string     `json:"allow,omitempty"`
 		Deny      []string     `json:"deny,omitempty"`
 		CreatedAt time.Time    `json:"created_at,omitempty"`
 		CreatedBy kes.Identity `json:"created_by,omitempty"`
 	}
+	type Response struct {
+		Identity   kes.Identity `json:"identity"`
+		IsAdmin    bool         `json:"admin,omitempty"`
+		PolicyName string       `json:"policy_name,omitempty"`
+		CreatedAt  time.Time    `json:"created_at,omitempty"`
+		CreatedBy  kes.Identity `json:"created_by,omitempty"`
+
+		Policy InlinePolicy `json:"policy"`
+	}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w = audit(w, r, config.AuditLog.Log())
 
@@ -176,27 +121,34 @@ func readPolicy(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
 
-		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
-			Error(w, err)
-			return
-		}
-		policy, err := enclave.GetPolicy(r.Context(), name)
+		identity := auth.Identify(r)
+		info, err := enclave.GetIdentity(r.Context(), identity)
 		if err != nil {
 			Error(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", ContentType)
+
+		policy := new(auth.Policy)
+		if !info.IsAdmin {
+			policy, err = enclave.GetPolicy(r.Context(), info.Policy)
+			if err != nil {
+				Error(w, err)
+				return
+			}
+		}
 		json.NewEncoder(w).Encode(Response{
-			Allow:     policy.Allow,
-			Deny:      policy.Deny,
-			CreatedAt: policy.CreatedAt,
-			CreatedBy: policy.CreatedBy,
+			Identity:   identity,
+			PolicyName: info.Policy,
+			IsAdmin:    info.IsAdmin,
+			CreatedAt:  info.CreatedAt,
+			CreatedBy:  info.CreatedBy,
+			Policy: InlinePolicy{
+				Allow:     policy.Allow,
+				Deny:      policy.Deny,
+				CreatedAt: policy.CreatedAt,
+				CreatedBy: policy.CreatedBy,
+			},
 		})
 	}
 	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
@@ -208,77 +160,10 @@ func readPolicy(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func writePolicy(mux *http.ServeMux, config *ServerConfig) API {
-	const (
-		Method  = http.MethodPost
-		APIPath = "/v1/policy/write/"
-		MaxBody = 1 << 20
-		Timeout = 15 * time.Second
-	)
-	type Request struct {
-		Allow []string `json:"allow,omitempty"`
-		Deny  []string `json:"deny,omitempty"`
-	}
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w = audit(w, r, config.AuditLog.Log())
-
-		if r.Method != Method {
-			w.Header().Set("Accept", Method)
-			Error(w, errMethodNotAllowed)
-			return
-		}
-		if err := normalizeURL(r.URL, APIPath); err != nil {
-			Error(w, err)
-			return
-		}
-		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
-
-		enclave, err := lookupEnclave(config.Vault, r)
-		if err != nil {
-			Error(w, err)
-			return
-		}
-		if err = enclave.VerifyRequest(r); err != nil {
-			Error(w, err)
-			return
-		}
-
-		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
-		if err = validateName(name); err != nil {
-			Error(w, err)
-			return
-		}
-
-		var req Request
-		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
-			Error(w, err)
-			return
-		}
-		policy := &auth.Policy{
-			Allow:     req.Allow,
-			Deny:      req.Deny,
-			CreatedAt: time.Now().UTC(),
-			CreatedBy: auth.Identify(r),
-		}
-		if err = enclave.SetPolicy(r.Context(), name, policy); err != nil {
-			Error(w, err)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	}
-	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
-	return API{
-		Method:  Method,
-		Path:    APIPath,
-		MaxBody: MaxBody,
-		Timeout: Timeout,
-	}
-}
-
-func deletePolicy(mux *http.ServeMux, config *ServerConfig) API {
+func serverDeleteIdentity(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodDelete
-		APIPath = "/v1/policy/delete/"
+		APIPath = "/v1/identity/delete/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
 	)
@@ -311,8 +196,7 @@ func deletePolicy(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-
-		if err = enclave.DeletePolicy(r.Context(), name); err != nil {
+		if err = enclave.DeleteIdentity(r.Context(), kes.Identity(name)); err != nil {
 			Error(w, err)
 			return
 		}
@@ -327,16 +211,18 @@ func deletePolicy(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
-func listPolicy(mux *http.ServeMux, config *ServerConfig) API {
+func serverListIdentity(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method      = http.MethodGet
-		APIPath     = "/v1/policy/list/"
+		APIPath     = "/v1/identity/list/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
 		ContentType = "application/x-ndjson"
 	)
 	type Response struct {
-		Name      string       `json:"name"`
+		Identity  kes.Identity `json:"identity"`
+		IsAdmin   bool         `json:"admin"`
+		Policy    string       `json:"policy"`
 		CreatedAt time.Time    `json:"created_at,omitempty"`
 		CreatedBy kes.Identity `json:"created_by,omitempty"`
 
@@ -371,29 +257,33 @@ func listPolicy(mux *http.ServeMux, config *ServerConfig) API {
 			Error(w, err)
 			return
 		}
-		iterator, err := enclave.ListPolicies(r.Context())
+		iterator, err := enclave.ListIdentities(r.Context())
 		if err != nil {
 			Error(w, err)
 			return
 		}
-
-		var hasWritten bool
-		encoder := json.NewEncoder(w)
-		w.Header().Set("Content-Type", ContentType)
+		var (
+			encoder    = json.NewEncoder(w)
+			hasWritten bool
+		)
 		for iterator.Next() {
-			if ok, _ := path.Match(pattern, iterator.Name()); !ok {
+			if ok, _ := path.Match(pattern, iterator.Identity().String()); !ok {
 				continue
 			}
-
-			policy, err := enclave.GetPolicy(r.Context(), iterator.Name())
+			info, err := enclave.GetIdentity(r.Context(), iterator.Identity())
 			if err != nil {
 				encoder.Encode(Response{Err: err.Error()})
 				return
 			}
+			if !hasWritten {
+				w.Header().Set("Content-Type", ContentType)
+			}
 			err = encoder.Encode(Response{
-				Name:      iterator.Name(),
-				CreatedAt: policy.CreatedAt,
-				CreatedBy: policy.CreatedBy,
+				Identity:  iterator.Identity(),
+				IsAdmin:   info.IsAdmin,
+				Policy:    info.Policy,
+				CreatedAt: info.CreatedAt,
+				CreatedBy: info.CreatedBy,
 			})
 			if err != nil {
 				return
@@ -401,7 +291,11 @@ func listPolicy(mux *http.ServeMux, config *ServerConfig) API {
 			hasWritten = true
 		}
 		if err = iterator.Close(); err != nil {
-			encoder.Encode(Response{Err: err.Error()})
+			if hasWritten {
+				encoder.Encode(Response{Err: err.Error()})
+			} else {
+				Error(w, err)
+			}
 			return
 		}
 		if !hasWritten {

--- a/internal/http/server-key-api.go
+++ b/internal/http/server-key-api.go
@@ -1,0 +1,627 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"encoding/json"
+	"math/rand"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/cpu"
+	"github.com/minio/kes/internal/fips"
+	"github.com/minio/kes/internal/key"
+)
+
+func serverCreateKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodPost
+		APIPath = "/v1/key/create/"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+
+		var algorithm key.Algorithm
+		if fips.Enabled || cpu.HasAESGCM() {
+			algorithm = key.AES256_GCM_SHA256
+		} else {
+			algorithm = key.XCHACHA20_POLY1305
+		}
+
+		key, err := key.Random(algorithm, auth.Identify(r))
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.CreateKey(r.Context(), name, key); err != nil {
+			Error(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverImportKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodPost
+		APIPath = "/v1/key/import/"
+		MaxBody = 1 << 20
+		Timeout = 15 * time.Second
+	)
+	type Request struct {
+		Bytes     []byte `json:"bytes"`
+		Algorithm string `json:"algorithm"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+
+		var req Request
+		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+			Error(w, err)
+			return
+		}
+
+		var algorithm key.Algorithm
+		switch key.Algorithm(req.Algorithm) {
+		case key.AES256_GCM_SHA256:
+			algorithm = key.AES256_GCM_SHA256
+		case key.XCHACHA20_POLY1305:
+			algorithm = key.XCHACHA20_POLY1305
+		case key.AlgorithmGeneric:
+			algorithm = key.AlgorithmGeneric
+		default:
+			Error(w, kes.NewError(http.StatusBadRequest, "invalid algorithm"))
+			return
+		}
+
+		if len(req.Bytes) != algorithm.KeySize() {
+			Error(w, kes.NewError(http.StatusBadRequest, "invalid key size"))
+			return
+		}
+		key, err := key.New(algorithm, req.Bytes, auth.Identify(r))
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.CreateKey(r.Context(), name, key); err != nil {
+			Error(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverDeleteKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodDelete
+		APIPath = "/v1/key/delete/"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+
+		if err = enclave.DeleteKey(r.Context(), name); err != nil {
+			Error(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverGenerateKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodPost
+		APIPath     = "/v1/key/generate/"
+		MaxBody     = 1 << 20
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Request struct {
+		Context []byte `json:"context"` // optional
+	}
+	type Response struct {
+		Plaintext  []byte `json:"plaintext"`
+		Ciphertext []byte `json:"ciphertext"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+
+		var req Request
+		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+			Error(w, err)
+			return
+		}
+		key, err := enclave.GetKey(r.Context(), name)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		dataKey := make([]byte, 32)
+		if _, err = rand.Read(dataKey); err != nil {
+			Error(w, err)
+			return
+		}
+		ciphertext, err := key.Wrap(dataKey, req.Context)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			Plaintext:  dataKey,
+			Ciphertext: ciphertext,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverEncryptKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodPost
+		APIPath     = "/v1/key/encrypt/"
+		MaxBody     = 1 << 20
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Request struct {
+		Plaintext []byte `json:"plaintext"`
+		Context   []byte `json:"context"` // optional
+	}
+	type Response struct {
+		Ciphertext []byte `json:"ciphertext"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+
+		var req Request
+		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+			Error(w, err)
+			return
+		}
+		key, err := enclave.GetKey(r.Context(), name)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		ciphertext, err := key.Wrap(req.Plaintext, req.Context)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			Ciphertext: ciphertext,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverDecryptKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodPost
+		APIPath     = "/v1/key/decrypt/"
+		MaxBody     = 1 << 20
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+	)
+	type Request struct {
+		Ciphertext []byte `json:"ciphertext"`
+		Context    []byte `json:"context"` // optional
+	}
+	type Response struct {
+		Plaintext []byte `json:"plaintext"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+
+		var req Request
+		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+			Error(w, err)
+			return
+		}
+		key, err := enclave.GetKey(r.Context(), name)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		plaintext, err := key.Unwrap(req.Ciphertext, req.Context)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(Response{
+			Plaintext: plaintext,
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverBulkDecryptKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodPost
+		APIPath     = "/v1/key/bulk/decrypt/"
+		MaxBody     = 1 << 20
+		Timeout     = 15 * time.Second
+		ContentType = "application/json"
+		MaxRequests = 1000 // For now, we limit the number of decryption requests in a single API call to 1000.
+	)
+	type Request struct {
+		Ciphertext []byte `json:"ciphertext"`
+		Context    []byte `json:"context"` // optional
+	}
+	type Response struct {
+		Plaintext []byte `json:"plaintext"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validateName(name); err != nil {
+			Error(w, err)
+			return
+		}
+		key, err := enclave.GetKey(r.Context(), name)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+
+		var (
+			requests  []Request
+			responses []Response
+		)
+		if err = json.NewDecoder(r.Body).Decode(&requests); err != nil {
+			Error(w, err)
+			return
+		}
+		if len(requests) > MaxRequests {
+			Error(w, kes.NewError(http.StatusBadRequest, "too many ciphertexts"))
+			return
+		}
+		responses = make([]Response, 0, len(requests))
+		for _, req := range requests {
+			plaintext, err := key.Unwrap(req.Ciphertext, req.Context)
+			if err != nil {
+				Error(w, err)
+				return
+			}
+			responses = append(responses, Response{
+				Plaintext: plaintext,
+			})
+		}
+
+		w.Header().Set("Content-Type", ContentType)
+		json.NewEncoder(w).Encode(responses)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverListKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/key/list/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/x-ndjson"
+	)
+	type Response struct {
+		Name string `json:"name,omitempty"`
+		Err  string `json:"error,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		pattern := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+		if err = validatePattern(pattern); err != nil {
+			Error(w, err)
+			return
+		}
+		iterator, err := enclave.ListKeys(r.Context())
+		if err != nil {
+			Error(w, err)
+			return
+		}
+
+		var (
+			hasWritten bool
+			encoder    = json.NewEncoder(w)
+		)
+		for iterator.Next() {
+			name := iterator.Name()
+			if ok, _ := path.Match(pattern, name); ok && name != "" {
+				if !hasWritten {
+					w.Header().Set("Content-Type", ContentType)
+				}
+				hasWritten = true
+
+				if err = encoder.Encode(Response{Name: name}); err != nil {
+					return
+				}
+				if err == http.ErrHandlerTimeout {
+					break
+				}
+				if err != nil {
+					encoder.Encode(Response{Err: err.Error()})
+					return
+				}
+			}
+		}
+		if err = iterator.Err(); err != nil {
+			if !hasWritten {
+				Error(w, err)
+			} else {
+				encoder.Encode(Response{Err: err.Error()})
+			}
+			return
+		}
+		if !hasWritten {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}

--- a/internal/http/server-log-api.go
+++ b/internal/http/server-log-api.go
@@ -1,0 +1,110 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"net/http"
+	"time"
+
+	xlog "github.com/minio/kes/internal/log"
+)
+
+func serverErrorLog(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/log/error"
+		MaxBody     = 0
+		Timeout     = 0 * time.Second // No timeout
+		ContentType = "application/x-ndjson"
+	)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		w.Header().Set("Content-Type", ContentType)
+		w.WriteHeader(http.StatusOK)
+
+		out := xlog.NewErrEncoder(NewFlushWriter(w))
+		config.ErrorLog.Add(out)
+		defer config.ErrorLog.Remove(out)
+
+		<-r.Context().Done() // Wait for the client to close the connection
+	}
+	mux.HandleFunc(APIPath, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverAuditLog(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/log/audit"
+		MaxBody     = 0
+		Timeout     = 0 * time.Second // No timeout
+		ContentType = "application/x-ndjson"
+	)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		enclave, err := lookupEnclave(config.Vault, r)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		if err = enclave.VerifyRequest(r); err != nil {
+			Error(w, err)
+			return
+		}
+
+		w.Header().Set("Content-Type", ContentType)
+		w.WriteHeader(http.StatusOK)
+
+		out := NewFlushWriter(w)
+		config.AuditLog.Add(out)
+		defer config.AuditLog.Remove(out)
+
+		<-r.Context().Done() // Wait for the client to close the connection
+	}
+	mux.HandleFunc(APIPath, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}

--- a/internal/http/server-sys-api.go
+++ b/internal/http/server-sys-api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/minio/kes/internal/auth"
 )
 
-func sealVault(mux *http.ServeMux, config *ServerConfig) API {
+func serverSealVault(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodPost
 		APIPath = "/v1/sys/seal"

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,0 +1,93 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/minio/kes/internal/auth"
+	xlog "github.com/minio/kes/internal/log"
+	"github.com/minio/kes/internal/metric"
+	"github.com/minio/kes/internal/sys"
+)
+
+// A ServerConfig structure is used to configure a
+// KES server.
+type ServerConfig struct {
+	// Certificate is TLS server certificate.
+	Certificate *Certificate
+
+	Vault sys.Vault
+
+	// Proxy is an optional TLS proxy that sits
+	// in-front of this server and forwards client
+	// requests.
+	//
+	// A TLS proxy is responsible for forwarding
+	// the client certificates via a request
+	// header such that this server can apply
+	// the corresponding policy.
+	Proxy *auth.TLSProxy
+
+	// AuditLog is a log target that receives
+	// audit log events.
+	AuditLog *xlog.Target
+
+	// ErrorLog is a log target that receives
+	// error log events.
+	ErrorLog *xlog.Target
+
+	// Metrics gathers various informations about
+	// the server.
+	Metrics *metric.Metrics
+
+	APIs []API
+}
+
+// NewServerMux returns a new KES server handler that
+// uses the given ServerConfig to implement the KES
+// HTTP API.
+func NewServerMux(config *ServerConfig) *http.ServeMux {
+	mux := http.NewServeMux()
+	config.APIs = append(config.APIs, serverVersion(mux, config))
+	config.APIs = append(config.APIs, serverStatus(mux, config))
+	config.APIs = append(config.APIs, serverMetrics(mux, config))
+	config.APIs = append(config.APIs, serverListAPIs(mux, config))
+
+	config.APIs = append(config.APIs, serverCreateKey(mux, config))
+	config.APIs = append(config.APIs, serverImportKey(mux, config))
+	config.APIs = append(config.APIs, serverDeleteKey(mux, config))
+	config.APIs = append(config.APIs, serverGenerateKey(mux, config))
+	config.APIs = append(config.APIs, serverEncryptKey(mux, config))
+	config.APIs = append(config.APIs, serverDecryptKey(mux, config))
+	config.APIs = append(config.APIs, serverBulkDecryptKey(mux, config))
+	config.APIs = append(config.APIs, serverListKey(mux, config))
+
+	config.APIs = append(config.APIs, serverDescribePolicy(mux, config))
+	config.APIs = append(config.APIs, serverAssignPolicy(mux, config))
+	config.APIs = append(config.APIs, serverReadPolicy(mux, config))
+	config.APIs = append(config.APIs, serverWritePolicy(mux, config))
+	config.APIs = append(config.APIs, serverListPolicy(mux, config))
+	config.APIs = append(config.APIs, serverDeletePolicy(mux, config))
+
+	config.APIs = append(config.APIs, serverDescribeIdentity(mux, config))
+	config.APIs = append(config.APIs, serverSelfDescribeIdentity(mux, config))
+	config.APIs = append(config.APIs, serverListIdentity(mux, config))
+	config.APIs = append(config.APIs, serverDeleteIdentity(mux, config))
+
+	config.APIs = append(config.APIs, serverErrorLog(mux, config))
+	config.APIs = append(config.APIs, serverAuditLog(mux, config))
+
+	config.APIs = append(config.APIs, serverCreateEnclave(mux, config))
+	config.APIs = append(config.APIs, serverDeleteEnclave(mux, config))
+
+	config.APIs = append(config.APIs, serverSealVault(mux, config))
+
+	mux.HandleFunc("/", timeout(10*time.Second, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	return mux
+}


### PR DESCRIPTION
This commit separates the stateful and stateless server (gateway)
implementation.

In particular, the abstracts for the gateway (e.g. KMS key store)
and the stateful server cause additional complexity and often
leak the underlying implementation or are fundamentally incorrect.

For example, the gateway should be stateless and read-only (except
for the managed keys) while the server require modifications to
policies, identities etc.

Therefore, mid and long-term it seems better to fundamentally separate
the gateway and server API such that each can be implemented specific
for the requirements.