### PR TITLE
cmd: improve `kes migrate` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/aws/aws-sdk-go v1.33.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/charmbracelet/lipgloss v0.6.0
-	github.com/fatih/color v1.13.0
 	github.com/hashicorp/vault/api v1.5.0
 	github.com/minio/selfupdate v0.4.0
 	github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0
@@ -45,6 +44,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
+	github.com/fatih/color v1.7.0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,9 +118,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
-github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=


### PR DESCRIPTION
This commit improves the `kes migrate`
command.

It now uses the lipgloss text UI framework
instead of handwritten code.

As side-effect, this commit removes the direct
`github.com/fatih/color` dependency.

Migrating keys from one KMS instance to another
one may now look as following:
```
Starting key migration...

Source:   Filesystem /tmp/1
Target:   Filesystem /tmp/2

Warning: Existing keys will be overwritten.
Migrated 3 keys in 3s DONE
```

### Testing this PR
1. Setup two KES instance (source and target). Therefore create a new TLS private/public key pair:
   ```sh
   kes identity new --ip 127.0.0.1 --dns localhost localhost
   ```
2. Create the source KES instance with the following config:
   ```yml
   admin: 
     identity: 3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22
  
   tls:
     key: private.key
     cert: public.crt
  
   keys:
   - name: my-key-1
   - name: my-key-2
   - name: my-key-3
   
   keystore:
     fs:
       path: /tmp/1
   ```
   ```
   kes server --config source.yml --auth off
   ```
3. Create the target KES instance with the following config:
   ```yml
   admin: 
     identity: 3ecfcdf38fcbe141ae26a1030f81e96b753365a46760ae6b578698a97c59fd22
  
   tls:
     key: private.key
     cert: public.crt
   
   keystore:
     fs:
       path: /tmp/2
   ```
   ```
   kes server --config target.yml --auth off
   ```
4. Migrate the keys from the source to the target:
   ```
   kes migrate --from source.yml --to target.yml
   ```

![Screenshot 2023-01-17 at 12 21 47](https://user-images.githubusercontent.com/20368805/212886482-c6841538-c13d-4525-a068-fddfaaa31752.png)