### PR TITLE
cli: add version field to init config files

### DIFF
--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,111 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestReadInitConfig(t *testing.T) {
+	for i, test := range readInitConfigTests {
+		_, err := ReadInitConfig(test.Filename)
+		if err != nil {
+			t.Fatalf("Test %d: failed to read init config: %v", i, err)
+		}
+	}
+}
+
+var readInitConfigTests = []struct {
+	Filename string
+}{
+	{Filename: "./testdata/env.yml"},
+}
+
+func TestFindVersion(t *testing.T) {
+	for i, test := range findVersionsTests {
+		version, err := findVersion(test.Root)
+		if err == nil && test.ShouldFail {
+			t.Fatalf("Test %d should fail but passed", i)
+		}
+		if err != nil && !test.ShouldFail {
+			t.Fatalf("Test %d: failed to find version: %v", i, err)
+		}
+		if !test.ShouldFail && version != test.Version {
+			t.Fatalf("Test %d: got '%s' - want '%s'", i, version, test.Version)
+		}
+	}
+}
+
+var findVersionsTests = []struct {
+	Version    string
+	Root       *yaml.Node
+	ShouldFail bool
+}{
+	{ // 0 - Document tree with a "version" node
+		Version: "v1",
+		Root: &yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{
+				{Content: []*yaml.Node{
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "version",
+					},
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "v1",
+					},
+				}},
+			},
+		},
+	},
+
+	{ // 1
+		Root:       nil,
+		ShouldFail: true,
+	},
+	{ // 2
+		Root:       &yaml.Node{Kind: yaml.ScalarNode},
+		ShouldFail: true,
+	},
+	{ // 3
+		Root:       &yaml.Node{Kind: yaml.DocumentNode},
+		ShouldFail: true,
+	},
+	{ // 4
+		Root:       &yaml.Node{Kind: yaml.DocumentNode, Content: make([]*yaml.Node, 2)},
+		ShouldFail: true,
+	},
+	{ // 5
+		Root: &yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{
+				{Content: []*yaml.Node{
+					{
+						Kind:  yaml.DocumentNode,
+						Value: "version",
+					},
+				}},
+			},
+		},
+		ShouldFail: true,
+	},
+	{ // 6
+		Root: &yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{
+				{Content: []*yaml.Node{
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "version",
+					},
+				}},
+			},
+		},
+		ShouldFail: true,
+	},
+}

--- a/internal/cli/testdata/env.yml
+++ b/internal/cli/testdata/env.yml
@@ -1,0 +1,30 @@
+version: v1
+address: 0.0.0.0:7373
+
+system:
+  admin:
+    identity: f4477eea43ff73d05020906cdb9d277dacf638326165ba92eb262531382a9a76
+  
+tls:
+  key: ./private.key
+  cert: ./public.crt
+
+  client:
+    verify_cert: false
+  
+unseal:
+  environment:
+    name: "KES_UNSEAL_KEY"
+
+enclave:
+  minio:
+    admin: 
+      identity: 974540ce5be311df3f29bff18caed43fcdbbeaf32efabee222b4827402699491
+    policy:
+      tenant-1:
+        allow:
+        - /v1/key/create/tenant-1*
+        - /v1/key/generate/tenant-1*
+        - /v1/key/decrypt/tenant-1*
+        identities:
+        - 413c29fe16e7e818a74386c5350ed6781ea4791fd65ce2454568695bd32b95e0


### PR DESCRIPTION
This commit requires a init config file
version on stateful KES server config files.

Currently, the only valid version is 'v1'.