### PR TITLE
keserv: fix GCP secretmanager initialization

### DIFF
--- a/keserv/yml.go
+++ b/keserv/yml.go
@@ -285,7 +285,7 @@ func yamlToServerConfig(yml *serverConfigYAML) *ServerConfig {
 	case yml.KeyStore.Aws.SecretsManager.Endpoint.Value != "":
 		config.KMS = new(SecretsManagerConfig)
 	case yml.KeyStore.GCP.SecretManager.ProjectID.Value != "":
-		config.KMS = new(SecretsManagerConfig)
+		config.KMS = new(SecretManagerConfig)
 	case yml.KeyStore.Azure.KeyVault.Endpoint.Value != "":
 		config.KMS = new(KeyVaultConfig)
 	case yml.KeyStore.Gemalto.KeySecure.Endpoint.Value != "":


### PR DESCRIPTION
This commit fixes a bug when initializing
a GCP secretsmanager.

A typo caused the YAML unmarshaling to use
an AWS SecretsManager not a GCP SecretManager.