### PR TITLE
add support for custom CA certificates

### DIFF
--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -187,6 +187,14 @@ func startGateway(gConfig gatewayConfig) {
 		}
 	}
 
+	var rootCAs *x509.CertPool
+	if config.TLS.CAPath.Value != "" {
+		rootCAs, err = xhttp.LoadCertPool(config.TLS.CAPath.Value)
+		if err != nil {
+			cli.Fatalf("failed to load TLS CA certificate: %v", err)
+		}
+	}
+
 	metrics := metric.New()
 	errorLog.Add(metrics.ErrorEventCounter())
 	auditLog.Add(metrics.AuditEventCounter())
@@ -207,6 +215,7 @@ func startGateway(gConfig gatewayConfig) {
 			GetCertificate:   certificate.GetCertificate,
 			CipherSuites:     fips.TLSCiphers(),
 			CurvePreferences: fips.TLSCurveIDs(),
+			RootCAs:          rootCAs,
 		},
 		ErrorLog: errorLog.Log(),
 

--- a/internal/http/tls_test.go
+++ b/internal/http/tls_test.go
@@ -52,3 +52,25 @@ func TestReadCertificate(t *testing.T) {
 		}
 	}
 }
+
+var loadCertPoolTests = []struct {
+	CAPath     string
+	ShouldFail bool
+}{
+	{CAPath: "testdata/certificates/single.pem"},
+	{CAPath: "testdata/certificates/with_whitespaces.pem"},
+	{CAPath: "testdata/certificates/with_privatekey.pem", ShouldFail: true},
+	{CAPath: "testdata/certificates", ShouldFail: true},
+}
+
+func TestLoadCertPool(t *testing.T) {
+	for i, test := range loadCertPoolTests {
+		_, err := LoadCertPool(test.CAPath)
+		if err != nil && !test.ShouldFail {
+			t.Fatalf("Test %d: failed to load certificate pool %s: %v", i, test.CAPath, err)
+		}
+		if err == nil && test.ShouldFail {
+			t.Fatalf("Test %d: reading certificate %s should have failed", i, test.CAPath)
+		}
+	}
+}

--- a/keserv/config.go
+++ b/keserv/config.go
@@ -123,6 +123,15 @@ type TLSConfig struct {
 	// Certificate is the path to the KES server's TLS certificate.
 	Certificate Env[string]
 
+	// CAPath is an optional path to a X.509 certificate or directory
+	// containing X.509 certificates that the KES server uses, in
+	// addition to the system root certificates, as authorities when
+	// verify client certificates.
+	//
+	// If empty, the KES server will only use the system root
+	// certificates.
+	CAPath Env[string]
+
 	// Password is an optional password to decrypt the KES server's
 	// private key.
 	Password Env[string]

--- a/keserv/config_test.go
+++ b/keserv/config_test.go
@@ -29,6 +29,7 @@ var readServerConfigTests = []struct {
 	ShouldFail bool
 }{
 	{Filename: "./testdata/fs.yml"},
+	{Filename: "./testdata/with_tls_ca.yml"},
 
 	{Filename: "./testdata/invalid_keys.yml", ShouldFail: true},
 	{Filename: "./testdata/invalid_root.yml", ShouldFail: true},
@@ -58,6 +59,7 @@ var roundtripServerConfigTests = []ServerConfig{
 			Password:    Env[string]{Value: "horse battery staple"},
 			PrivateKey:  Env[string]{Value: "/tmp/private.key"},
 			Certificate: Env[string]{Value: "/tmp/public.crt"},
+			CAPath:      Env[string]{Value: "/tmp/CAs"},
 			Proxies: []Env[kes.Identity]{
 				{Value: "bf8d6fd2cffc6bf98f423013c13559ae2c25cfd3cd0c76f626901c95aa8c3eff"},
 			},

--- a/keserv/testdata/with_tls_ca.yml
+++ b/keserv/testdata/with_tls_ca.yml
@@ -1,0 +1,28 @@
+address: 0.0.0.0:7373
+admin:
+  identity: disabled
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+  ca:   "./CAs"
+  
+cache:
+  expiry:
+    any: 5m0s
+    unused: 30s
+    offline: 0s
+    
+policy:
+  minio:
+    allow:
+    - /v1/key/create/*
+    - /v1/key/generate/*
+    - /v1/key/decrypt/*
+    - /v1/key/bulk/decrypt/*
+    deny:
+    - /v1/key/decrypt/2022-10-31_my-bucket-1
+
+keystore:
+  fs:
+    path: /tmp/kes

--- a/keserv/yml.go
+++ b/keserv/yml.go
@@ -20,6 +20,7 @@ type serverConfigYAML struct {
 	TLS struct {
 		PrivateKey  Env[string] `yaml:"key"`
 		Certificate Env[string] `yaml:"cert"`
+		CAPath      Env[string] `yaml:"ca,omitempty"`
 		Password    Env[string] `yaml:"password,omitempty"`
 
 		Proxy struct {
@@ -182,6 +183,7 @@ func serverConfigToYAML(config *ServerConfig) *serverConfigYAML {
 	// TLS
 	yml.TLS.PrivateKey = config.TLS.PrivateKey
 	yml.TLS.Certificate = config.TLS.Certificate
+	yml.TLS.CAPath = config.TLS.CAPath
 	yml.TLS.Password = config.TLS.Password
 	yml.TLS.Proxy.Identities = config.TLS.Proxies
 	yml.TLS.Proxy.Header.ClientCert = config.TLS.ForwardCertHeader
@@ -239,6 +241,7 @@ func yamlToServerConfig(yml *serverConfigYAML) *ServerConfig {
 	// TLS
 	config.TLS.PrivateKey = yml.TLS.PrivateKey
 	config.TLS.Certificate = yml.TLS.Certificate
+	config.TLS.CAPath = yml.TLS.CAPath
 	config.TLS.Password = yml.TLS.Password
 	config.TLS.Proxies = yml.TLS.Proxy.Identities
 	config.TLS.ForwardCertHeader = yml.TLS.Proxy.Header.ClientCert

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -16,6 +16,13 @@ tls:
   key:      ./server.key   # Path to the TLS private key
   cert:     ./server.cert  # Path to the TLS certificate
   password: ""             # An optional password to decrypt the TLS private key
+  
+  # An optional path to a file or directory containing X.509 certificate(s).
+  # If set, the certificate(s) get added to the list of CA certificates for
+  # verifying the mTLS certificates sent by the KES clients.
+  #
+  # If empty, the system root CAs will be used.
+  ca:       ""        
 
   # The TLS proxy configuration. A TLS proxy, like nginx, sits in
   # between a KES client and the KES server and usually acts as a


### PR DESCRIPTION
This commit adds support for custom CA
certificates for verifying mTLS client
certificates.

Now, the stateless KES server accepts
an optional `ca:` config field that points
to a X.509 certificate file or directory
containing X.509 certificate files.

If set, the X.509 certificates get added to
the system root certificate pool.