### PR TITLE
enclave: fix bug in enclave name query parameter construction

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -850,7 +850,7 @@ func (e *Enclave) path(api string, args ...string) string {
 		api = path.Join(api, url.PathEscape(arg))
 	}
 	if e.Name != "" {
-		api = "?enclave=" + url.QueryEscape(e.Name)
+		api += "?enclave=" + url.QueryEscape(e.Name)
 	}
 	return api
 }


### PR DESCRIPTION
This commit fixes a bug when constructing the URL containg an enclave as query paramater.
Before, the URL API path got overwritten with the URL query parameter. For example:
```
/v1/key/create/my-key?enclacve=my-enclave
```
would have been overwritten to:

```
?enclacve=my-enclave
```