### PR TITLE
keystore: add support for KES<->KES setup

### DIFF
--- a/internal/keystore/kes/kes.go
+++ b/internal/keystore/kes/kes.go
@@ -1,0 +1,150 @@
+// Copyright 2022 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"time"
+
+	"github.com/minio/kes"
+	"github.com/minio/kes/internal/https"
+	"github.com/minio/kes/kms"
+)
+
+// Config is a structure containing configuration
+// options for connecting to a KES server.
+type Config struct {
+	// Endpoints contains one or multiple KES
+	// server endpoints.
+	//
+	// A Conn will automatically load balance
+	// between multiple endpoints.
+	Endpoints []string
+
+	// Enclave is an optional KES enclave name.
+	// If empty, the default enclave is used.
+	Enclave string
+
+	// PrivateKey is a path to a file containing
+	// a X.509 private key for mTLS authentication.
+	PrivateKey string
+
+	// Certificate is a path to a file containing
+	// a X.509 certificate for mTLS authentication.
+	Certificate string
+
+	// CAPath is an optional path to the root CA
+	// certificate(s) used to verify the TLS
+	// certificate of the KES server. If empty,
+	// the host's root CA set is used.
+	CAPath string
+}
+
+// Connect connects to a KES server with the given configuration.
+func Connect(ctx context.Context, config *Config) (*Conn, error) {
+	if len(config.Endpoints) == 0 {
+		return nil, errors.New("kes: no endpoints provided")
+	}
+	if config.Certificate == "" {
+		return nil, errors.New("kes: no certificate provided")
+	}
+	if config.PrivateKey == "" {
+		return nil, errors.New("kes: no private key provided")
+	}
+
+	cert, err := https.CertificateFromFile(config.Certificate, config.PrivateKey, "")
+	if err != nil {
+		return nil, err
+	}
+	var rootCAs *x509.CertPool
+	if config.CAPath != "" {
+		rootCAs, err = https.CertPoolFromFile(config.CAPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	conn := &Conn{
+		client: kes.NewClientWithConfig("", &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      rootCAs,
+		}),
+		enclave: config.Enclave,
+	}
+	conn.client.Endpoints = config.Endpoints
+
+	if _, err := conn.Status(ctx); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// Conn is a connection to a KES server.
+type Conn struct {
+	client  *kes.Client
+	enclave string
+}
+
+// Status returns the current state of the KES connection.
+// I particular, whether it is reachable and the network latency.
+func (c *Conn) Status(ctx context.Context) (kms.State, error) {
+	start := time.Now()
+	_, err := c.client.Status(ctx)
+	latency := time.Since(start)
+
+	if connErr, ok := kes.IsConnError(err); ok {
+		return kms.State{}, &kms.Unreachable{Err: connErr}
+	}
+	if err != nil {
+		return kms.State{}, &kms.Unavailable{Err: err}
+	}
+	return kms.State{
+		Latency: latency,
+	}, nil
+}
+
+// Create creates the given key-value pair at the KES server
+// as a seret if and only no such secret already exists.
+// If such an entry already exists it returns kes.ErrKeyExists.
+func (c *Conn) Create(ctx context.Context, name string, value []byte) error {
+	enclave := c.client.Enclave(c.enclave)
+	err := enclave.CreateSecret(ctx, name, value, nil)
+	if errors.Is(err, kes.ErrSecretExists) {
+		return kes.ErrKeyExists
+	}
+	return err
+}
+
+// Get returns the value associated with the given name.
+// If no entry for the key exists it returns kes.ErrKeyNotFound.
+func (c *Conn) Get(ctx context.Context, name string) ([]byte, error) {
+	enclave := c.client.Enclave(c.enclave)
+	secret, _, err := enclave.ReadSecret(ctx, name)
+	if errors.Is(err, kes.ErrSecretNotFound) {
+		return nil, kes.ErrKeyNotFound
+	}
+	return secret, err
+}
+
+// Delete removes a the value associated with the given name
+// from KES, if it exists. If no such entry exists it returns
+// kes.ErrKeyNotFound.
+func (c *Conn) Delete(ctx context.Context, name string) error {
+	enclave := c.client.Enclave(c.enclave)
+	err := enclave.DeleteSecret(ctx, name)
+	if errors.Is(err, kes.ErrSecretNotFound) {
+		return kes.ErrKeyNotFound
+	}
+	return err
+}
+
+// List returns a new kms.Iter over all stored entries.
+func (c *Conn) List(ctx context.Context) (kms.Iter, error) {
+	enclave := c.client.Enclave(c.enclave)
+	return enclave.ListSecrets(ctx, "*")
+}

--- a/keserv/config.go
+++ b/keserv/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/minio/kes/internal/keystore/gcp"
 	"github.com/minio/kes/internal/keystore/gemalto"
 	"github.com/minio/kes/internal/keystore/generic"
+	kesstore "github.com/minio/kes/internal/keystore/kes"
 	"github.com/minio/kes/internal/keystore/mem"
 	"github.com/minio/kes/internal/keystore/vault"
 	"github.com/minio/kes/kms"
@@ -321,6 +322,68 @@ func (c *FSConfig) toYAML(yml *serverConfigYAML) {
 
 func (c *FSConfig) fromYAML(yml *serverConfigYAML) {
 	c.Dir = yml.KeyStore.Fs.Path
+}
+
+// KESConfig is a structure containing the configuration
+// for using a KES server/cluster as KMS.
+type KESConfig struct {
+	// Endpoints is a set of KES server endpoints.
+	//
+	// If multiple endpoints are provided, the requests
+	// will be automatically balanced across them.
+	Endpoints []Env[string]
+
+	// Enclave is an optional enclave name. If empty,
+	// the default enclave name will be used.
+	Enclave Env[string]
+
+	// CertificateFile is a path to a mTLS client
+	// certificate file used to authenticate to
+	// the KES server.
+	CertificateFile Env[string]
+
+	// PrivateKeyFile is a path to a mTLS private
+	// key used to authenticate to the KES server.
+	PrivateKeyFile Env[string]
+
+	// CAPath is an optional path to the root
+	// CA certificate(s) for verifying the TLS
+	// certificate of the KES server.
+	//
+	// If empty, the OS default root CA set is
+	// used.
+	CAPath Env[string]
+}
+
+// Connect establishes and returns a kms.Conn to the
+// KES server.
+func (c *KESConfig) Connect(ctx context.Context) (kms.Conn, error) {
+	endpoints := make([]string, 0, len(c.Endpoints))
+	for _, endpoint := range c.Endpoints {
+		endpoints = append(endpoints, endpoint.Value)
+	}
+	return kesstore.Connect(ctx, &kesstore.Config{
+		Endpoints:   endpoints,
+		Enclave:     c.Enclave.Value,
+		Certificate: c.CertificateFile.Value,
+		PrivateKey:  c.PrivateKeyFile.Value,
+		CAPath:      c.CAPath.Value,
+	})
+}
+
+func (c *KESConfig) toYAML(yml *serverConfigYAML) {
+	yml.KeyStore.KES.Endpoint = c.Endpoints
+	yml.KeyStore.KES.TLS.Certificate = c.CertificateFile
+	yml.KeyStore.KES.TLS.PrivateKey = c.PrivateKeyFile
+	yml.KeyStore.KES.TLS.CAPath = c.CAPath
+}
+
+func (c *KESConfig) fromYAML(yml *serverConfigYAML) {
+	c.Endpoints = yml.KeyStore.KES.Endpoint
+	c.Enclave = yml.KeyStore.KES.Enclave
+	c.CertificateFile = yml.KeyStore.KES.TLS.Certificate
+	c.PrivateKeyFile = yml.KeyStore.KES.TLS.PrivateKey
+	c.CAPath = yml.KeyStore.KES.TLS.CAPath
 }
 
 // KMSPluginConfig is a structure containing the

--- a/keserv/yml.go
+++ b/keserv/yml.go
@@ -61,6 +61,16 @@ type serverConfigYAML struct {
 			Path Env[string] `yaml:"path,omitempty"`
 		} `yaml:"fs,omitempty"`
 
+		KES struct {
+			Endpoint []Env[string] `yaml:"endpoint,omitempty"`
+			Enclave  Env[string]   `yaml:"enclave,omitempty"`
+			TLS      struct {
+				Certificate Env[string] `yaml:"cert,omitempty"`
+				PrivateKey  Env[string] `yaml:"key,omitempty"`
+				CAPath      Env[string] `yaml:"ca,omitempty"`
+			} `yaml:"tls,omitempty"`
+		} `yaml:"kes,omitempty"`
+
 		Generic struct {
 			Endpoint Env[string] `yaml:"endpoint,omitempty"`
 			TLS      struct {
@@ -281,6 +291,8 @@ func yamlToServerConfig(yml *serverConfigYAML) *ServerConfig {
 	switch {
 	case yml.KeyStore.Fs.Path.Value != "":
 		config.KMS = new(FSConfig)
+	case len(yml.KeyStore.KES.Endpoint) != 0:
+		config.KMS = new(KESConfig)
 	case yml.KeyStore.Generic.Endpoint.Value != "":
 		config.KMS = new(KMSPluginConfig)
 	case yml.KeyStore.Vault.Endpoint.Value != "":

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -184,6 +184,16 @@ keystore:
   fs:
     path: "" # Path to directory. Keys will be stored as files.
 
+  # Configuration for storing keys on a KES server.
+  kes:
+    endpoint: 
+    - ""           # The endpoint (or list of endpoints) to the KES server(s)
+    enclave: ""    # An optional enclave name. If empty, the default enclave will be used
+    tls:           # The KES mTLS authentication credentials - i.e. client certificate.
+      cert: ""     # Path to the TLS client certificate for mTLS authentication
+      key: ""      # Path to the TLS client private key for mTLS authentication
+      ca: ""       # Path to one or multiple PEM root CA certificates
+    
   # Configuration for storing keys via a KES KeyStore plugin or at
   # a KeyStore that exposes an API compatible to the KES KeyStore
   # plugin specification: https://github.com/minio/kes/blob/master/internal/generic/spec-v1.md


### PR DESCRIPTION
This commit adds keystore support for KES.
Now, a stateless KES server can use a stateful
KES server for storing keys as secrets.

The KES server now accepts a new KES keystore
config:
```
  # Configuration for storing keys on a KES server.
  kes:
    endpoint: 
    - ""           # The endpoint (or list of endpoints) to the KES server(s)
    enclave: ""    # An optional enclave name. If empty, the default enclave will be used
    tls:           # The KES mTLS authentication credentials - i.e. client certificate.
      cert: ""     # Path to the TLS client certificate for mTLS authentication
      key: ""      # Path to the TLS client private key for mTLS authentication
      ca: ""       # Path to one or multiple PEM root CA certificates
```