### PR TITLE
gcp: avoid passing invalid private keys to SDK

### DIFF
--- a/internal/gcp/secret-manager.go
+++ b/internal/gcp/secret-manager.go
@@ -35,10 +35,10 @@ func Connect(ctx context.Context, c *Config) (*Conn, error) {
 	if c == nil {
 		c = &Config{}
 	}
-	c.setDefaults()
 
-	options := []option.ClientOption{
-		option.WithEndpoint(c.Endpoint),
+	var options []option.ClientOption
+	if c.Endpoint != "" {
+		options = append(options, option.WithEndpoint(c.Endpoint))
 	}
 	// We only pass credentials to the GCP client if they
 	// are not empty. When running inside GCP, e.g. on app engine,


### PR DESCRIPTION
This adds a safety check to the GCP KMS implementation when parsing the GCP credentials.

A YAML string can contain control characters like newlines (`\n`). However, whether they are interpreted as such control characters or as raw symbol sequences (`\` , `n`) depends upon whether the YAML string is single- or double-quoted.

The YAML string `"Hello\nWorld"` is rendered as:
```
Hello
World
```
In contrast, the YAML string `'Hello\nWorld'` is rendered as:
```
Hello\nWorld
```

A GCP private key is will contain newline characters and a user may choose to use single-quotes for the key. Therefore, we replace the symbol sequence (`\` , `n`) with the actual `\n` newline character to avoid GCP SDK parsing errors.

Further, this commit makes the GCP credentials marshaling compliant with: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-console