### PR TITLE
all: use human-readable size limits and mem.LimitReader

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -188,12 +187,14 @@ func (e *Enclave) DescribeKey(ctx context.Context, name string) (*KeyInfo, error
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
 
 	var response Response
-	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err := json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, err
 	}
 	return &KeyInfo{
@@ -219,6 +220,8 @@ func (e *Enclave) DeleteKey(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return parseErrorResponse(resp)
 	}
@@ -272,13 +275,14 @@ func (e *Enclave) GenerateKey(ctx context.Context, name string, context []byte) 
 	if err != nil {
 		return DEK{}, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return DEK{}, parseErrorResponse(resp)
 	}
-	defer resp.Body.Close()
 
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return DEK{}, err
 	}
 	return DEK(response), nil
@@ -321,13 +325,14 @@ func (e *Enclave) Encrypt(ctx context.Context, name string, plaintext, context [
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
-	defer resp.Body.Close()
 
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, err
 	}
 	return response.Ciphertext, nil
@@ -369,13 +374,14 @@ func (e *Enclave) Decrypt(ctx context.Context, name string, ciphertext, context 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
-	defer resp.Body.Close()
 
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, err
 	}
 	return response.Plaintext, nil
@@ -424,13 +430,14 @@ func (e *Enclave) DecryptAll(ctx context.Context, name string, ciphertexts ...CC
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
-	defer resp.Body.Close()
 
 	var responses []Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&responses); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&responses); err != nil {
 		return nil, err
 	}
 
@@ -503,6 +510,8 @@ func (e *Enclave) AssignPolicy(ctx context.Context, policy string, identity Iden
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return parseErrorResponse(resp)
 	}
@@ -530,6 +539,8 @@ func (e *Enclave) SetPolicy(ctx context.Context, name string, policy *Policy) er
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return parseErrorResponse(resp)
 	}
@@ -556,12 +567,14 @@ func (e *Enclave) DescribePolicy(ctx context.Context, name string) (*PolicyInfo,
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
 
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, err
 	}
 	return &PolicyInfo{
@@ -594,12 +607,14 @@ func (e *Enclave) GetPolicy(ctx context.Context, name string) (*Policy, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
 
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, err
 	}
 	return &Policy{
@@ -630,6 +645,8 @@ func (e *Enclave) DeletePolicy(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return parseErrorResponse(resp)
 	}
@@ -689,11 +706,13 @@ func (e *Enclave) DescribeIdentity(ctx context.Context, identity Identity) (*Ide
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, parseErrorResponse(resp)
 	}
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, err
 	}
 	return &IdentityInfo{
@@ -740,11 +759,13 @@ func (e *Enclave) DescribeSelf(ctx context.Context) (*IdentityInfo, *Policy, err
 	if err != nil {
 		return nil, nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return nil, nil, parseErrorResponse(resp)
 	}
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, int64(MaxResponseSize))).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxResponseSize)).Decode(&response); err != nil {
 		return nil, nil, err
 	}
 	info := &IdentityInfo{
@@ -784,6 +805,8 @@ func (e *Enclave) DeleteIdentity(ctx context.Context, identity Identity) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != StatusOK {
 		return parseErrorResponse(resp)
 	}

--- a/error.go
+++ b/error.go
@@ -156,8 +156,8 @@ func parseErrorResponse(resp *http.Response) error {
 	}
 	defer resp.Body.Close()
 
-	const MaxBodySize = int64(1 * mem.MiB)
-	size := resp.ContentLength
+	const MaxBodySize = 1 * mem.MiB
+	size := mem.Size(resp.ContentLength)
 	if size < 0 || size > MaxBodySize {
 		size = MaxBodySize
 	}
@@ -168,7 +168,7 @@ func parseErrorResponse(resp *http.Response) error {
 			Message string `json:"message"`
 		}
 		var response Response
-		if err := json.NewDecoder(io.LimitReader(resp.Body, size)).Decode(&response); err != nil {
+		if err := json.NewDecoder(mem.LimitReader(resp.Body, size)).Decode(&response); err != nil {
 			return err
 		}
 
@@ -184,7 +184,7 @@ func parseErrorResponse(resp *http.Response) error {
 	}
 
 	var sb strings.Builder
-	if _, err := io.Copy(&sb, io.LimitReader(resp.Body, size)); err != nil {
+	if _, err := io.Copy(&sb, mem.LimitReader(resp.Body, size)); err != nil {
 		return err
 	}
 	return NewError(resp.StatusCode, sb.String())

--- a/internal/azure/error.go
+++ b/internal/azure/error.go
@@ -6,8 +6,9 @@ package azure
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
+
+	"aead.dev/mem"
 )
 
 // errorResponse is a KeyVault secrets API error response.
@@ -24,14 +25,14 @@ type errorResponse struct {
 // parseErrorResponse parses the response body as
 // KeyVault secrets API error response.
 func parseErrorResponse(resp *http.Response) (errorResponse, error) {
-	const MaxSize = 1 << 20
-	limit := resp.ContentLength
+	const MaxSize = 1 * mem.MiB
+	limit := mem.Size(resp.ContentLength)
 	if limit < 0 || limit > MaxSize {
 		limit = MaxSize
 	}
 
 	var response errorResponse
-	if err := json.NewDecoder(io.LimitReader(resp.Body, limit)).Decode(&response); err != nil {
+	if err := json.NewDecoder(mem.LimitReader(resp.Body, limit)).Decode(&response); err != nil {
 		return errorResponse{}, err
 	}
 	return response, nil

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"aead.dev/mem"
 	"github.com/minio/kes"
 	"github.com/minio/kes/kms"
 )
@@ -98,7 +99,7 @@ func (c *Conn) Create(_ context.Context, name string, value []byte) error {
 // directory. It returns kes.ErrKeyNotFound if no such file
 // exists.
 func (c *Conn) Get(_ context.Context, name string) ([]byte, error) {
-	const MaxSize = 1 << 20 // 1 MiB
+	const MaxSize = 1 * mem.MiB
 
 	if err := validName(name); err != nil {
 		return nil, err
@@ -115,7 +116,7 @@ func (c *Conn) Get(_ context.Context, name string) ([]byte, error) {
 	}
 	defer file.Close()
 
-	value, err := io.ReadAll(io.LimitReader(file, MaxSize))
+	value, err := io.ReadAll(mem.LimitReader(file, MaxSize))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gemalto/client.go
+++ b/internal/gemalto/client.go
@@ -10,11 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"time"
 
+	"aead.dev/mem"
 	xhttp "github.com/minio/kes/internal/http"
 )
 
@@ -88,9 +88,9 @@ func (c *client) Authenticate(ctx context.Context, endpoint string, login Creden
 		return fmt.Errorf("%s: %s (%d)", resp.Status, response.Message, response.Code)
 	}
 
-	const MaxSize = 1 << 20 // An auth. token response should not exceed 1 MiB
+	const MaxSize = 1 * mem.MiB // An auth. token response should not exceed 1 MiB
 	var response Response
-	if err = json.NewDecoder(io.LimitReader(resp.Body, MaxSize)).Decode(&response); err != nil {
+	if err = json.NewDecoder(mem.LimitReader(resp.Body, MaxSize)).Decode(&response); err != nil {
 		return err
 	}
 	if response.Token == "" {

--- a/internal/generic/server.go
+++ b/internal/generic/server.go
@@ -128,9 +128,9 @@ func (s *KeyStore) CreateKey(w http.ResponseWriter, r *http.Request) {
 	type Request struct {
 		Bytes []byte `json:"bytes"`
 	}
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var request Request
-	if err := json.NewDecoder(io.LimitReader(r.Body, MaxSize)).Decode(&request); err != nil {
+	if err := json.NewDecoder(mem.LimitReader(r.Body, MaxSize)).Decode(&request); err != nil {
 		xhttp.Error(w, kes.NewError(http.StatusBadRequest, err.Error()))
 		return
 	}

--- a/internal/sys/identity-fs.go
+++ b/internal/sys/identity-fs.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"aead.dev/mem"
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/auth"
 	"github.com/minio/kes/internal/key"
@@ -63,9 +64,9 @@ func (fs *identityFS) Admin(_ context.Context) (kes.Identity, error) {
 	}
 	defer file.Close()
 
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var ciphertext bytes.Buffer
-	if _, err = io.Copy(&ciphertext, io.LimitReader(file, MaxSize)); err != nil {
+	if _, err = io.Copy(&ciphertext, mem.LimitReader(file, MaxSize)); err != nil {
 		return "", err
 	}
 	plaintext, err := fs.rootKey.Unwrap(ciphertext.Bytes(), []byte(path.Join(AdminDir, admin)))
@@ -256,9 +257,9 @@ func (fs *identityFS) GetIdentity(_ context.Context, identity kes.Identity) (aut
 	}
 	defer file.Close()
 
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var ciphertext bytes.Buffer
-	if _, err = io.Copy(&ciphertext, io.LimitReader(file, MaxSize)); err != nil {
+	if _, err = io.Copy(&ciphertext, mem.LimitReader(file, MaxSize)); err != nil {
 		return auth.IdentityInfo{}, err
 	}
 	plaintext, err := fs.rootKey.Unwrap(ciphertext.Bytes(), associatedData)

--- a/internal/sys/key-fs.go
+++ b/internal/sys/key-fs.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"aead.dev/mem"
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/key"
 	"github.com/minio/kes/kms"
@@ -98,7 +99,7 @@ func (fs *keyFS) GetKey(_ context.Context, name string) (key.Key, error) {
 	defer file.Close()
 
 	var ciphertext bytes.Buffer
-	if _, err := io.Copy(&ciphertext, io.LimitReader(file, key.MaxSize)); err != nil {
+	if _, err := io.Copy(&ciphertext, mem.LimitReader(file, key.MaxSize)); err != nil {
 		return key.Key{}, err
 	}
 	plaintext, err := fs.rootKey.Unwrap(ciphertext.Bytes(), []byte(name))

--- a/internal/sys/policy-fs.go
+++ b/internal/sys/policy-fs.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"aead.dev/mem"
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/auth"
 	"github.com/minio/kes/internal/key"
@@ -98,9 +99,9 @@ func (fs *policyFS) GetPolicy(_ context.Context, name string) (auth.Policy, erro
 	}
 	defer file.Close()
 
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var ciphertext bytes.Buffer
-	if _, err = io.Copy(&ciphertext, io.LimitReader(file, MaxSize)); err != nil {
+	if _, err = io.Copy(&ciphertext, mem.LimitReader(file, MaxSize)); err != nil {
 		return auth.Policy{}, err
 	}
 

--- a/internal/sys/vault-fs.go
+++ b/internal/sys/vault-fs.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"aead.dev/mem"
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/cpu"
 	"github.com/minio/kes/internal/fips"
@@ -47,9 +48,9 @@ func (v *vaultFS) Unseal(ctx context.Context, unsealKeys ...UnsealKey) error {
 	}
 	defer file.Close()
 
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var buffer bytes.Buffer
-	if _, err = io.Copy(&buffer, io.LimitReader(file, MaxSize)); err != nil {
+	if _, err = io.Copy(&buffer, mem.LimitReader(file, MaxSize)); err != nil {
 		return err
 	}
 
@@ -159,9 +160,9 @@ func (v *vaultFS) GetEnclave(ctx context.Context, name string) (*Enclave, error)
 	}
 	defer file.Close()
 
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var ciphertext bytes.Buffer
-	if _, err = io.Copy(&ciphertext, io.LimitReader(file, MaxSize)); err != nil {
+	if _, err = io.Copy(&ciphertext, mem.LimitReader(file, MaxSize)); err != nil {
 		return nil, err
 	}
 	plaintext, err := v.rootKey.Unwrap(ciphertext.Bytes(), []byte(name))
@@ -194,9 +195,9 @@ func (v *vaultFS) GetEnclaveInfo(ctx context.Context, name string) (EnclaveInfo,
 	}
 	defer file.Close()
 
-	const MaxSize = 1 << 20
+	const MaxSize = 1 * mem.MiB
 	var ciphertext bytes.Buffer
-	if _, err = io.Copy(&ciphertext, io.LimitReader(file, MaxSize)); err != nil {
+	if _, err = io.Copy(&ciphertext, mem.LimitReader(file, MaxSize)); err != nil {
 		return EnclaveInfo{}, err
 	}
 	plaintext, err := v.rootKey.Unwrap(ciphertext.Bytes(), []byte(name))

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -16,12 +16,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path"
 	"time"
 
+	"aead.dev/mem"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/minio/kes"
 	"github.com/minio/kes/kms"
@@ -413,8 +413,8 @@ func (s *Conn) List(ctx context.Context) (kms.Iter, error) {
 	// (reasonable) way to parse the response in batches or use some
 	// form of pagination. Therefore, we limit the response body to
 	// a some reasonable limit to not exceed memory resources.
-	const MaxBody = 32 * 1 << 20
-	secret, err := vaultapi.ParseSecret(io.LimitReader(resp.Body, MaxBody))
+	const MaxBody = 32 * mem.MiB
+	secret, err := vaultapi.ParseSecret(mem.LimitReader(resp.Body, MaxBody))
 	if err != nil {
 		return nil, fmt.Errorf("vault: failed to list '%s': %v", location, err)
 	}


### PR DESCRIPTION
This commit uses human-readable size limits instead of untypted constants - i.e. `1 * mem.MiB` instead of `1 << 20`.

Further, replace `io.LimitReader` with `mem.LimitReader` to avoid type casting.