### PR TITLE
cmd: reject server certificates without SANs

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -177,6 +177,15 @@ func startServer(path string, sConfig serverConfig) {
 	}
 	certificate.ErrorLog = errorLog
 
+	if c, _ := certificate.GetCertificate(nil); c != nil && c.Leaf != nil {
+		if len(c.Leaf.DNSNames) == 0 && len(c.Leaf.IPAddresses) == 0 {
+			// Support for TLS certificates with a subject CN but without any SAN
+			// has been removed in Go 1.15. Ref: https://go.dev/doc/go1.15#commonname
+			// Therefore, we require at least one SAN for the server certificate.
+			cli.Fatal("failed to load TLS certificate: certificate does not contain any DNS or IP address as SAN")
+		}
+	}
+
 	clientAuth := tls.RequireAnyClientCert
 	if init.VerifyClientCerts.Value() {
 		clientAuth = tls.RequireAndVerifyClientCert


### PR DESCRIPTION
This commit disallows the use of TLS server
certificates that do not contain any SANs.

Certificate verification fails when a certificate
contains a CN but not a SAN since Go 1.15.
Ref: https://go.dev/doc/go1.15#commonname

We don't reject client certificates without a SAN
since client certificates may not be verified at
all due to the identity verification.