### PR TITLE
keserv: fix nil assignment and add tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.3
         check-latest: true
       id: go
     - name: Check out code
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.3
         check-latest: true
       id: go
     - name: Check out code
@@ -56,7 +56,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.3
         check-latest: true
       id: go
     - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.2
+          go-version: 1.19.3
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.2
+        go-version: 1.19.3
         check-latest: true
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/keserv/config_test.go
+++ b/keserv/config_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package keserv
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/minio/kes"
+)
+
+func TestReadServerConfig(t *testing.T) {
+	for i, test := range readServerConfigTests {
+		_, err := ReadServerConfig(test.Filename)
+		if err == nil && test.ShouldFail {
+			t.Fatalf("Test %d should fail but passed", i)
+		}
+		if err != nil && !test.ShouldFail {
+			t.Fatalf("Test %d: failed to read server config: %v", i, err)
+		}
+	}
+}
+
+var readServerConfigTests = []struct {
+	Filename   string
+	ShouldFail bool
+}{
+	{Filename: "./testdata/fs.yml"},
+
+	{Filename: "./testdata/invalid_keys.yml", ShouldFail: true},
+	{Filename: "./testdata/invalid_root.yml", ShouldFail: true},
+}
+
+func TestRoundtripServerConfig(t *testing.T) {
+	for i, config := range roundtripServerConfigTests {
+		var buffer bytes.Buffer
+		if err := EncodeServerConfig(&buffer, &config); err != nil {
+			t.Fatalf("Test %d: failed to encode config: %v", i, err)
+		}
+		if _, err := DecodeServerConfig(&buffer); err != nil {
+			t.Fatalf("Test %d: failed to encode config: %v", i, err)
+		}
+	}
+}
+
+var roundtripServerConfigTests = []ServerConfig{
+	{
+		Addr:  Env[string]{Value: "0.0.0.0:7373"},
+		Admin: Env[kes.Identity]{Value: "disabled"},
+	},
+	{
+		Addr:  Env[string]{Value: "0.0.0.0:7373"},
+		Admin: Env[kes.Identity]{Value: "disabled"},
+		TLS: TLSConfig{
+			Password:    Env[string]{Value: "horse battery staple"},
+			PrivateKey:  Env[string]{Value: "/tmp/private.key"},
+			Certificate: Env[string]{Value: "/tmp/public.crt"},
+			Proxies: []Env[kes.Identity]{
+				{Value: "bf8d6fd2cffc6bf98f423013c13559ae2c25cfd3cd0c76f626901c95aa8c3eff"},
+			},
+			ForwardCertHeader: Env[string]{Value: "Client-Cert"},
+		},
+		Cache: CacheConfig{
+			Expiry:        Env[time.Duration]{Value: 5*time.Minute + 30*time.Second},
+			ExpiryUnused:  Env[time.Duration]{Value: 30 * time.Second},
+			ExpiryOffline: Env[time.Duration]{Value: 1 * time.Hour},
+		},
+		Log: LogConfig{
+			Audit: Env[string]{Value: "off"},
+			Error: Env[string]{Value: "on"},
+		},
+		Policies: map[string]Policy{
+			"my-policy": {
+				Allow: []string{
+					"/v1/key/create/*",
+					"/v1/key/generate/*",
+					"/v1/key/decrypt/*",
+					"/v1/key/delete/*",
+				},
+				Deny: []string{
+					"/v1/key/decrypt/disallowed-key",
+				},
+				Identities: []Env[kes.Identity]{
+					{Value: "74c51d3e53094d1a6c35c667ae0d122150b867deb564dc17cc2249b9a1af3a78"},
+				},
+			},
+		},
+		Keys: []Key{
+			{
+				Name: Env[string]{Value: "my-key-1"},
+			},
+			{
+				Name: Env[string]{Value: "my-key-2"},
+			},
+		},
+		KMS: &FSConfig{
+			Dir: Env[string]{Value: "/tmp/keys"},
+		},
+	},
+}

--- a/keserv/env.go
+++ b/keserv/env.go
@@ -1,3 +1,7 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
 package keserv
 
 import (

--- a/keserv/example_test.go
+++ b/keserv/example_test.go
@@ -1,3 +1,7 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
 package keserv
 
 import (

--- a/keserv/testdata/fs.yml
+++ b/keserv/testdata/fs.yml
@@ -1,0 +1,27 @@
+address: 0.0.0.0:7373
+admin:
+  identity: disabled
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+  
+cache:
+  expiry:
+    any: 5m0s
+    unused: 30s
+    offline: 0s
+    
+policy:
+  minio:
+    allow:
+    - /v1/key/create/*
+    - /v1/key/generate/*
+    - /v1/key/decrypt/*
+    - /v1/key/bulk/decrypt/*
+    deny:
+    - /v1/key/decrypt/2022-10-31_my-bucket-1
+
+keystore:
+  fs:
+    path: /tmp/kes

--- a/keserv/testdata/invalid_keys.yml
+++ b/keserv/testdata/invalid_keys.yml
@@ -1,0 +1,27 @@
+address: 0.0.0.0:7373
+admin:
+  identity: disabled
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+  
+cache:
+  expiry:
+    any: 5m0s
+    unused: 30s
+    offline: 0s
+    
+policy:
+  minio:
+    allow:
+    - /v1/key/create/*
+    - /v1/key/generate/*
+    - /v1/key/decrypt/*
+    - /v1/key/bulk/decrypt/*
+    deny:
+    - /v1/key/decrypt/2022-10-31_my-bucket-1
+
+keys:
+  fs:
+    path: /tmp/kes

--- a/keserv/testdata/invalid_root.yml
+++ b/keserv/testdata/invalid_root.yml
@@ -1,0 +1,26 @@
+address: 0.0.0.0:7373
+root: disabled
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+  
+cache:
+  expiry:
+    any: 5m0s
+    unused: 30s
+    offline: 0s
+    
+policy:
+  minio:
+    allow:
+    - /v1/key/create/*
+    - /v1/key/generate/*
+    - /v1/key/decrypt/*
+    - /v1/key/bulk/decrypt/*
+    deny:
+    - /v1/key/decrypt/2022-10-31_my-bucket-1
+
+keys:
+  fs:
+    path: /tmp/kes

--- a/keserv/yml.go
+++ b/keserv/yml.go
@@ -1,3 +1,7 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
 package keserv
 
 import (
@@ -192,6 +196,11 @@ func serverConfigToYAML(config *ServerConfig) *serverConfigYAML {
 	yml.Log.Error = config.Log.Error
 
 	// Policies
+	yml.Policies = make(map[string]struct {
+		Allow      []string            `yaml:"allow,omitempty"`
+		Deny       []string            `yaml:"deny,omitempty"`
+		Identities []Env[kes.Identity] `yaml:"identities,omitempty"`
+	}, len(config.Policies))
 	for name, policy := range config.Policies {
 		type Item struct {
 			Allow      []string            `yaml:"allow,omitempty"`
@@ -244,6 +253,7 @@ func yamlToServerConfig(yml *serverConfigYAML) *ServerConfig {
 	config.Log.Error = yml.Log.Error
 
 	// Policies
+	config.Policies = make(map[string]Policy, len(yml.Policies))
 	for name, policy := range yml.Policies {
 		config.Policies[name] = Policy{
 			Allow:      policy.Allow,


### PR DESCRIPTION
This commit fixes two nil assignment bugs
when en/decoding server config structs.
In both cases, an entry used to be assigned
to a potentially nil map causing a panic.

Further, this commit adds some basic tests
for reading / writing server configuration.