### PR TITLE
init: define policy assignments in init file

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -52,8 +52,9 @@ type InitConfig struct {
 		} `yaml:"admin"`
 
 		Policy map[string]struct {
-			Allow []string `yaml:"allow"`
-			Deny  []string `yaml:"deny"`
+			Allow    []string       `yaml:"allow"`
+			Deny     []string       `yaml:"deny"`
+			Identity []yml.Identity `yaml:"identities"`
 		} `yaml:"policy"`
 	} `yaml:"enclave"`
 }
@@ -71,5 +72,6 @@ func ReadInitConfig(filename string) (*InitConfig, error) {
 	if err := yaml.NewDecoder(f).Decode(&config); err != nil {
 		return nil, err
 	}
+
 	return &config, nil
 }


### PR DESCRIPTION
This commit adds declarative policy assignments
for the stateful KES init config.

Now it is possible to pre-define identities and
there policies in the init config:
```
policy:
      minio:
        allow:
        - /v1/key/create/*
        - /v1/key/generate/*
        - /v1/key/decrypt/*
        - /v1/key/bulk/decrypt/*
        deny:
        - /v1/key/decrypt/internal-*
        - /v1/key/bulk/decrypt/internal-*
        identities:
        - c40bca7bfa2e4e92cd61f56580b9b7f2e5c356b6443ca6960df877ecce2e8016
```

During `kes init` the specified policy will be assigned to
all listed identities. This is a nice quality-of-life
improvement when deploying KES on e.g. K8S.

The `init` command will make sure that within the same enclave,
an identity can only be assigned to one policy and that the
identity is not equal to the sys admin or the enclave admin.