### PR TITLE
gcp: fix bug when listing keys

### DIFF
--- a/internal/gcp/iterator.go
+++ b/internal/gcp/iterator.go
@@ -5,6 +5,8 @@
 package gcp
 
 import (
+	"path"
+
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	gcpiterator "google.golang.org/api/iterator"
 )
@@ -29,7 +31,7 @@ func (i *iterator) Next() bool {
 		i.err = err
 		return false
 	}
-	i.last = v.GetName()
+	i.last = path.Base(v.GetName())
 	return true
 }
 

--- a/internal/gcp/secret-manager.go
+++ b/internal/gcp/secret-manager.go
@@ -185,7 +185,7 @@ func (c *Conn) Delete(ctx context.Context, name string) error {
 // List returns a new Iterator over the names of
 // all stored keys.
 func (c *Conn) List(ctx context.Context) (kms.Iter, error) {
-	location := path.Join("projects", c.config.ProjectID, "*")
+	location := path.Join("projects", c.config.ProjectID)
 	return &iterator{
 		src: c.client.ListSecrets(ctx, &secretmanagerpb.ListSecretsRequest{
 			Parent: location,


### PR DESCRIPTION
This commit fixes two bugs in the list key
implementation for GCP SecretManager.

The first bug is caused by a additional `*`
appended to the `ListSecrets` API call.
This caused GCP to respond with an error like:
```
rpc error: code = NotFound desc = Project 'projects/<project-id>/*' not found.
```

Further, the GCP ListSecrets API returns full paths for each secrets. However, KES clients just know about the key name. Therefore, we have to strip the path prefix and just return the path base as key name.