### PR TITLE
vault: read K8S JWT token from file

### DIFF
--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -115,6 +115,13 @@ func Connect(ctx context.Context, c *Config) (*Conn, error) {
 	case c.AppRole.ID != "" || c.AppRole.Secret != "":
 		authenticate, retry = client.AuthenticateWithAppRole(c.AppRole), c.AppRole.Retry
 	case c.K8S.Role != "" || c.K8S.JWT != "":
+		jwt, err := os.ReadFile(c.K8S.JWT) // The JWT may be a file path containing the actaul token
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if err == nil {
+			c.K8S.JWT = string(jwt)
+		}
 		authenticate, retry = client.AuthenticateWithK8S(c.K8S), c.K8S.Retry
 	}
 


### PR DESCRIPTION
This commit fixes a bug introduced by `v0.22.0`.
In the config file, a user may specify K8S JWT
as file path containing the actual token.

We stopped reading the JWT token if the user specified a file path.

This commit restores this behavior.

Fixes #318