### PR TITLE
keserv: add version field to server config

### DIFF
--- a/keserv/testdata/invalid_version.yml
+++ b/keserv/testdata/invalid_version.yml
@@ -1,0 +1,28 @@
+version: v2
+address: 0.0.0.0:7373
+admin:
+  identity: disabled
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+  
+cache:
+  expiry:
+    any: 5m0s
+    unused: 30s
+    offline: 0s
+    
+policy:
+  minio:
+    allow:
+    - /v1/key/create/*
+    - /v1/key/generate/*
+    - /v1/key/decrypt/*
+    - /v1/key/bulk/decrypt/*
+    deny:
+    - /v1/key/decrypt/2022-10-31_my-bucket-1
+
+keystore:
+  fs:
+    path: /tmp/kes

--- a/keserv/testdata/with_version.yml
+++ b/keserv/testdata/with_version.yml
@@ -1,0 +1,28 @@
+version: v1
+address: 0.0.0.0:7373
+admin:
+  identity: disabled
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+  
+cache:
+  expiry:
+    any: 5m0s
+    unused: 30s
+    offline: 0s
+    
+policy:
+  minio:
+    allow:
+    - /v1/key/create/*
+    - /v1/key/generate/*
+    - /v1/key/decrypt/*
+    - /v1/key/bulk/decrypt/*
+    deny:
+    - /v1/key/decrypt/2022-10-31_my-bucket-1
+
+keystore:
+  fs:
+    path: /tmp/kes

--- a/keserv/yml.go
+++ b/keserv/yml.go
@@ -11,6 +11,8 @@ import (
 )
 
 type serverConfigYAML struct {
+	Version string `yaml:"version"`
+
 	Addr Env[string] `yaml:"address,omitempty"`
 
 	Admin struct {
@@ -176,7 +178,10 @@ type serverConfigYAML struct {
 }
 
 func serverConfigToYAML(config *ServerConfig) *serverConfigYAML {
+	const Version = "v1"
+
 	yml := new(serverConfigYAML)
+	yml.Version = Version
 	yml.Addr = config.Addr
 	yml.Admin.Identity = config.Admin
 

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -1,5 +1,9 @@
+# The config file version. Currently this field is optional but future
+# KES versions will require it. The only valid value is "v1". 
+version: v1
+
 # The TCP address (ip:port) for the KES server to listen on.
-address: 0.0.0.0:7373
+address: 0.0.0.0:7373 # The pseudo address 0.0.0.0 refers to all network interfaces 
 
 admin:
   # The admin identity identifies the public/private key pair


### PR DESCRIPTION
This commit adds a version field to the
server configuration. It's purpose is to
reliably detect and parse incompatible
server config files in the future.

Currently, the only valid value for the
version field is "v1" and the field itself
is optional - for backward compatibility.
```
version: v1
address: 0.0.0.0:7373
...
```
Future versions of KES will eventually require
this field.

Based on the version field we can now distinguish
incompatible config files and parse or reject them with a proper messaging.