### PR TITLE
keserv: fix region assignment in AWS SecretsManager.

### DIFF
--- a/keserv/config.go
+++ b/keserv/config.go
@@ -566,7 +566,7 @@ type SecretsManagerConfig struct {
 func (c *SecretsManagerConfig) Connect(ctx context.Context) (kms.Conn, error) {
 	return aws.Connect(ctx, &aws.Config{
 		Addr:     c.Endpoint.Value,
-		Region:   c.Endpoint.Value,
+		Region:   c.Region.Value,
 		KMSKeyID: c.KMSKey.Value,
 		Login: aws.Credentials{
 			AccessKey:    c.AccessKey.Value,


### PR DESCRIPTION
This commit fixes an assignment bug in the AWS
SecretsManager config. This error leads to an
KES server error log message like:
```
aws: failed to create 'my-key': InvalidSignatureException: Credential should be scoped to a valid region.
	status code: 400
```