### PR TITLE
use commit-time based release tags instead of semver for server

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: kes
 
 release:
-   name_template: "Release version {{.Version}}"
+   name_template: Release {{ replace .CommitDate ":" "-" }}
 
    github:
     owner: minio
@@ -10,6 +10,7 @@ release:
 before:
   hooks:
     - go mod tidy
+    - sh -c 'git diff --quiet || (echo "Repo contains modified files. Run git checkout" && exit 1)'
 
 builds:
   -
@@ -30,7 +31,7 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
-      - --tags=version=v{{.Version}}
+      - -buildvcs=true
     ldflags:
       - "-s -w"
 
@@ -60,44 +61,44 @@ signs:
     artifacts: all
 
 snapshot:
-  name_template: v0.0.0@{{.ShortCommit}}
+  name_template: '{{ replace .CommitDate ":" "-" }}'
 
 changelog:
   sort: asc
 
 dockers:
 - image_templates:
-  - "minio/kes:{{ .Tag }}-amd64"
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-amd64
   use: buildx
   dockerfile: Dockerfile.release
   extra_files:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/amd64"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/amd64'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "minio/kes:{{ .Tag }}-ppc64le"
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-ppc64le
   use: buildx
   dockerfile: Dockerfile.release
   extra_files:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/ppc64le"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/ppc64le'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "minio/kes:{{ .Tag }}-s390x"
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-s390x
   use: buildx
   dockerfile: Dockerfile.release
   extra_files:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/s390x"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/s390x'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "minio/kes:{{ .Tag }}-arm64"
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-arm64
   use: buildx
   goarch: arm64
   dockerfile: Dockerfile.release
@@ -105,40 +106,40 @@ dockers:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/arm64"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/arm64'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "quay.io/minio/kes:{{ .Tag }}-amd64"
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-amd64
   use: buildx
   dockerfile: Dockerfile.release
   extra_files:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/amd64"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/amd64'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "quay.io/minio/kes:{{ .Tag }}-ppc64le"
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-ppc64le
   use: buildx
   dockerfile: Dockerfile.release
   extra_files:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/ppc64le"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/ppc64le'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "quay.io/minio/kes:{{ .Tag }}-s390x"
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-s390x
   use: buildx
   dockerfile: Dockerfile.release
   extra_files:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/s390x"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/s390x'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 - image_templates:
-  - "quay.io/minio/kes:{{ .Tag }}-arm64"
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-arm64
   use: buildx
   goarch: arm64
   dockerfile: Dockerfile.release
@@ -146,24 +147,24 @@ dockers:
     - LICENSE
     - CREDITS
   build_flag_templates:
-  - "--platform=linux/arm64"
-  - "--build-arg=TAG={{ .Tag }}"
+  - '--platform=linux/arm64'
+  - '--build-arg=TAG={{ replace .CommitDate ":" "-" }}'
 docker_manifests:
-- name_template: minio/kes:{{ .Tag }}
+- name_template: minio/kes:{{ replace .CommitDate ":" "-" }}
   image_templates:
-  - minio/kes:{{ .Tag }}-amd64
-  - minio/kes:{{ .Tag }}-arm64
-  - minio/kes:{{ .Tag }}-ppc64le
-  - minio/kes:{{ .Tag }}-s390x
-- name_template: quay.io/minio/kes:{{ .Tag }}
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-amd64
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-arm64
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-ppc64le
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-s390x
+- name_template: quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}
   image_templates:
-  - quay.io/minio/kes:{{ .Tag }}-amd64
-  - quay.io/minio/kes:{{ .Tag }}-arm64
-  - quay.io/minio/kes:{{ .Tag }}-ppc64le
-  - quay.io/minio/kes:{{ .Tag }}-s390x
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-amd64
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-arm64
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-ppc64le
+  - quay.io/minio/kes:{{ replace .CommitDate ":" "-" }}-s390x
 - name_template: minio/kes:latest
   image_templates:
-  - minio/kes:{{ .Tag }}-amd64
-  - minio/kes:{{ .Tag }}-arm64
-  - minio/kes:{{ .Tag }}-ppc64le
-  - minio/kes:{{ .Tag }}-s390x
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-amd64
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-arm64
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-ppc64le
+  - minio/kes:{{ replace .CommitDate ":" "-" }}-s390x

--- a/internal/http/gateway-api.go
+++ b/internal/http/gateway-api.go
@@ -24,6 +24,7 @@ func gatewayVersion(mux *http.ServeMux, config *GatewayConfig) API {
 	)
 	type Response struct {
 		Version string `json:"version"`
+		Commit  string `json:"commit"`
 	}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w = audit(w, r, config.AuditLog.Log())
@@ -34,6 +35,7 @@ func gatewayVersion(mux *http.ServeMux, config *GatewayConfig) API {
 		}
 		json.NewEncoder(w).Encode(Response{
 			Version: sys.BinaryInfo().Version,
+			Commit:  sys.BinaryInfo().CommitID,
 		})
 	}
 	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))

--- a/internal/http/server-api.go
+++ b/internal/http/server-api.go
@@ -23,6 +23,7 @@ func serverVersion(mux *http.ServeMux, config *ServerConfig) API {
 	)
 	type Response struct {
 		Version string `json:"version"`
+		Commit  string `json:"commit"`
 	}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w = audit(w, r, config.AuditLog.Log())
@@ -33,6 +34,7 @@ func serverVersion(mux *http.ServeMux, config *ServerConfig) API {
 		}
 		json.NewEncoder(w).Encode(Response{
 			Version: sys.BinaryInfo().Version,
+			Commit:  sys.BinaryInfo().CommitID,
 		})
 	}
 	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))

--- a/internal/sys/build.go
+++ b/internal/sys/build.go
@@ -8,8 +8,6 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
-
-	"github.com/blang/semver/v4"
 )
 
 // BuildInfo contains build information
@@ -32,7 +30,7 @@ func BinaryInfo() BuildInfo {
 
 func readBinaryInfo() BuildInfo {
 	const (
-		DefaultVersion  = "v0.0.0-dev"
+		DefaultVersion  = "<unknown>"
 		DefaultCommitID = "<unknown>"
 	)
 	binaryInfo := BuildInfo{
@@ -46,23 +44,12 @@ func readBinaryInfo() BuildInfo {
 	}
 
 	const (
-		TagKey         = "-tags"
+		GitTimeKey     = "vcs.time"
 		GitRevisionKey = "vcs.revision"
-
-		VersionTag = "version="
 	)
 	for _, setting := range info.Settings {
-		if strings.HasPrefix(setting.Key, TagKey) {
-			keys := strings.Split(setting.Value, ",")
-			for _, key := range keys {
-				if strings.HasPrefix(key, VersionTag) {
-					v := strings.TrimPrefix(key, VersionTag)
-					if _, err := semver.ParseTolerant(v); err == nil {
-						binaryInfo.Version = v
-					}
-					break
-				}
-			}
+		if setting.Key == GitTimeKey {
+			binaryInfo.Version = strings.ReplaceAll(setting.Value, ":", "-")
 		}
 		if setting.Key == GitRevisionKey {
 			binaryInfo.CommitID = setting.Value

--- a/kestest/example_test.go
+++ b/kestest/example_test.go
@@ -25,7 +25,7 @@ func ExampleGateway() {
 	fmt.Println(version)
 
 	// Output:
-	// v0.0.0-dev
+	// <unknown>
 }
 
 func ExampleGateway_IssueClientCertificate() {


### PR DESCRIPTION
This commit changes the KES CLI and server versioning scheme from
semver to a rolling release model where the server version is the
RFC3339 commit timestamp.

In general, semver is useful for libraries, like the KES SDK, to
signal compatibility and API breaking changes.
However, it is less useful for a server and CLI. Further, the KES
repo contains the SDK as well as the CLI and server code. If, for
example, there would be a breaking change in the SDK but not in the
CLI or server API we still would create a new major release of the
KES server and CLI. Likewise vice-versa.

Hence, we separate the SDK and CLI/server versioning. The SDK continuous
to use semver. However, the CLI and server will use rolling release
versioning.

In particular, the CLI and server version is now the time of the last
commit. For example: `2022-12-01T11-40-08Z`.

This allows snapshot and hotfix releases at any point in time without
implications on the SDK semver.
Also, this information is automatically available in the Go binary.
Ref: `go version -m <binary>`

```
	build	vcs=git
	build	vcs.revision=57f3264adef1230eec345fb770de21b44181250f
	build	vcs.time=2022-12-01T11:40:08Z
```

We convert the RFC3339 time format by replacing all ':' with '-'
since git tags and docker image names cannot contain a ':'.