### PR TITLE
add new secrets API

### DIFF
--- a/client.go
+++ b/client.go
@@ -499,6 +499,69 @@ func (c *Client) ListKeys(ctx context.Context, pattern string) (*KeyIterator, er
 	return enclave.ListKeys(ctx, pattern)
 }
 
+// CreateSecret creates a new secret with the given name.
+//
+// It returns ErrSecretExists if a secret with the same name
+// already exists.
+func (c *Client) CreateSecret(ctx context.Context, name string, value []byte, options *SecretOptions) error {
+	enclave := Enclave{
+		Endpoints:  c.Endpoints,
+		HTTPClient: c.HTTPClient,
+		lb:         c.lb,
+	}
+	return enclave.CreateSecret(ctx, name, value, options)
+}
+
+// DescribeSecret returns the SecretInfo for the given secret.
+//
+// It returns ErrSecretNotFound if no such secret exists.
+func (c *Client) DescribeSecret(ctx context.Context, name string) (*SecretInfo, error) {
+	enclave := Enclave{
+		Endpoints:  c.Endpoints,
+		HTTPClient: c.HTTPClient,
+		lb:         c.lb,
+	}
+	return enclave.DescribeSecret(ctx, name)
+}
+
+// ReadSecret returns the secret with the given name.
+//
+// It returns ErrSecretNotFound if no such secret exists.
+func (c *Client) ReadSecret(ctx context.Context, name string) ([]byte, *SecretInfo, error) {
+	enclave := Enclave{
+		Endpoints:  c.Endpoints,
+		HTTPClient: c.HTTPClient,
+		lb:         c.lb,
+	}
+	return enclave.ReadSecret(ctx, name)
+}
+
+// DeleteSecret deletes the secret with the given name.
+//
+// It returns ErrSecretNotFound if no such secret exists.
+func (c *Client) DeleteSecret(ctx context.Context, name string) error {
+	enclave := Enclave{
+		Endpoints:  c.Endpoints,
+		HTTPClient: c.HTTPClient,
+		lb:         c.lb,
+	}
+	return enclave.DeleteSecret(ctx, name)
+}
+
+// ListSecrets returns a SecretIter that iterates over all secrets
+// matching the pattern.
+//
+// The '*' pattern matches any secret. If pattern is empty the
+// SecretIter iterates over all secrets names.
+func (c *Client) ListSecrets(ctx context.Context, pattern string) (*SecretIter, error) {
+	enclave := Enclave{
+		Endpoints:  c.Endpoints,
+		HTTPClient: c.HTTPClient,
+		lb:         c.lb,
+	}
+	return enclave.ListSecrets(ctx, pattern)
+}
+
 // SetPolicy creates the given policy. If a policy with the same
 // name already exists, SetPolicy overwrites the existing policy
 // with the given one. Any existing identites will be assigned to

--- a/cmd/kes/key.go
+++ b/cmd/kes/key.go
@@ -226,7 +226,7 @@ func describeKeyCmd(args []string) {
 	case cmd.NArg() == 0:
 		cli.Fatal("no key name specified. See 'kes key info --help'")
 	case cmd.NArg() > 1:
-		cli.Fatal("too many arguments. See 'kes key ls --help'")
+		cli.Fatal("too many arguments. See 'kes key info --help'")
 	}
 
 	ctx, cancelCtx := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)

--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -33,6 +33,7 @@ Commands:
 
     enclave                  Manage KES enclaves.
     key                      Manage cryptographic keys.
+    secret                   Manage KES secrets.
     policy                   Manage KES policies.
     identity                 Manage KES identities.
 
@@ -63,6 +64,7 @@ func main() {
 
 		"enclave":  enclaveCmd,
 		"key":      keyCmd,
+		"secret":   secretCmd,
 		"policy":   policyCmd,
 		"identity": identityCmd,
 

--- a/cmd/kes/secret.go
+++ b/cmd/kes/secret.go
@@ -1,0 +1,543 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"time"
+
+	"aead.dev/mem"
+	tui "github.com/charmbracelet/lipgloss"
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/cli"
+	"github.com/minio/kes/internal/secret"
+	flag "github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+const secretCmdUsage = `Usage:
+    kes secret <command>
+
+Commands:
+    create                   Create a new secret.
+    info                     Get information about a secret. 
+    show                     Display a secret.
+    ls                       List secrets.
+    rm                       Delete a secret.
+
+Options:
+    -h, --help               Print command line options.
+`
+
+func secretCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, secretCmdUsage) }
+
+	subCmds := commands{
+		"create": createSecretCmd,
+		"info":   describeSecretCmd,
+		"show":   showSecretCmd,
+		"ls":     lsSecretCmd,
+		"rm":     deleteSecretCmd,
+	}
+
+	if len(args) < 2 {
+		cmd.Usage()
+		os.Exit(2)
+	}
+	if cmd, ok := subCmds[args[1]]; ok {
+		cmd(args[1:])
+		return
+	}
+
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes key --help'", err)
+	}
+	if cmd.NArg() > 0 {
+		cli.Fatalf("%q is not a key command. See 'kes key --help'", cmd.Arg(0))
+	}
+	cmd.Usage()
+	os.Exit(2)
+}
+
+const createSecretCmdUsage = `Usage:
+    kes secret create [options] <name> <value>
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+    -e, --enclave <name>     Operate within the specified enclave.
+        --file <name>        Use the file content as secret value.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes secret create my-secret
+      Enter secret:
+
+    $ kes secret create my-secret password123
+    $ kes secret create my-secret --file password.txt
+`
+
+func createSecretCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, createSecretCmdUsage) }
+
+	var (
+		insecureSkipVerify bool
+		enclaveName        string
+		filename           string
+	)
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	cmd.StringVarP(&enclaveName, "enclave", "e", "", "Operate within the specified enclave")
+	cmd.StringVar(&filename, "file", "", "Use the file contet as secret value")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes secret create --help'", err)
+	}
+
+	switch n := cmd.NArg(); {
+	case n == 0:
+		cli.Fatal("no secret name specified. See 'kes secret create --help'")
+	case n == 2 && filename != "":
+		cli.Fatalf("cannot read from '%s' when a secret value is specified. See 'kes secret create --help'", filename)
+	case n > 2:
+		cli.Fatal("too many arguments. See 'kes secret create --help'")
+	}
+
+	var value []byte
+	switch {
+	case cmd.NArg() == 2:
+		value = []byte(cmd.Arg(1))
+	case filename != "":
+		file, err := os.Open(filename)
+		if err != nil {
+			cli.Fatalf("failed to read '%s': %v", err)
+		}
+		defer file.Close()
+
+		var buffer bytes.Buffer
+		if _, err = io.Copy(&buffer, mem.LimitReader(os.Stdin, secret.MaxSize)); err != nil {
+			cli.Fatalf("failed to read '%s': %v", err)
+		}
+		value = buffer.Bytes()
+	default:
+		fmt.Print("Enter secret: ")
+		secret, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			cli.Fatalf("failed to read secret input: %v", err)
+		}
+		value = secret
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	name := cmd.Arg(0)
+	enclave := newEnclave(enclaveName, insecureSkipVerify)
+	if err := enclave.CreateSecret(ctx, name, value, nil); err != nil {
+		if errors.Is(err, context.Canceled) {
+			os.Exit(1)
+		}
+		cli.Fatalf("failed to create secret %q: %v", name, err)
+	}
+}
+
+const describeSecretCmdUsage = `Usage:
+    kes secret info [options] <name>
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+        --json               Print keys in JSON format. 
+        --color <when>       Specify when to use colored output. The automatic
+                             mode only enables colors if an interactive terminal
+                             is detected - colors are automatically disabled if
+                             the output goes to a pipe.
+                             Possible values: *auto*, never, always.
+    -e, --enclave <name>     Operate within the specified enclave.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes secret info my-secret
+`
+
+func describeSecretCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, describeSecretCmdUsage) }
+
+	var (
+		jsonFlag           bool
+		colorFlag          colorOption
+		insecureSkipVerify bool
+		enclaveName        string
+	)
+	cmd.BoolVar(&jsonFlag, "json", false, "Print identities in JSON format")
+	cmd.Var(&colorFlag, "color", "Specify when to use colored output")
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	cmd.StringVarP(&enclaveName, "enclave", "e", "", "Operate within the specified enclave")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes secret info --help'", err)
+	}
+
+	switch {
+	case cmd.NArg() == 0:
+		cli.Fatal("no secret name specified. See 'kes secret info --help'")
+	case cmd.NArg() > 1:
+		cli.Fatal("too many arguments. See 'kes secret info --help'")
+	}
+
+	ctx, cancelCtx := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancelCtx()
+
+	name := cmd.Arg(0)
+	enclave := newEnclave(enclaveName, insecureSkipVerify)
+	info, err := enclave.DescribeSecret(ctx, name)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			os.Exit(1)
+		}
+		cli.Fatalf("failed to describe keys: %v", err)
+	}
+	if jsonFlag {
+		if err = json.NewEncoder(os.Stdout).Encode(info); err != nil {
+			cli.Fatalf("failed to describe keys: %v", err)
+		}
+		return
+	}
+
+	var faint, nameStyle tui.Style
+	if colorFlag.Colorize() {
+		const ColorName tui.Color = "#2e42d1"
+		faint = faint.Faint(true).Bold(true)
+		nameStyle = nameStyle.Foreground(ColorName)
+	}
+	year, month, day := info.CreatedAt.Date()
+	hour, min, sec := info.CreatedAt.Clock()
+
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Name")),
+		nameStyle.Render(info.Name),
+	)
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Type")),
+		info.Type.String(),
+	)
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Created At")),
+		fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec),
+	)
+	if info.CreatedBy.IsUnknown() {
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Created By")),
+			"<unknown>",
+		)
+	} else {
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Created By")),
+			info.CreatedBy,
+		)
+	}
+}
+
+const showSecretCmdUsage = `Usage:
+    kes secret show [options] <name>
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+    -p, --plain              Print the raw secret without any styling.
+        --json               Print the secret in JSON format. 
+        --color <when>       Specify when to use colored output. The automatic
+                             mode only enables colors if an interactive terminal
+                             is detected - colors are automatically disabled if
+                             the output goes to a pipe.
+                             Possible values: *auto*, never, always.
+    -e, --enclave <name>     Operate within the specified enclave.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes secret show my-secret
+`
+
+func showSecretCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, showSecretCmdUsage) }
+
+	var (
+		plainFlag          bool
+		jsonFlag           bool
+		colorFlag          colorOption
+		insecureSkipVerify bool
+		enclaveName        string
+	)
+	cmd.BoolVar(&jsonFlag, "json", false, "Print identities in JSON format")
+	cmd.Var(&colorFlag, "color", "Specify when to use colored output")
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	cmd.BoolVarP(&plainFlag, "plain", "p", false, "Print the raw secret without any styling")
+	cmd.StringVarP(&enclaveName, "enclave", "e", "", "Operate within the specified enclave")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes secret show --help'", err)
+	}
+
+	switch {
+	case cmd.NArg() == 0:
+		cli.Fatal("no secret name specified. See 'kes secret show --help'")
+	case cmd.NArg() > 1:
+		cli.Fatal("too many arguments. See 'kes secret show --help'")
+	}
+
+	ctx, cancelCtx := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancelCtx()
+
+	name := cmd.Arg(0)
+	enclave := newEnclave(enclaveName, insecureSkipVerify)
+	secret, info, err := enclave.ReadSecret(ctx, name)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			os.Exit(1)
+		}
+		cli.Fatalf("failed to describe keys: %v", err)
+	}
+	if plainFlag {
+		fmt.Println(string(secret))
+		return
+	}
+	if jsonFlag {
+		type JSON struct {
+			Bytes     []byte       `json:"bytes"`
+			Name      string       `json:"name"`
+			CreatedAt time.Time    `json:"created_at,omitempty"`
+			CreatedBy kes.Identity `json:"created_by,omitempty"`
+		}
+		err = json.NewEncoder(os.Stdout).Encode(JSON{
+			Bytes:     secret,
+			Name:      info.Name,
+			CreatedAt: info.CreatedAt,
+			CreatedBy: info.CreatedBy,
+		})
+		if err != nil {
+			cli.Fatalf("failed to describe keys: %v", err)
+		}
+		return
+	}
+
+	var faint, nameStyle tui.Style
+	if colorFlag.Colorize() {
+		const ColorName tui.Color = "#2e42d1"
+		faint = faint.Faint(true).Bold(true)
+		nameStyle = nameStyle.Foreground(ColorName)
+	}
+	year, month, day := info.CreatedAt.Date()
+	hour, min, sec := info.CreatedAt.Clock()
+
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Name")),
+		nameStyle.Render(info.Name),
+	)
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Type")),
+		info.Type.String(),
+	)
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Created At")),
+		fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec),
+	)
+	if info.CreatedBy.IsUnknown() {
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Created By")),
+			"<unknown>",
+		)
+	} else {
+		fmt.Println(
+			faint.Render(fmt.Sprintf("%-11s", "Created By")),
+			info.CreatedBy,
+		)
+	}
+	fmt.Println()
+	fmt.Println(
+		faint.Render(fmt.Sprintf("%-11s", "Value")),
+		string(secret),
+	)
+}
+
+const deleteSecretCmdUsage = `Usage:
+    kes secret rm [options] <name>...
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+    -e, --enclave <name>     Operate within the specified enclave.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes secret rm my-secret
+`
+
+func deleteSecretCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, deleteSecretCmdUsage) }
+
+	var (
+		insecureSkipVerify bool
+		enclaveName        string
+	)
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	cmd.StringVarP(&enclaveName, "enclave", "e", "", "Operate within the specified enclave")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes secret rm --help'", err)
+	}
+	if cmd.NArg() == 0 {
+		cli.Fatal("no secret name specified. See 'kes secret rm --help'")
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	enclave := newEnclave(enclaveName, insecureSkipVerify)
+	for _, name := range cmd.Args() {
+		if err := enclave.DeleteSecret(ctx, name); err != nil {
+			if errors.Is(err, context.Canceled) {
+				os.Exit(1)
+			}
+			cli.Fatalf("failed to remove secret %q: %v", name, err)
+		}
+	}
+}
+
+const lsSecretCmdUsage = `Usage:
+    kes secret ls [options] [<pattern>]
+
+Options:
+    -k, --insecure           Skip TLS certificate validation.
+        --json               Print keys in JSON format. 
+        --color <when>       Specify when to use colored output. The automatic
+                             mode only enables colors if an interactive terminal
+                             is detected - colors are automatically disabled if
+                             the output goes to a pipe.
+                             Possible values: *auto*, never, always.
+    -e, --enclave <name>     Operate within the specified enclave.
+
+    -h, --help               Print command line options.
+
+Examples:
+    $ kes secret ls
+    $ kes secret ls 'my-secret*'
+`
+
+func lsSecretCmd(args []string) {
+	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, lsSecretCmdUsage) }
+
+	var (
+		jsonFlag           bool
+		colorFlag          colorOption
+		insecureSkipVerify bool
+		enclaveName        string
+	)
+	cmd.BoolVar(&jsonFlag, "json", false, "Print identities in JSON format")
+	cmd.Var(&colorFlag, "color", "Specify when to use colored output")
+	cmd.BoolVarP(&insecureSkipVerify, "insecure", "k", false, "Skip TLS certificate validation")
+	cmd.StringVarP(&enclaveName, "enclave", "e", "", "Operate within the specified enclave")
+	if err := cmd.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		cli.Fatalf("%v. See 'kes secret ls --help'", err)
+	}
+
+	if cmd.NArg() > 1 {
+		cli.Fatal("too many arguments. See 'kes secret ls --help'")
+	}
+
+	pattern := "*"
+	if cmd.NArg() == 1 {
+		pattern = cmd.Arg(0)
+	}
+
+	ctx, cancelCtx := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancelCtx()
+
+	enclave := newEnclave(enclaveName, insecureSkipVerify)
+	iterator, err := enclave.ListSecrets(ctx, pattern)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			os.Exit(1)
+		}
+		cli.Fatalf("failed to list secrets: %v", err)
+	}
+	defer iterator.Close()
+
+	if jsonFlag {
+		if _, err = iterator.WriteTo(os.Stdout); err != nil {
+			cli.Fatal(err)
+		}
+		if err = iterator.Close(); err != nil {
+			cli.Fatal(err)
+		}
+	} else {
+		secrets, err := iterator.Values(0)
+		if err != nil {
+			cli.Fatalf("failed to list keys: %v", err)
+		}
+		if err = iterator.Close(); err != nil {
+			cli.Fatalf("failed to list keys: %v", err)
+		}
+
+		if len(secrets) > 0 {
+			sort.Slice(secrets, func(i, j int) bool {
+				return strings.Compare(secrets[i].Name, secrets[j].Name) < 0
+			})
+
+			headerStyle := tui.NewStyle()
+			dateStyle := tui.NewStyle()
+			if colorFlag.Colorize() {
+				const ColorDate tui.Color = "#5f8700"
+				headerStyle = headerStyle.Underline(true).Bold(true)
+				dateStyle = dateStyle.Foreground(ColorDate)
+			}
+
+			fmt.Println(
+				headerStyle.Render(fmt.Sprintf("%-19s", "Date Created")),
+				headerStyle.Render("Key"),
+			)
+			for _, key := range secrets {
+				var date string
+				if key.CreatedAt.IsZero() {
+					date = fmt.Sprintf("%5s%s%5s", " ", "<unknown>", " ")
+				} else {
+					year, month, day := key.CreatedAt.Local().Date()
+					hour, min, sec := key.CreatedAt.Local().Clock()
+					date = fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, min, sec)
+				}
+				fmt.Printf("%s %s\n", dateStyle.Render(date), key.Name)
+			}
+		}
+
+	}
+}

--- a/error.go
+++ b/error.go
@@ -36,6 +36,14 @@ var (
 	// to create a cryptographic key which already exists.
 	ErrKeyExists = NewError(http.StatusBadRequest, "key already exists")
 
+	// ErrSecretNotFound is returned by a KES server when a client tries to
+	// access a secret which does not exist.
+	ErrSecretNotFound = NewError(http.StatusNotFound, "secret does not exist")
+
+	// ErrKeyExists is returned by a KES server when a client tries
+	// to create a secret which already exists.
+	ErrSecretExists = NewError(http.StatusNotFound, "secret already exists")
+
 	// ErrPolicyNotFound is returned by a KES server when a client
 	// tries to access a policy which does not exist.
 	ErrPolicyNotFound = NewError(http.StatusNotFound, "policy does not exist")

--- a/internal/http/server-secret-api.go
+++ b/internal/http/server-secret-api.go
@@ -1,0 +1,373 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"aead.dev/mem"
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/internal/secret"
+)
+
+func serverCreateSecret(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodPost
+		APIPath = "/v1/secret/create/"
+		MaxBody = int64(1 * mem.MiB)
+		Timeout = 15 * time.Second
+	)
+	type Request struct {
+		Type  kes.SecretType `json:"type"`
+		Bytes []byte         `json:"bytes"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		err := Sync(config.Vault.RLocker(), func() error {
+			enclave, err := lookupEnclave(config.Vault, r)
+			if err != nil {
+				return err
+			}
+			return Sync(enclave.Locker(), func() error {
+				if err = enclave.VerifyRequest(r); err != nil {
+					return err
+				}
+
+				name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+				if err = validateName(name); err != nil {
+					return err
+				}
+
+				var req Request
+				if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+					return err
+				}
+				if req.Type != kes.SecretGeneric { // Currently, we only support generic secrets
+					return kes.NewError(http.StatusBadRequest, "unsupported secret type '"+req.Type.String()+"'")
+				}
+
+				secret := secret.NewSecret(req.Bytes, auth.Identify(r))
+				return enclave.CreateSecret(r.Context(), name, secret)
+			})
+		})
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverDescribeSecret(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodGet
+		APIPath = "/v1/secret/describe/"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	type Response struct {
+		Type      kes.SecretType `json:"type"`
+		CreatedAt time.Time      `json:"created_at"`
+		ModTime   time.Time      `json:"mod_time"`
+		CreatedBy kes.Identity   `json:"created_by"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		secret, err := VSync(config.Vault.RLocker(), func() (secret.Secret, error) {
+			enclave, err := lookupEnclave(config.Vault, r)
+			if err != nil {
+				return secret.Secret{}, err
+			}
+			return VSync(enclave.RLocker(), func() (secret.Secret, error) {
+				if err = enclave.VerifyRequest(r); err != nil {
+					return secret.Secret{}, err
+				}
+
+				name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+				if err = validateName(name); err != nil {
+					return secret.Secret{}, err
+				}
+				return enclave.GetSecret(r.Context(), name)
+			})
+		})
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(Response{
+			Type:      secret.Type(),
+			CreatedAt: secret.CreatedAt(),
+			ModTime:   secret.ModTime(),
+			CreatedBy: secret.CreatedBy(),
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverReadSecret(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodGet
+		APIPath = "/v1/secret/read/"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	type Response struct {
+		Bytes     []byte         `json:"bytes"`
+		Type      kes.SecretType `json:"type"`
+		CreatedAt time.Time      `json:"created_at"`
+		ModTime   time.Time      `json:"mod_time"`
+		CreatedBy kes.Identity   `json:"created_by"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		secret, err := VSync(config.Vault.RLocker(), func() (secret.Secret, error) {
+			enclave, err := lookupEnclave(config.Vault, r)
+			if err != nil {
+				return secret.Secret{}, err
+			}
+			return VSync(enclave.RLocker(), func() (secret.Secret, error) {
+				if err = enclave.VerifyRequest(r); err != nil {
+					return secret.Secret{}, err
+				}
+
+				name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+				if err = validateName(name); err != nil {
+					return secret.Secret{}, err
+				}
+				return enclave.GetSecret(r.Context(), name)
+			})
+		})
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(Response{
+			Bytes:     secret.Bytes(),
+			Type:      secret.Type(),
+			CreatedAt: secret.CreatedAt(),
+			ModTime:   secret.ModTime(),
+			CreatedBy: secret.CreatedBy(),
+		})
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverDeleteSecret(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method  = http.MethodDelete
+		APIPath = "/v1/secret/delete/"
+		MaxBody = 0
+		Timeout = 15 * time.Second
+	)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		err := Sync(config.Vault.RLocker(), func() error {
+			enclave, err := lookupEnclave(config.Vault, r)
+			if err != nil {
+				return err
+			}
+			return Sync(enclave.Locker(), func() error {
+				if err = enclave.VerifyRequest(r); err != nil {
+					return err
+				}
+
+				name := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+				if err = validateName(name); err != nil {
+					return err
+				}
+				return enclave.DeleteSecret(r.Context(), name)
+			})
+		})
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}
+
+func serverListSecrets(mux *http.ServeMux, config *ServerConfig) API {
+	const (
+		Method      = http.MethodGet
+		APIPath     = "/v1/secret/list/"
+		MaxBody     = 0
+		Timeout     = 15 * time.Second
+		ContentType = "application/x-ndjson"
+	)
+	type Response struct {
+		Name      string         `json:"name,omitempty"`
+		Type      kes.SecretType `json:"type,omitempty"`
+		CreatedAt time.Time      `json:"created_at,omitempty"`
+		ModTime   time.Time      `json:"mod_time,omitempty"`
+		CreatedBy kes.Identity   `json:"created_by,omitempty"`
+
+		Err string `json:"error,omitempty"`
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w = audit(w, r, config.AuditLog.Log())
+
+		if r.Method != Method {
+			w.Header().Set("Accept", Method)
+			Error(w, errMethodNotAllowed)
+			return
+		}
+		if err := normalizeURL(r.URL, APIPath); err != nil {
+			Error(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, MaxBody)
+
+		hasWritten, err := VSync(config.Vault.RLocker(), func() (bool, error) {
+			enclave, err := lookupEnclave(config.Vault, r)
+			if err != nil {
+				return false, err
+			}
+			return VSync(enclave.RLocker(), func() (bool, error) {
+				if err = enclave.VerifyRequest(r); err != nil {
+					return false, err
+				}
+				pattern := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, APIPath))
+				if err = validatePattern(pattern); err != nil {
+					return false, err
+				}
+
+				iterator, err := enclave.ListSecrets(r.Context())
+				if err != nil {
+					return false, err
+				}
+				defer iterator.Close()
+
+				var hasWritten bool
+				encoder := json.NewEncoder(w)
+				for iterator.Next() {
+					if ok, _ := path.Match(pattern, iterator.Name()); !ok || iterator.Name() == "" {
+						continue
+					}
+					secret, err := enclave.GetSecret(r.Context(), iterator.Name())
+					if err != nil {
+						return hasWritten, err
+					}
+					if !hasWritten {
+						hasWritten = true
+						w.Header().Set("Content-Type", ContentType)
+						w.WriteHeader(http.StatusOK)
+					}
+
+					err = encoder.Encode(Response{
+						Name:      iterator.Name(),
+						CreatedAt: secret.CreatedAt(),
+						ModTime:   secret.ModTime(),
+						CreatedBy: secret.CreatedBy(),
+					})
+					if err != nil {
+						return hasWritten, err
+					}
+				}
+				return hasWritten, iterator.Close()
+			})
+		})
+		if err != nil {
+			if hasWritten {
+				json.NewEncoder(w).Encode(Response{Err: err.Error()})
+			} else {
+				Error(w, err)
+			}
+			return
+		}
+		if !hasWritten {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+	mux.HandleFunc(APIPath, timeout(Timeout, proxy(config.Proxy, config.Metrics.Count(config.Metrics.Latency(handler)))))
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Timeout: Timeout,
+	}
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -67,6 +67,12 @@ func NewServerMux(config *ServerConfig) *http.ServeMux {
 	config.APIs = append(config.APIs, serverBulkDecryptKey(mux, config))
 	config.APIs = append(config.APIs, serverListKey(mux, config))
 
+	config.APIs = append(config.APIs, serverCreateSecret(mux, config))
+	config.APIs = append(config.APIs, serverDescribeSecret(mux, config))
+	config.APIs = append(config.APIs, serverReadSecret(mux, config))
+	config.APIs = append(config.APIs, serverDeleteSecret(mux, config))
+	config.APIs = append(config.APIs, serverListSecrets(mux, config))
+
 	config.APIs = append(config.APIs, serverDescribePolicy(mux, config))
 	config.APIs = append(config.APIs, serverAssignPolicy(mux, config))
 	config.APIs = append(config.APIs, serverReadPolicy(mux, config))

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -1,0 +1,136 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package secret
+
+import (
+	"bytes"
+	"encoding/gob"
+	"time"
+
+	"aead.dev/mem"
+	"github.com/minio/kes"
+)
+
+// MaxSize is the maximum size of a secret.
+const MaxSize = 1 * mem.MiB
+
+// Secret is a generic secret, like a password,
+// API key, or private key.
+type Secret struct {
+	kind      kes.SecretType
+	createdAt time.Time
+	modTime   time.Time
+	createdBy kes.Identity
+
+	bytes []byte
+}
+
+// NewSecret returns a new generic Secret from the given
+// value.
+//
+// Its CreatedAt timestamp is time.Now and its CreatedBy
+// identity is the owner.
+func NewSecret(value []byte, owner kes.Identity) Secret {
+	now := time.Now().UTC()
+	return Secret{
+		bytes:     clone(value),
+		kind:      kes.SecretGeneric,
+		createdAt: now,
+		modTime:   now,
+		createdBy: owner,
+	}
+}
+
+// Type returns the Secret's type.
+func (s *Secret) Type() kes.SecretType { return s.kind }
+
+// CreatedAt returns the point in time when the secret has
+// been created.
+func (s *Secret) CreatedAt() time.Time { return s.createdAt }
+
+// ModTime returns the most recent point in time at which
+// the secret has been modified. If the secret has never
+// been modified, its ModTime is equal to its CreatedAt
+// time.
+func (s *Secret) ModTime() time.Time { return s.modTime }
+
+// CreatedBy returns the identity that created the secret.
+func (s *Secret) CreatedBy() kes.Identity { return s.createdBy }
+
+// Bytes returns the Secret value.
+func (s *Secret) Bytes() []byte { return clone(s.bytes) }
+
+// MarshalBinary returns the Secret's binary representation.
+func (s *Secret) MarshalBinary() ([]byte, error) {
+	type GOB struct {
+		Type      kes.SecretType
+		CreatedAt time.Time
+		ModTime   time.Time
+		CreatedBy kes.Identity
+		Bytes     []byte
+	}
+
+	var buffer bytes.Buffer
+	err := gob.NewEncoder(&buffer).Encode(GOB{
+		Type:      s.kind,
+		Bytes:     s.bytes,
+		CreatedAt: s.CreatedAt(),
+		ModTime:   s.modTime,
+		CreatedBy: s.CreatedBy(),
+	})
+	return buffer.Bytes(), err
+}
+
+// UnmarshalBinary unmarshals the Secret's binary representation.
+func (s *Secret) UnmarshalBinary(data []byte) error {
+	type GOB struct {
+		Type      kes.SecretType
+		CreatedAt time.Time
+		ModTime   time.Time
+		CreatedBy kes.Identity
+		Bytes     []byte
+	}
+
+	var value GOB
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&value); err != nil {
+		return err
+	}
+
+	s.kind = value.Type
+	s.bytes = value.Bytes
+	s.createdAt = value.CreatedAt
+	s.modTime = value.ModTime
+	s.createdBy = value.CreatedBy
+	return nil
+}
+
+// Iter is an iterator over secrets.
+type Iter interface {
+	// Next fetches the next secret entry. It returns
+	// false when there are no more entries or once it
+	// encounters an error.
+	//
+	// Once Next returns false, it returns false on any
+	// subsequent Next call.
+	Next() bool
+
+	// Name returns the name of the latest fetched entry.
+	// It returns the same name until Next is called again.
+	//
+	// As long as Next hasn't been called once or once Next
+	// returns false, Name returns the empty string.
+	Name() string
+
+	// Close closes the Iter. Once closed, any subsequent
+	// Next call returns false.
+	//
+	// Close returns the first error encountered while iterating
+	// over the entires, if any. Otherwise, it returns the error
+	// encountered while cleaning up any resources, if any.
+	// Subsequent calls to Close return the same error.
+	Close() error
+}
+
+func clone(data []byte) []byte { return append(make([]byte, 0, len(data)), data...) }

--- a/internal/sys/secret-fs.go
+++ b/internal/sys/secret-fs.go
@@ -1,0 +1,95 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package sys
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/key"
+	"github.com/minio/kes/internal/secret"
+)
+
+// NewSecretFS returns a new SecretFS that
+// reads/writes secrets from/to the given
+// directory path and en/decrypts them with
+// the given encryption key.
+func NewSecretFS(filename string, key key.Key) SecretFS {
+	return &secretFS{
+		rootDir: filename,
+		rootKey: key,
+	}
+}
+
+type secretFS struct {
+	rootDir string
+	rootKey key.Key
+}
+
+func (fs *secretFS) CreateSecret(_ context.Context, name string, secret secret.Secret) error {
+	if err := valid(name); err != nil {
+		return err
+	}
+	plaintext, err := secret.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	filename := filepath.Join(fs.rootDir, name)
+	err = createFile(filename, fs.rootKey, plaintext, []byte(name))
+	if errors.Is(err, os.ErrExist) {
+		return kes.ErrSecretExists
+	}
+	if err != nil {
+		os.Remove(filename)
+	}
+	return err
+}
+
+func (fs *secretFS) GetSecret(_ context.Context, name string) (sec secret.Secret, err error) {
+	if err = valid(name); err != nil {
+		return sec, err
+	}
+
+	filename := filepath.Join(fs.rootDir, name)
+	plaintext, err := readFile(filename, fs.rootKey, secret.MaxSize, []byte(name))
+	if errors.Is(err, os.ErrNotExist) {
+		return sec, kes.ErrSecretNotFound
+	}
+	if err != nil {
+		return sec, err
+	}
+
+	if err = sec.UnmarshalBinary(plaintext); err != nil {
+		return sec, err
+	}
+	return sec, nil
+}
+
+func (fs *secretFS) DeleteSecret(_ context.Context, name string) error {
+	if err := valid(name); err != nil {
+		return err
+	}
+
+	err := os.Remove(filepath.Join(fs.rootDir, name))
+	if errors.Is(err, os.ErrNotExist) {
+		return kes.ErrSecretNotFound
+	}
+	return err
+}
+
+func (fs *secretFS) ListSecrets(ctx context.Context) (secret.Iter, error) {
+	file, err := os.Open(fs.rootDir)
+	if err != nil {
+		return nil, err
+	}
+	return &iter{
+		ctx:  ctx,
+		file: file,
+	}, nil
+}

--- a/key.go
+++ b/key.go
@@ -328,7 +328,7 @@ func (i *KeyIterator) Values(n int) ([]KeyInfo, error) {
 	return values, nil
 }
 
-// Close closes the IdentityIterator and releases
+// Close closes the KeyIterator and releases
 // any associated resources.
 func (i *KeyIterator) Close() error {
 	if !i.closed {

--- a/secret.go
+++ b/secret.go
@@ -1,0 +1,298 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"time"
+)
+
+// SecretOptions is a struct containing customization
+// options for secret - like the Secret type.
+type SecretOptions struct {
+	// Type specifies the type of the Secret.
+	// Its default vaule is SecretGeneric.
+	Type SecretType
+}
+
+// All valid secret types.
+const (
+	SecretGeneric SecretType = iota
+)
+
+// SecretType is an enum representing the type of a Secret.
+type SecretType uint
+
+// String returns the SecretType string representation.
+func (s SecretType) String() string {
+	switch s {
+	case SecretGeneric:
+		return "generic"
+	default:
+		return "%" + strconv.Itoa(int(s))
+	}
+}
+
+// MarshalText returns the SecretType text representation.
+// In contrast to String, it returns an error if s is not
+// a valid SecretType.
+func (s SecretType) MarshalText() ([]byte, error) {
+	switch s {
+	case SecretGeneric:
+		return []byte("generic"), nil
+	default:
+		return nil, errors.New("kes: invalid secret type '%" + strconv.Itoa(int(s)) + "'")
+	}
+}
+
+// UnmarshalText decodes the given SecretType text
+// representation into s. It returns an error if
+// text is not a valid SecretType.
+func (s *SecretType) UnmarshalText(text []byte) error {
+	switch v := string(text); v {
+	case "generic":
+		*s = SecretGeneric
+		return nil
+	default:
+		return errors.New("kes: invalid secret type '" + v + "'")
+	}
+}
+
+// SecretInfo describes a secret at a KES server.
+type SecretInfo struct {
+	Name      string     // The name of the secret
+	Type      SecretType // The type of secret
+	CreatedAt time.Time  // Point in time when the secret was created
+	ModTime   time.Time  // Most recent point in time when the secret has been modified.
+	CreatedBy Identity   // Identity that created the secret
+}
+
+// MarshalJSON returns the SecretInfo JSON representation.
+func (s *SecretInfo) MarshalJSON() ([]byte, error) {
+	type JSON struct {
+		Name      string     `json:"name,omitempty"`
+		Type      SecretType `json:"type,omitempty"`
+		CreatedAt time.Time  `json:"created_at,omitempty"`
+		ModTime   time.Time  `json:"mod_time,omitempty"`
+		CreatedBy Identity   `json:"created_by,omitempty"`
+	}
+	modTime := s.ModTime
+	if modTime.IsZero() {
+		modTime = s.CreatedAt
+	}
+	return json.Marshal(JSON{
+		Name:      s.Name,
+		Type:      s.Type,
+		CreatedAt: s.CreatedAt,
+		ModTime:   modTime,
+		CreatedBy: s.CreatedBy,
+	})
+}
+
+// UnmarshalJSON decodes the given JSON data into the SecretInfo.
+func (s *SecretInfo) UnmarshalJSON(data []byte) error {
+	type JSON struct {
+		Name      string     `json:"name"`
+		Type      SecretType `json:"type"`
+		CreatedAt time.Time  `json:"created_at"`
+		ModTime   time.Time  `json:"mod_time"`
+		CreatedBy Identity   `json:"created_by"`
+	}
+
+	var v JSON
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	s.Name = v.Name
+	s.Type = v.Type
+	s.CreatedAt = v.CreatedAt
+	s.ModTime = v.ModTime
+	s.CreatedBy = v.CreatedBy
+
+	if s.ModTime.IsZero() {
+		s.ModTime = v.CreatedAt
+	}
+	return nil
+}
+
+// SecretIter iterates over a stream of SecretInfo objects.
+// Close the SecretIter to release associated resources.
+type SecretIter struct {
+	decoder *json.Decoder
+	closer  io.Closer
+
+	current SecretInfo
+	err     error
+	closed  bool
+}
+
+// Value returns the current SecretInfo. It returns
+// the same SecretInfo until Next is called again.
+//
+// If SecretIter has been closed or if Next has not been
+// called once resp. once Next returns false then the
+// behavior of Value is undefined.
+func (i *SecretIter) Value() SecretInfo { return i.current }
+
+// Name returns the name of the current secret. It is a
+// short-hand for Value().Name.
+func (i *SecretIter) Name() string { return i.current.Name }
+
+// Type returns the type of the current secret. It is a
+// short-hand for Value().Type.
+func (i *SecretIter) Type() SecretType { return i.current.Type }
+
+// CreatedAt returns the created-at timestamp of the current
+// secret. It is a short-hand for Value().CreatedAt.
+func (i *SecretIter) CreatedAt() time.Time { return i.current.CreatedAt }
+
+// ModTime returns the most recent point in time at which the
+// secret has been modified. If the secret has never been modified
+// ModTime is equal to CreatedAt.
+//
+// It is a short-hand for Value().ModTime.
+func (i *SecretIter) ModTime() time.Time { return i.current.ModTime }
+
+// CreatedBy returns the identiy that created the current
+// secret. It is a short-hand for Value().CreatedBy.
+func (i *SecretIter) CreatedBy() Identity { return i.current.CreatedBy }
+
+// Next returns true if there is another SecretInfo.
+// It returns false if there are no more SecretInfo
+// objects or when the SecretIter encounters an
+// error.
+func (i *SecretIter) Next() bool {
+	type Response struct {
+		Name      string    `json:"name"`
+		Type      int       `json:"type"`
+		CreatedAt time.Time `json:"created_at"`
+		CreatedBy Identity  `json:"created_by"`
+
+		Err string `json:"error"`
+	}
+	if i.closed || i.err != nil {
+		return false
+	}
+	var resp Response
+	if err := i.decoder.Decode(&resp); err != nil {
+		if errors.Is(err, io.EOF) {
+			i.err = i.Close()
+		} else {
+			i.err = err
+		}
+		return false
+	}
+	if resp.Err != "" {
+		i.err = errors.New(resp.Err)
+		return false
+	}
+	i.current = SecretInfo{
+		Name:      resp.Name,
+		CreatedAt: resp.CreatedAt,
+		CreatedBy: resp.CreatedBy,
+	}
+	return true
+}
+
+// WriteTo encodes and writes all remaining SecretInfos
+// from its current iterator position to w. It returns
+// the number of bytes written to w and the first error
+// encounterred, if any.
+func (i *SecretIter) WriteTo(w io.Writer) (int64, error) {
+	type Response struct {
+		Name      string    `json:"name,omitempty"`
+		Type      int       `json:"type,omitempty"`
+		CreatedAt time.Time `json:"created_at,omitempty"`
+		ModTime   time.Time `json:"mod_time,omitempty"`
+		CreatedBy Identity  `json:"created_by,omitempty"`
+
+		Err string `json:"error,omitempty"`
+	}
+	if i.err != nil {
+		return 0, i.err
+	}
+	if i.closed {
+		return 0, errors.New("kes: WriteTo called after Close")
+	}
+
+	cw := countWriter{W: w}
+	encoder := json.NewEncoder(&cw)
+	for {
+		var resp Response
+		if err := i.decoder.Decode(&resp); err != nil {
+			if errors.Is(err, io.EOF) {
+				i.err = i.Close()
+			} else {
+				i.err = err
+			}
+			return cw.N, i.err
+		}
+		if resp.Err != "" {
+			i.err = errors.New(resp.Err)
+			return cw.N, i.err
+		}
+		if resp.ModTime.IsZero() {
+			resp.ModTime = resp.CreatedAt
+		}
+		if err := encoder.Encode(resp); err != nil {
+			i.err = err
+			return cw.N, err
+		}
+	}
+}
+
+// Values returns up to the next n SecretInfo values. Subsequent
+// calls will yield further SecretInfos if there are any.
+//
+// If n > 0, Values returns at most n SecretInfo structs. In this case,
+// if Values returns an empty slice, it will return an error explaining
+// why. At the end of the listing, the error is io.EOF.
+//
+// If n <= 0, Values returns all remaining SecretInfo records. In this
+// case, Values always closes the SecretIter. When it succeeds, it
+// returns a nil error, not io.EOF.
+func (i *SecretIter) Values(n int) ([]SecretInfo, error) {
+	values := []SecretInfo{}
+	if n > 0 && i.closed {
+		return values, io.EOF // Return early, don't alloc a slice
+	}
+	if n > 0 {
+		values = make([]SecretInfo, 0, n)
+	}
+
+	var count int
+	for i.Next() {
+		values = append(values, i.Value())
+		count++
+
+		if n > 0 && count >= n {
+			return values, nil
+		}
+	}
+	if err := i.Close(); err != nil {
+		return values, err
+	}
+	if n > 0 && len(values) == 0 { // As by doc contract
+		return values, io.EOF
+	}
+	return values, nil
+}
+
+// Close closes the SecretIter and releases any associated resources.
+func (i *SecretIter) Close() error {
+	if !i.closed {
+		err := i.closer.Close()
+		if i.err == nil {
+			i.err = err
+		}
+		i.closed = true
+		return err
+	}
+	return i.err
+}

--- a/secret_test.go
+++ b/secret_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSecretType_String(t *testing.T) {
+	for i, test := range secretTypeStringTests {
+		if s := test.Type.String(); s != test.String {
+			t.Fatalf("Test %d: got '%s' - want '%s'", i, s, test.String)
+		}
+	}
+}
+
+var secretTypeStringTests = []struct {
+	Type   SecretType
+	String string
+}{
+	{Type: 0, String: "generic"},             // 0
+	{Type: SecretGeneric, String: "generic"}, // 1
+
+	{Type: 1, String: "%1"}, // 2 - invalid type
+}
+
+func TestSecretType_MarshalText(t *testing.T) {
+	for i, test := range secretTypeMarshalTextTests {
+		text, err := test.Type.MarshalText()
+		if err == nil && test.ShouldFail {
+			t.Fatalf("Test %d: should have failed but passed", i)
+		}
+		if err != nil && !test.ShouldFail {
+			t.Fatalf("Test %d: failed to MarshalText: %v", i, err)
+		}
+		if err == nil {
+			if !bytes.Equal(text, test.Text) {
+				t.Fatalf("Test %d: got '%s' - want '%s'", i, string(text), string(test.Text))
+			}
+		}
+	}
+}
+
+var secretTypeMarshalTextTests = []struct {
+	Type       SecretType
+	Text       []byte
+	ShouldFail bool
+}{
+	{Type: 0, Text: []byte("generic")},             // 0
+	{Type: SecretGeneric, Text: []byte("generic")}, // 1
+
+	{Type: 1, ShouldFail: true}, // 2 - invalid type
+}
+
+func TestSecretType_UnmarshalText(t *testing.T) {
+	for i, test := range secretTypeUnmarshalTextTests {
+		var kind SecretType
+		err := kind.UnmarshalText(test.Text)
+		if err == nil && test.ShouldFail {
+			t.Fatalf("Test %d: should have failed but passed", i)
+		}
+		if err != nil && !test.ShouldFail {
+			t.Fatalf("Test %d: failed to UnmarshalText: %v", i, err)
+		}
+		if err == nil {
+			if kind != test.Type {
+				t.Fatalf("Test %d: got '%d' - want '%d'", i, uint(kind), uint(test.Type))
+			}
+		}
+	}
+}
+
+var secretTypeUnmarshalTextTests = []struct {
+	Text       []byte
+	Type       SecretType
+	ShouldFail bool
+}{
+	{Text: []byte("generic"), Type: SecretGeneric}, // 0
+
+	{Text: nil, ShouldFail: true},
+	{Text: []byte{}, ShouldFail: true},
+	{Text: []byte(""), ShouldFail: true},
+	{Text: []byte("unknown"), ShouldFail: true},
+}


### PR DESCRIPTION
This commit adds a new set of server APIs, client
APIs and CLI commands for secrets.

A secret is, similar to a crypto. key, an object
stored at the KES server. However, in contrast
to a key, a the value of a secret can be modified
and fetched from the client.

A typical use case for secrets are e.g. passwords
or API keys.

This commit adds five new server APIs:
 - `/v1/secret/create`
 - `/v1/secret/describe`
 - `/v1/secret/read`
 - `/v1/secret/delete`
 - `/v1/secret/list`

Note that there is currently no modify or edit
API endpoint. Further, a secret can only be
created if no such secret exists. Otherwise,
the KES server returns a `ErrSecretExists` error.

On the client side, this commit adds new SDK
functions (corresponding to the server APIs)
and CLI commands for managing secrets.
For example:
```
$ kes secret create my-secret "password123"

$ kes secret info my-secret

$ kes secret show my-secret

$ kes secret ls

$ kes secret rm my-secret
```
See: `kes secret --help`

***

One key use case of secrets is the ability to
use a stateful KES server as keystore for a
one or multiple stateless KES servers.