### PR TITLE
cache: fix bug in offline caching

### DIFF
--- a/internal/key/cache.go
+++ b/internal/key/cache.go
@@ -70,7 +70,7 @@ func NewCache(store Store, config *CacheConfig) *Cache {
 	c.gcUnused(config.ExpiryUnused)
 
 	if config.ExpiryOffline > 0 {
-		c.gcOffline(config.ExpiryUnused)
+		c.gcOffline(config.ExpiryOffline)
 		c.watchOfflineStatus(10 * time.Second)
 	}
 	return c


### PR DESCRIPTION
This commit fixes a bug in the offline
caching. Before, the `unused` caching time
was used for the offline cache - which is incorrect.

This leads to confusing offline caching behavior.
The offline cache works for some amount of time,
precisely the `unused` time.

This commit fixes this by using the correct `offline` time.