### PR TITLE
add `/v1/enclave/describe` API

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,18 +8,16 @@ on:
     - master
 jobs:
   build:
-    name: Build ${{ matrix.go-version }}
+    name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.19.x]
     steps:
-    - name: Set up Go ${{ matrix.go-version }}
+    - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.19.1
+        check-latest: true
       id: go
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v3
     - name: Build and Lint
       env:
@@ -31,21 +29,21 @@ jobs:
          $(go env GOPATH)/bin/golangci-lint run --config ./.golangci.yml
 
   test:
-    name: Test ${{ matrix.go-version }} on ${{ matrix.os }}
+    name: Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.19.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
+    - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.19.1
+        check-latest: true
       id: go
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v3
-    - name: Test on ${{ matrix.os }}
+    - name: Test
       env:
         GO111MODULE: on
       run: |
@@ -54,16 +52,14 @@ jobs:
   integration:
     name: Integration Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.19.x]
     steps:
-    - name: Set up Go ${{ matrix.go-version }}
+    - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.19.1
+        check-latest: true
       id: go
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v3
     - name: Integration Test
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,8 @@ on:
     - master
 jobs:
   goreleaser:
-    name: Go ${{ matrix.go-version }}
+    name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.19.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,8 +18,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
-        id: go
+          go-version: 1.19.1
+          check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -13,5 +13,14 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-    - name: Check for vulnerabilities
-      uses: kmulvey/govulncheck-action@main
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.1
+        check-latest: true
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      shell: bash
+    - name: Run govulncheck
+      run: govulncheck ./...
+      shell: bash 

--- a/cmd/kes/enclave.go
+++ b/cmd/kes/enclave.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 
+	tui "github.com/charmbracelet/lipgloss"
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/cli"
 	flag "github.com/spf13/pflag"
@@ -21,6 +23,7 @@ const enclaveCmdUsage = `Usage:
 
 Commands:
     create                   Create a new enclave.
+    info                     Get information about an enclave. 
     rm                       Delete an enclave.
 
 Options:
@@ -33,6 +36,7 @@ func enclaveCmd(args []string) {
 
 	subCmds := commands{
 		"create": createEnclaveCmd,
+		"info":   describeEnclaveCmd,
 		"rm":     deleteEnclaveCmd,
 	}
 
@@ -103,6 +107,93 @@ func createEnclaveCmd(args []string) {
 		}
 		cli.Fatalf("failed to create enclave '%s': %v", name, err)
 	}
+}
+
+const describeEnclaveCmdUsage = `Usage:
+    kes enclave info [options] [<name>]
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+        --json               Print identity information in JSON format.
+        --color <when>       Specify when to use colored output. The automatic
+                             mode only enables colors if an interactive terminal
+                             is detected - colors are automatically disabled if
+                             the output goes to a pipe.
+                             Possible values: *auto*, never, always.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes enclave info tenant-1
+`
+
+func describeEnclaveCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, describeEnclaveCmdUsage) }
+
+	var (
+		jsonFlag           bool
+		colorFlag          colorOption
+		insecureSkipVerify bool
+	)
+	cmd.BoolVar(&jsonFlag, "json", false, "Print policy information in JSON format")
+	cmd.Var(&colorFlag, "color", "Specify when to use colored output")
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes enclave info --help'", err)
+	}
+
+	if cmd.NArg() > 1 {
+		cli.Fatal("too many arguments. See 'kes enclave info --help'")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	var name string
+	if cmd.NArg() > 0 {
+		name = cmd.Arg(0)
+	}
+	client := newClient(insecureSkipVerify)
+	info, err := client.DescribeEnclave(ctx, name)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			os.Exit(1)
+		}
+		cli.Fatalf("failed to describe enclave '%s': %v", name, err)
+	}
+
+	if jsonFlag {
+		if err := json.NewEncoder(os.Stdout).Encode(info); err != nil {
+			cli.Fatalf("failed to describe enclave '%s': %v", name, err)
+		}
+		return
+	}
+
+	var faint, enclaveStyle tui.Style
+	if colorFlag.Colorize() {
+		const ColorIdentity tui.Color = "#2e42d1"
+		faint = faint.Faint(true).Bold(true)
+		enclaveStyle = enclaveStyle.Foreground(ColorIdentity)
+	}
+
+	year, month, day := info.CreatedAt.Date()
+	hour, min, sec := info.CreatedAt.Clock()
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Enclave")),
+		enclaveStyle.Render(info.Name),
+	)
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Created At")),
+		fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec),
+	)
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Created By")),
+		info.CreatedBy,
+	)
 }
 
 const deleteEnclaveCmdUsage = `Usage:

--- a/enclave.go
+++ b/enclave.go
@@ -15,6 +15,13 @@ import (
 	"time"
 )
 
+// EnclaveInfo describes a KES enclave.
+type EnclaveInfo struct {
+	Name      string    `json:"name"`       // Enclave name
+	CreatedAt time.Time `json:"created_at"` // Point in time when the enclave has been created
+	CreatedBy Identity  `json:"created_by"` // Identity that created the enclave
+}
+
 // An Enclave is an isolated area within a KES server.
 // It stores cryptographic keys, policies and other
 // related information securely.

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -82,6 +82,7 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 	config.APIs = append(config.APIs, serverAuditLog(mux, config))
 
 	config.APIs = append(config.APIs, serverCreateEnclave(mux, config))
+	config.APIs = append(config.APIs, serverDescribeEnclave(mux, config))
 	config.APIs = append(config.APIs, serverDeleteEnclave(mux, config))
 
 	config.APIs = append(config.APIs, serverSealVault(mux, config))

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -30,12 +30,17 @@ type VaultFS interface {
 	// as enclave admin.
 	//
 	// It returns ErrEnclaveExists if such an enclave already exists.
-	CreateEnclave(ctx context.Context, name string, admin kes.Identity) (*EnclaveInfo, error)
+	CreateEnclave(ctx context.Context, name string, admin kes.Identity) (EnclaveInfo, error)
 
 	// GetEnclave returns the requested enclave.
 	//
 	// It returns ErrEnclaveNotFound if no such enclave exists.
 	GetEnclave(ctx context.Context, name string) (*Enclave, error)
+
+	// GetEnclaveInfo returns information about the specified enclave.
+	//
+	// It returns ErrEnclaveNotFound if no such enclave exists.
+	GetEnclaveInfo(ctx context.Context, name string) (EnclaveInfo, error)
 
 	// DeleteEnclave deletes the specified enclave.
 	//

--- a/internal/sys/vault.go
+++ b/internal/sys/vault.go
@@ -95,19 +95,19 @@ func (v *Vault) Admin(ctx context.Context) (kes.Identity, error) {
 // enclave admin identity.
 //
 // It returns ErrEnclaveExists if such an enclave already exists.
-func (v *Vault) CreateEnclave(ctx context.Context, name string, admin kes.Identity) (*EnclaveInfo, error) {
+func (v *Vault) CreateEnclave(ctx context.Context, name string, admin kes.Identity) (EnclaveInfo, error) {
 	if name == "" {
 		name = DefaultEnclaveName
 	}
 
 	if v.sealed {
-		return nil, kes.ErrSealed
+		return EnclaveInfo{}, kes.ErrSealed
 	}
 	if admin.IsUnknown() {
-		return nil, kes.NewError(http.StatusBadRequest, "admin cannot be empty")
+		return EnclaveInfo{}, kes.NewError(http.StatusBadRequest, "admin cannot be empty")
 	}
 	if admin == v.admin {
-		return nil, kes.NewError(http.StatusBadRequest, "admin cannot be the system admin")
+		return EnclaveInfo{}, kes.NewError(http.StatusBadRequest, "admin cannot be the system admin")
 	}
 
 	delete(v.enclaves, name)
@@ -141,6 +141,19 @@ func (v *Vault) GetEnclave(ctx context.Context, name string) (*Enclave, error) {
 	}
 	v.enclaves[name] = enclave
 	return enclave, nil
+}
+
+// GetEnclaveInfo returns information about the specified enclave.
+//
+// It returns ErrEnclaveNotFound if no such enclave exists.
+func (v *Vault) GetEnclaveInfo(ctx context.Context, name string) (EnclaveInfo, error) {
+	if name == "" {
+		name = DefaultEnclaveName
+	}
+	if v.sealed {
+		return EnclaveInfo{}, kes.ErrSealed
+	}
+	return v.fs.GetEnclaveInfo(ctx, name)
 }
 
 // DeleteEnclave deletes the enclave with the given name.


### PR DESCRIPTION
This commit adds a describe enclave
API: `/v1/enclave/describe`.

In addition, this commit adds a client
API implementation and CLI command for
fetching enclave description.