### PR TITLE
cmd: add support for enclaves

### DIFF
--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -169,6 +169,14 @@ func newClient(insecureSkipVerify bool) *kes.Client {
 	})
 }
 
+func newEnclave(name string, insecureSkipVerify bool) *kes.Enclave {
+	client := newClient(insecureSkipVerify)
+	if name == "" {
+		name = os.Getenv("KES_ENCLAVE")
+	}
+	return client.Enclave(name)
+}
+
 func isTerm(f *os.File) bool { return term.IsTerminal(int(f.Fd())) }
 
 func decodePrivateKey(pemBlock []byte) (*pem.Block, error) {


### PR DESCRIPTION
This commit adds support for KES
enclaves for various commands.

The CLI commands will use the enclave
specified by the `KES_ENCLAVE` env. variable,
or, if not set, uses the default enclave.

Each command also accepts a `-e, --enclave <name>` flag
which overwrites the enclave set via `KES_ENCLAVE`.