### PR TITLE
WIP: add key export to stateful KES server API

### DIFF
--- a/client.go
+++ b/client.go
@@ -387,6 +387,18 @@ func (c *Client) ImportKey(ctx context.Context, name string, key []byte) error {
 	return enclave.ImportKey(ctx, name, key)
 }
 
+// ExportKey exports the specified key from a KES server. It
+// returns ErrKeyNotFound if a key with the given name does not
+// exists.
+func (c *Client) ExportKey(ctx context.Context, name string) ([]byte, *KeyInfo, error) {
+	enclave := Enclave{
+		Endpoints:  c.Endpoints,
+		HTTPClient: c.HTTPClient,
+		lb:         c.lb,
+	}
+	return enclave.ExportKey(ctx, name)
+}
+
 // DescribeKey returns the KeyInfo for the given key.
 // It returns ErrKeyNotFound if no such key exists.
 func (c *Client) DescribeKey(ctx context.Context, name string) (*KeyInfo, error) {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -59,6 +59,7 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 
 	config.APIs = append(config.APIs, serverCreateKey(mux, config))
 	config.APIs = append(config.APIs, serverImportKey(mux, config))
+	config.APIs = append(config.APIs, serverExportKey(mux, config))
 	config.APIs = append(config.APIs, serverDescribeKey(mux, config))
 	config.APIs = append(config.APIs, serverDeleteKey(mux, config))
 	config.APIs = append(config.APIs, serverGenerateKey(mux, config))

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -137,6 +137,11 @@ func (k *Key) ID() string {
 	return hex.EncodeToString(h[:Size])
 }
 
+func (k *Key) Bytes() []byte {
+	b := make([]byte, 0, len(k.bytes))
+	return append(b, k.bytes...)
+}
+
 // Clone returns a deep copy of the key.
 func (k *Key) Clone() Key {
 	return Key{

--- a/key.go
+++ b/key.go
@@ -50,6 +50,7 @@ type PCP struct {
 // KeyInfo describes a cryptographic key at a KES server.
 type KeyInfo struct {
 	Name      string    `json:"name"`                 // Name of the cryptographic key
+	Algorithm string    `json:"algorithm,omitempty"`  // Cryptographic algorithm the key can be used for
 	ID        string    `json:"id,omitempty"`         // ID of the cryptographic key
 	CreatedAt time.Time `json:"created_at,omitempty"` // Point in time when the key was created
 	CreatedBy Identity  `json:"created_by,omitempty"` // Identity that created the key


### PR DESCRIPTION
This commit adds a new `/v1/key/export` API
to the stateful KES server. It allows keys
to be exported by clients.

A major use case for this API is to enable a
stateless KES server to use a stateful KES
server as key store. Therefore, the stateless
KES server has to import and export keys
from/to the stateful KES server.

Furthermore, this commit adds the client-side
implementation for the `/v1/key/export` API
as well as a CLI command `kes key export`.