### PR TITLE
add `/v1/key/describe` API

### DIFF
--- a/client.go
+++ b/client.go
@@ -347,6 +347,16 @@ func (c *Client) ImportKey(ctx context.Context, name string, key []byte) error {
 	return enclave.ImportKey(ctx, name, key)
 }
 
+// DescribeKey returns the KeyInfo for the given key.
+// It returns ErrKeyNotFound if no such key exists.
+func (c *Client) DescribeKey(ctx context.Context, name string) (*KeyInfo, error) {
+	enclave := Enclave{
+		endpoints: c.Endpoints,
+		client:    retry(c.HTTPClient),
+	}
+	return enclave.DescribeKey(ctx, name)
+}
+
 // DeleteKey deletes the key from a KES server. It returns
 // ErrKeyNotFound if no such key exists.
 func (c *Client) DeleteKey(ctx context.Context, name string) error {

--- a/internal/http/gateway.go
+++ b/internal/http/gateway.go
@@ -48,6 +48,7 @@ func NewGatewayMux(config *GatewayConfig) *http.ServeMux {
 
 	config.APIs = append(config.APIs, gatewayCreateKey(mux, config))
 	config.APIs = append(config.APIs, gatewayImportKey(mux, config))
+	config.APIs = append(config.APIs, gatewayDescribeKey(mux, config))
 	config.APIs = append(config.APIs, gatewayDeleteKey(mux, config))
 	config.APIs = append(config.APIs, gatewayGenerateKey(mux, config))
 	config.APIs = append(config.APIs, gatewayEncryptKey(mux, config))

--- a/internal/http/server-key-api.go
+++ b/internal/http/server-key-api.go
@@ -166,6 +166,71 @@ func serverImportKey(mux *http.ServeMux, config *ServerConfig) API {
 	}
 }
 
+func serverDescribeKey(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodGet
+		APIPath = "/v1/key/describe/"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	type Response struct {
+		Name      string       `json:"name"`
+		ID        string       `json:"id,omitempty"`
+		CreatedAt time.Time    `json:"created_at,omitempty"`
+		CreatedBy kes.Identity `json:"created_by,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		key, err := VSync(config.Vault.RLocker(), func() (key.Key, error) {
+			enclave, err := lookupEnclave(config.Vault, r)
+			if err != nil {
+				return key.Key{}, err
+			}
+			return VSync(enclave.RLocker(), func() (key.Key, error) {
+				if err = enclave.VerifyRequest(r); err != nil {
+					return key.Key{}, err
+				}
+				name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+				if err = validateName(name); err != nil {
+					return key.Key{}, err
+				}
+				return enclave.GetKey(r.Context(), name)
+			})
+		})
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Length", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(Response{
+			Name:      strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath)),
+			ID:        key.ID(),
+			CreatedAt: key.CreatedAt(),
+			CreatedBy: key.CreatedBy(),
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
 func serverDeleteKey(mux *http.ServeMux, config *ServerConfig) API {
 	const (
 		Method  = http.MethodDelete
@@ -547,6 +612,7 @@ func serverListKey(mux *http.ServeMux, config *ServerConfig) API {
 	)
 	type Response struct {
 		Name      string       `json:"name,omitempty"`
+		ID        string       `json:"id,omitempty"`
 		CreatedAt time.Time    `json:"created_at,omitempty"`
 		CreatedBy kes.Identity `json:"created_by,omitempty"`
 
@@ -604,6 +670,7 @@ func serverListKey(mux *http.ServeMux, config *ServerConfig) API {
 
 					err = encoder.Encode(Response{
 						Name:      iterator.Name(),
+						ID:        key.ID(),
 						CreatedAt: key.CreatedAt(),
 						CreatedBy: key.CreatedBy(),
 					})

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -59,6 +59,7 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 
 	config.APIs = append(config.APIs, serverCreateKey(mux, config))
 	config.APIs = append(config.APIs, serverImportKey(mux, config))
+	config.APIs = append(config.APIs, serverDescribeKey(mux, config))
 	config.APIs = append(config.APIs, serverDeleteKey(mux, config))
 	config.APIs = append(config.APIs, serverGenerateKey(mux, config))
 	config.APIs = append(config.APIs, serverEncryptKey(mux, config))

--- a/kestest/gateway_test.go
+++ b/kestest/gateway_test.go
@@ -29,6 +29,7 @@ var gatewayAPIs = []kes.API{
 
 	{Method: http.MethodPost, Path: "/v1/key/create/", MaxBody: 0, Timeout: 15 * time.Second},             // 4
 	{Method: http.MethodPost, Path: "/v1/key/import/", MaxBody: 1 << 20, Timeout: 15 * time.Second},       // 5
+	{Method: http.MethodGet, Path: "/v1/key/describe/", MaxBody: 0, Timeout: 15 * time.Second},            // 5
 	{Method: http.MethodDelete, Path: "/v1/key/delete/", MaxBody: 0, Timeout: 15 * time.Second},           // 6
 	{Method: http.MethodPost, Path: "/v1/key/generate/", MaxBody: 1 << 20, Timeout: 15 * time.Second},     // 7
 	{Method: http.MethodPost, Path: "/v1/key/encrypt/", MaxBody: 1 << 20, Timeout: 15 * time.Second},      // 8

--- a/key.go
+++ b/key.go
@@ -49,9 +49,10 @@ type PCP struct {
 
 // KeyInfo describes a cryptographic key at a KES server.
 type KeyInfo struct {
-	Name      string    // Name of the cryptographic key
-	CreatedAt time.Time // Point in time when the key was created
-	CreatedBy Identity  // Identity that created the key
+	Name      string    `json:"name"`                 // Name of the cryptographic key
+	ID        string    `json:"id,omitempty"`         // ID of the cryptographic key
+	CreatedAt time.Time `json:"created_at,omitempty"` // Point in time when the key was created
+	CreatedBy Identity  `json:"created_by,omitempty"` // Identity that created the key
 }
 
 // KeyIterator iterates over a stream of KeyInfo objects.
@@ -77,6 +78,10 @@ func (i *KeyIterator) Value() KeyInfo { return i.current }
 // short-hand for Value().Name.
 func (i *KeyIterator) Name() string { return i.current.Name }
 
+// ID returns the ID of the current key. It is a
+// short-hand for Value().ID.
+func (i *KeyIterator) ID() string { return i.current.ID }
+
 // CreatedAt returns the created-at timestamp of the current
 // key. It is a short-hand for Value().CreatedAt.
 func (i *KeyIterator) CreatedAt() time.Time { return i.current.CreatedAt }
@@ -92,6 +97,7 @@ func (i *KeyIterator) CreatedBy() Identity { return i.current.CreatedBy }
 func (i *KeyIterator) Next() bool {
 	type Response struct {
 		Name      string    `json:"name"`
+		ID        string    `json:"id"`
 		CreatedAt time.Time `json:"created_at"`
 		CreatedBy Identity  `json:"created_by"`
 
@@ -127,7 +133,8 @@ func (i *KeyIterator) Next() bool {
 // encounterred, if any.
 func (i *KeyIterator) WriteTo(w io.Writer) (int64, error) {
 	type Response struct {
-		Name      string    `json:"name"`
+		Name      string    `json:"name,omitempty"`
+		ID        string    `json:"id,omitempty"`
 		CreatedAt time.Time `json:"created_at,omitempty"`
 		CreatedBy Identity  `json:"created_by,omitempty"`
 


### PR DESCRIPTION
This commit adds a describe key
API: `/v1/key/describe` to the
stateful/stateless server.

In addition, this commit adds a client
API implementation and CLI command for
fetching a key description.