### PR TITLE
vault: use default approle engine

### DIFF
--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -47,6 +47,9 @@ func Connect(ctx context.Context, c *Config) (*Conn, error) {
 	if c.AppRole.Retry == 0 {
 		c.AppRole.Retry = 5 * time.Second
 	}
+	if c.AppRole.Engine == "" {
+		c.AppRole.Engine = EngineAppRole
+	}
 	if c.K8S.Engine == "" {
 		c.K8S.Engine = EngineKubernetes
 	}


### PR DESCRIPTION
This commit fixes an bug when connecting
to Hashicorp Vault with AppRole credentials.

Before, ommiting the approle engine in the
config file no default engine path has used.
Now, if the approle engine in the config file
is empty, we default to `approle`.

RELEASE_TAGS BUG_FIX