### PR TITLE
add support for API keys

### DIFF
--- a/apikey.go
+++ b/apikey.go
@@ -1,0 +1,190 @@
+// Copyright 2023 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// APIKey is an object that can generate a private/public key pair.
+type APIKey interface {
+	// Public returns the public key that coresponds to
+	// the public key.
+	Public() crypto.PublicKey
+
+	// Private returns the private key that correspons
+	// to the public key.
+	Private() crypto.PrivateKey
+
+	// Identity returns the Identity of the public key.
+	//
+	// The identity is the cryptographic fingerprint of
+	// the raw DER-encoded public key as present in a
+	// corresponding X509 cerificate.
+	Identity() Identity
+
+	// String returns the APIKey's textual representation.
+	String() string
+}
+
+// GenerateAPIKey generates a new random API key. If rand
+// is nil, crypto/rand.Reader is used.
+func GenerateAPIKey(rand io.Reader) (APIKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand)
+	if err != nil {
+		return nil, err
+	}
+	id, err := ed25519Identity(pub)
+	if err != nil {
+		return nil, err
+	}
+	return &apiKey{
+		key:      priv,
+		identity: id,
+	}, nil
+}
+
+// ParseAPIKey parses a formatted APIKey and returns the
+// value it represents.
+func ParseAPIKey(s string) (APIKey, error) {
+	const (
+		Header      = "kes:v1:"
+		Ed25519Type = 0
+	)
+	if !strings.HasPrefix(s, Header) {
+		return nil, errors.New("kes: invalid API key: missing 'kes:v1:' prefix")
+	}
+	b, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(s, Header))
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != 1+ed25519.SeedSize {
+		return nil, errors.New("kes: invalid API key: invalid length")
+	}
+	if b[0] != Ed25519Type {
+		return nil, errors.New("kes: invalid API key: unsupported type")
+	}
+	key := ed25519.NewKeyFromSeed(b[1:])
+	id, err := ed25519Identity(key[ed25519.SeedSize:])
+	if err != nil {
+		return nil, err
+	}
+	return &apiKey{
+		key:      key,
+		identity: id,
+	}, nil
+}
+
+// CertificateOption is a function modifying the passed *x509.Certificate.
+type CertificateOption func(*x509.Certificate)
+
+// GenerateCertificate generates a new tls.Certificate from the APIKey's
+// private and public key. The certificate can be customized by specifying
+// one or multiple CertificateOptions.
+//
+// By default, the returned certificate is valid for 90 days.
+func GenerateCertificate(key APIKey, options ...CertificateOption) (tls.Certificate, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: key.Identity().String(),
+		},
+		NotBefore: time.Now().UTC(),
+		NotAfter:  time.Now().UTC().Add(90 * 24 * time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+	for _, option := range options {
+		option(&template)
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, key.Public(), key.Private())
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	privPKCS8, err := x509.MarshalPKCS8PrivateKey(key.Private())
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	cert, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privPKCS8}),
+	)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	if cert.Leaf == nil {
+		cert.Leaf, _ = x509.ParseCertificate(cert.Certificate[0])
+	}
+	return cert, nil
+}
+
+// apiKey is an APIKey implementation using Ed25519 public/private keys.
+type apiKey struct {
+	key      ed25519.PrivateKey
+	identity Identity
+}
+
+func (ak *apiKey) Public() crypto.PublicKey {
+	public := make([]byte, 0, len(ak.key[ed25519.SeedSize:]))
+	return ed25519.PublicKey(append(public, ak.key[ed25519.SeedSize:]...))
+}
+
+func (ak *apiKey) Private() crypto.PrivateKey {
+	private := make([]byte, 0, len(ak.key))
+	return ed25519.PrivateKey(append(private, ak.key...))
+}
+
+func (ak *apiKey) Identity() Identity { return ak.identity }
+
+func (ak *apiKey) String() string {
+	const Ed25519Type = 0
+	k := make([]byte, 0, 1+ed25519.SeedSize)
+	k = append(k, Ed25519Type)
+	k = append(k, ak.key[:ed25519.SeedSize]...)
+	return "kes:v1:" + base64.StdEncoding.EncodeToString(k)
+}
+
+func ed25519Identity(pubKey []byte) (Identity, error) {
+	type publicKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		PublicKey asn1.BitString
+	}
+	derPublicKey, err := asn1.Marshal(publicKeyInfo{
+		Algorithm: pkix.AlgorithmIdentifier{
+			Algorithm: asn1.ObjectIdentifier{1, 3, 101, 112},
+		},
+		PublicKey: asn1.BitString{BitLength: len(pubKey) * 8, Bytes: pubKey},
+	})
+	if err != nil {
+		return "", err
+	}
+	id := sha256.Sum256(derPublicKey)
+	return Identity(hex.EncodeToString(id[:])), nil
+}

--- a/apikey_test.go
+++ b/apikey_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package kes_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/minio/kes"
+)
+
+func ExampleParseAPIKey() {
+	key, err := kes.ParseAPIKey("kes:v1:AGaV6VXHasF0FnaB60WdCOeTZ8eTIDikL4zlN16c8NAs")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(key)
+	// Output:
+	// kes:v1:AGaV6VXHasF0FnaB60WdCOeTZ8eTIDikL4zlN16c8NAs
+}
+
+func ExampleGenerateCertificate() {
+	key, err := kes.GenerateAPIKey(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	certificate, err := kes.GenerateCertificate(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_ = &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+	}
+	// Output:
+}
+
+func ExampleAPIKey_Identity() {
+	key, err := kes.ParseAPIKey("kes:v1:AGaV6VXHasF0FnaB60WdCOeTZ8eTIDikL4zlN16c8NAs")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(key.Identity())
+	// Output:
+	// ea9826089311fe44d7590408ede9150f7c637b6cab0a91ee6fe1aa5d9fb366f6
+}
+
+func TestParseAPIKey(t *testing.T) {
+	for i, test := range parseAPIKeyTests {
+		key, err := kes.ParseAPIKey(test.String)
+		if err == nil && test.ShouldFail {
+			t.Fatalf("Test %d: parsing APIKey should have failed", i)
+		}
+		if err != nil && !test.ShouldFail {
+			t.Fatalf("Test %d: failed to parse APIKey: %v", i, err)
+		}
+		if err == nil {
+			if s := key.String(); s != test.String {
+				t.Fatalf("Test %d: got '%s' - want '%s'", i, s, test.String)
+			}
+		}
+	}
+}
+
+func TestAPIKey_Identity(t *testing.T) {
+	for i, test := range apiKeyIdentityTests {
+		key, err := kes.ParseAPIKey(test.Key)
+		if err != nil {
+			t.Fatalf("Test %d: failed to parse APIKey: %v", i, err)
+		}
+		if id := key.Identity(); id != test.Identiy {
+			t.Fatalf("Test %d: got '%s' - want '%s'", i, id, test.Identiy)
+		}
+	}
+}
+
+var parseAPIKeyTests = []struct {
+	String     string
+	ShouldFail bool
+}{
+	{String: "kes:v1:AGaV6VXHasF0FnaB60WdCOeTZ8eTIDikL4zlN16c8NAs"},
+	{String: "kes:v1:AM0F5TP43FYEShMzA42f2drFYGnBOiNx7UH4DK0nm08E"},
+
+	{String: "v1:AM0F5TP43FYEShMzA42f2drFYGnBOiNx7UH4DK0nm08E", ShouldFail: true},
+	{String: "kes:AM0F5TP43FYEShMzA42f2drFYGnBOiNx7UH4DK0nm08E", ShouldFail: true},
+	{String: "kes:v1:sbDvZFqUPFFwxRS4EkuoEb2nyyInkdKSUEYHXFHeTouW", ShouldFail: true},
+}
+
+var apiKeyIdentityTests = []struct {
+	Key     string
+	Identiy kes.Identity
+}{
+	{Key: "kes:v1:ACQpoGqx3rHHjT938Hfu5hVVQJHZWSqVI2Xp1KlYxFVw", Identiy: "0426fa9a04bc2756b92fbe8a97e1a1e07b53ecf04ed33da22c33e5c9faeb8cbb"},
+	{Key: "kes:v1:AMxvd2uV1l5dDSRwuKZxSjuM5BDemlr+685+JAHA1TuJ", Identiy: "ab785e3b95d80d72cc9c27cb9fde886a0bf9068a69d40e3bd08a54e68c3f2bf7"},
+}

--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -7,20 +7,13 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/hex"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"os"
 	"os/signal"
@@ -31,7 +24,6 @@ import (
 	tui "github.com/charmbracelet/lipgloss"
 	"github.com/minio/kes"
 	"github.com/minio/kes/internal/cli"
-	"github.com/minio/kes/internal/fips"
 	"github.com/minio/kes/internal/https"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/term"
@@ -120,12 +112,12 @@ func newIdentityCmd(args []string) {
 		expiry    time.Duration
 		encrypt   bool
 	)
-	cmd.StringVar(&keyPath, "key", "private.key", "Path to private key")
-	cmd.StringVar(&certPath, "cert", "public.crt", "Path to certificate")
+	cmd.StringVar(&keyPath, "key", "", "Path to private key")
+	cmd.StringVar(&certPath, "cert", "", "Path to certificate")
 	cmd.BoolVarP(&forceFlag, "force", "f", false, "Overwrite an existing private key and/or certificate")
 	cmd.IPSliceVar(&IPs, "ip", []net.IP{}, "Add <IP> as subject alternative name")
 	cmd.StringSliceVar(&domains, "dns", []string{}, "Add <DOMAIN> as subject alternative name")
-	cmd.DurationVar(&expiry, "expiry", 720*time.Hour, "Duration until the certificate expires")
+	cmd.DurationVar(&expiry, "expiry", 0, "Duration until the certificate expires")
 	cmd.BoolVar(&encrypt, "encrypt", false, "Encrypt the private key with a password")
 	if err := cmd.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -133,129 +125,150 @@ func newIdentityCmd(args []string) {
 		}
 		cli.Fatalf("%v. See 'kes identity new --help'", err)
 	}
-	if cmd.NArg() == 0 {
-		cli.Fatal("no certificate subject specified. See 'kes identity new --help'")
-	}
 	if cmd.NArg() > 1 {
 		cli.Fatal("too many arguments. See 'kes identity new --help'")
 	}
-
-	var (
-		subject    = cmd.Arg(0)
-		publicKey  crypto.PublicKey
-		privateKey crypto.PrivateKey
-	)
-	if fips.Enabled {
-		private, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			cli.Fatalf("failed to generate private key: %v", err)
+	if keyPath != "" && certPath == "" {
+		cli.Fatalf("private key file specified but no certificate file. Set the '--cert' flag")
+	}
+	if keyPath == "" && certPath != "" {
+		cli.Fatalf("certificate file specified but no private key file. Set the '--key' flag")
+	}
+	if keyPath == "" || certPath == "" {
+		if encrypt {
+			cli.Fatalf("'--encrypt' requires a private key and certificate file. Set the '--cert' and '--key' flag")
 		}
-		publicKey, privateKey = private.Public(), private
-	} else {
-		public, private, err := ed25519.GenerateKey(rand.Reader)
-		if err != nil {
-			cli.Fatalf("failed to generate private key: %v", err)
+		if forceFlag {
+			cli.Fatalf("'--force' requires a private key and certificate file. Set the '--cert' and '--key' flag")
 		}
-		publicKey, privateKey = public, private
+		if expiry > 0 {
+			cli.Fatalf("'--expiry' requires a private key and certificate file. Set the '--cert' and '--key' flag")
+		}
+		if len(IPs) > 0 {
+			cli.Fatalf("'--ip' requires a private key and certificate file. Set the '--cert' and '--key' flag")
+		}
+		if len(domains) > 0 {
+			cli.Fatalf("'--dns' requires a private key and certificate file. Set the '--cert' and '--key' flag")
+		}
 	}
 
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	key, err := kes.GenerateAPIKey(nil)
 	if err != nil {
-		cli.Fatalf("failed to create certificate serial number: %v", err)
-	}
-	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			CommonName: subject,
-		},
-		NotBefore: time.Now().UTC(),
-		NotAfter:  time.Now().UTC().Add(expiry),
-		KeyUsage:  x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-			x509.ExtKeyUsageClientAuth,
-		},
-		DNSNames:              domains,
-		IPAddresses:           IPs,
-		BasicConstraintsValid: true,
+		cli.Fatalf("failed to generate API key: %v", err)
 	}
 
-	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
-	if err != nil {
-		cli.Fatalf("failed to create certificate: %v", err)
-	}
-	privBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		cli.Fatalf("failed to create private key: %v", err)
-	}
-
-	if !forceFlag {
-		if _, err = os.Stat(keyPath); err == nil {
-			cli.Fatal("private key already exists. Use --force to overwrite it")
+	if keyPath != "" && certPath != "" {
+		options := []kes.CertificateOption{
+			func(cert *x509.Certificate) { cert.DNSNames = domains },
+			func(cert *x509.Certificate) { cert.IPAddresses = IPs },
 		}
-		if _, err = os.Stat(certPath); err == nil {
-			cli.Fatal("certificate already exists. Use --force to overwrite it")
+		if cmd.NArg() == 1 {
+			name := cmd.Arg(0)
+			options = append(options, func(cert *x509.Certificate) { cert.Subject.CommonName = name })
 		}
-	}
-
-	var keyPem []byte
-	if encrypt {
-		fmt.Fprint(os.Stderr, "Enter password for private key:")
-		p, err := term.ReadPassword(int(os.Stderr.Fd()))
+		if expiry > 0 {
+			options = append(options, func(cert *x509.Certificate) {
+				now := time.Now()
+				cert.NotBefore, cert.NotAfter = now, now.Add(expiry)
+			})
+		}
+		cert, err := kes.GenerateCertificate(key, options...)
 		if err != nil {
-			cli.Fatal(err)
+			cli.Fatalf("failed to generate certificate: %v", err)
 		}
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprint(os.Stderr, "Confirm password for private key:")
-		confirm, err := term.ReadPassword(int(os.Stderr.Fd()))
+
+		certBytes := cert.Certificate[0]
+		privBytes, err := x509.MarshalPKCS8PrivateKey(key.Private())
 		if err != nil {
-			cli.Fatal(err)
-		}
-		fmt.Fprintln(os.Stderr)
-		if !bytes.Equal(p, confirm) {
-			cli.Fatal("passwords don't match")
+			cli.Fatalf("failed to create private key: %v", err)
 		}
 
-		block, err := x509.EncryptPEMBlock(rand.Reader, "PRIVATE KEY", privBytes, p, x509.PEMCipherAES256)
-		if err != nil {
-			cli.Fatalf("failed to encrypt private key: %v", err)
+		if !forceFlag {
+			if _, err = os.Stat(keyPath); err == nil {
+				cli.Fatal("private key already exists. Use --force to overwrite it")
+			}
+			if _, err = os.Stat(certPath); err == nil {
+				cli.Fatal("certificate already exists. Use --force to overwrite it")
+			}
 		}
-		keyPem = pem.EncodeToMemory(block)
-	} else {
-		keyPem = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
-	}
-	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
 
-	if err = os.WriteFile(keyPath, keyPem, 0o600); err != nil {
-		cli.Fatalf("failed to create private key: %v", err)
-	}
-	if err = os.WriteFile(certPath, certPem, 0o644); err != nil {
-		os.Remove(keyPath)
-		cli.Fatalf("failed to create certificate: %v", err)
+		var keyPem []byte
+		if encrypt {
+			fmt.Fprint(os.Stderr, "Enter password for private key:")
+			p, err := term.ReadPassword(int(os.Stderr.Fd()))
+			if err != nil {
+				cli.Fatal(err)
+			}
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprint(os.Stderr, "Confirm password for private key:")
+			confirm, err := term.ReadPassword(int(os.Stderr.Fd()))
+			if err != nil {
+				cli.Fatal(err)
+			}
+			fmt.Fprintln(os.Stderr)
+			if !bytes.Equal(p, confirm) {
+				cli.Fatal("passwords don't match")
+			}
+
+			block, err := x509.EncryptPEMBlock(rand.Reader, "PRIVATE KEY", privBytes, p, x509.PEMCipherAES256)
+			if err != nil {
+				cli.Fatalf("failed to encrypt private key: %v", err)
+			}
+			keyPem = pem.EncodeToMemory(block)
+		} else {
+			keyPem = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+		}
+		certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+
+		if err = os.WriteFile(keyPath, keyPem, 0o600); err != nil {
+			cli.Fatalf("failed to create private key: %v", err)
+		}
+		if err = os.WriteFile(certPath, certPem, 0o644); err != nil {
+			os.Remove(keyPath)
+			cli.Fatalf("failed to create certificate: %v", err)
+		}
 	}
 
+	bold := tui.NewStyle()
 	if isTerm(os.Stdout) {
-		fmt.Printf("\n  Private key:  %s\n", keyPath)
-		fmt.Printf("  Certificate:  %s\n", certPath)
-
-		cert, err := x509.ParseCertificate(certBytes)
-		if err == nil {
-			identity := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
-			fmt.Printf("  Identity:     %s\n", hex.EncodeToString(identity[:]))
-		}
+		bold = bold.Bold(true)
 	}
+	var buffer strings.Builder
+	fmt.Fprintln(&buffer, "Your API key:")
+	fmt.Fprintln(&buffer)
+	fmt.Fprintln(&buffer, "   "+bold.Render(key.String())+"\n")
+	fmt.Fprintln(&buffer, "This is the only time it is shown. Keep it secret and secure!")
+	fmt.Fprintln(&buffer)
+	fmt.Fprintln(&buffer, "Your Identity:")
+	fmt.Fprintln(&buffer)
+	fmt.Fprintln(&buffer, "   "+bold.Render(key.Identity().String())+"\n")
+	fmt.Fprintln(&buffer, "The identity is not a secret. It can be shared. Any peer")
+	fmt.Fprintln(&buffer, "needs this identity in order to verify your API key.")
+	if keyPath != "" && certPath != "" {
+		fmt.Fprintln(&buffer)
+		fmt.Fprintf(&buffer, "The generated TLS private key is stored at: %s\n", keyPath)
+		fmt.Fprintf(&buffer, "The generated TLS certificate is stored at: %s\n", certPath)
+	}
+	fmt.Fprintln(&buffer)
+	fmt.Fprintln(&buffer, "The identity can be computed again via:")
+	fmt.Fprintln(&buffer)
+	fmt.Fprintf(&buffer, "    kes identity of %s\n", key.String())
+	if keyPath != "" && certPath != "" {
+		fmt.Fprintf(&buffer, "    kes identity of %s", certPath)
+	}
+	cli.Println(buffer.String())
 }
 
 const ofIdentityCmdUsage = `Usage:
-    kes identity of <certificate>...
+    kes identity of <api-key>
+    kes identity of <certificate>
 
 Options:
     -h, --help               Print command line options.
 
 Examples:
+    $ kes identity of kes:v1:ACQpoGqx3rHHjT938Hfu5hVVQJHZWSqVI2Xp1KlYxFVw
     $ kes identity of client.crt
-    $ kes identity of client1.crt client2.crt
 `
 
 func ofIdentityCmd(args []string) {
@@ -269,63 +282,43 @@ func ofIdentityCmd(args []string) {
 		cli.Fatalf("%v. See 'kes identity of --help'", err)
 	}
 	if cmd.NArg() == 0 {
-		cli.Fatal("no certificate specified. See 'kes identity of --help'")
+		cli.Fatal("no API key or certificate specified. See 'kes identity of --help'")
 	}
 
-	identify := func(filename string) (kes.Identity, error) {
+	var identity kes.Identity
+	if strings.HasPrefix(cmd.Arg(0), "kes:v1:") {
+		key, err := kes.ParseAPIKey(cmd.Arg(0))
+		if err != nil {
+			cli.Fatal(err)
+		}
+		identity = key.Identity()
+	} else {
+		filename := cmd.Arg(0)
 		pemBlock, err := os.ReadFile(filename)
 		if err != nil {
-			return "", err
+			cli.Fatal(err)
 		}
 		pemBlock, err = https.FilterPEM(pemBlock, func(b *pem.Block) bool { return b.Type == "CERTIFICATE" })
 		if err != nil {
-			return "", fmt.Errorf("failed to parse certificate in %q: %v", filename, err)
+			cli.Fatalf("failed to parse certificate in '%s': %v", filename, err)
 		}
 
 		next, _ := pem.Decode(pemBlock)
 		cert, err := x509.ParseCertificate(next.Bytes)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse certificate in %q: %v", filename, err)
+			cli.Fatalf("failed to parse certificate in '%s': %v", filename, err)
 		}
-		identity := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
-		return kes.Identity(hex.EncodeToString(identity[:])), nil
+		h := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+		identity = kes.Identity(hex.EncodeToString(h[:]))
 	}
-
-	switch {
-	case cmd.NArg() == 1:
-		identity, err := identify(cmd.Arg(0))
-		if err != nil {
-			cli.Fatal(err)
-		}
-		if isTerm(os.Stdout) {
-			fmt.Printf("\n  Identity:  %s\n", identity)
-		} else {
-			fmt.Print(identity)
-		}
-	case isTerm(os.Stdout):
-		for _, filename := range cmd.Args() {
-			identity, err := identify(filename)
-			if err != nil {
-				cli.Fatal(err)
-			}
-			fmt.Printf("%s: %s\n", filename, identity)
-		}
-	default:
-		type Pair struct {
-			Name     string       `json:"name"`
-			Identity kes.Identity `json:"identity"`
-		}
-		encoder := json.NewEncoder(os.Stdout)
-		for _, filename := range cmd.Args() {
-			identity, err := identify(filename)
-			if err != nil {
-				cli.Fatal(err)
-			}
-			encoder.Encode(Pair{
-				Name:     filename,
-				Identity: identity,
-			})
-		}
+	if isTerm(os.Stdout) {
+		var buffer strings.Builder
+		fmt.Fprintln(&buffer, "Identity:")
+		fmt.Fprintln(&buffer)
+		fmt.Fprintln(&buffer, "   "+tui.NewStyle().Bold(true).Render(identity.String()))
+		cli.Print(buffer.String())
+	} else {
+		fmt.Print(identity)
 	}
 }
 


### PR DESCRIPTION
This commit adds API keys as secret-based
authentication mechanism.

An API key has the following format:
```
kes:v1:base64-encode(<key-type> | <key-bytes>)

key-type:  1 byte key algorithm identifier
key-bytes: value of the secret key
```

An example API key looks like this:
```
kes:v1:ACQpoGqx3rHHjT938Hfu5hVVQJHZWSqVI2Xp1KlYxFVw
```

Like TLS certificates, an API has a corresponding
identity. The identity of the example API key
above is:
```
0426fa9a04bc2756b92fbe8a97e1a1e07b53ecf04ed33da22c33e5c9faeb8cbb
```

Now, the `kes identity new` and `kes identity of`, by default, generate an API key resp. compute the identity from an API key.

***

Under the hood, an API key deterministically generates a private/public key pair - from which a CA-signed / self-signed certificate can be generated.

However, with API keys it is possible to generate
a TLS certificate, e.g. for mTLS authentication, on the fly from a single secret value.

Hence, API keys still boil down to private/public
key / TLS-based authentication. However, the simply key management when certificates don't need to be
signed by a publicly trusted CA but instead are used for internal machine-to-machine communication.

In particular, a client requires just the API key
while the server just requires the corresponding identity. Furthermore, the server does not hold any secret
(identities aren't secret information). So, we don't have to worry about compromise of API keys from the server-side.