### PR TITLE
allow server API customization 

### DIFF
--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -543,6 +543,22 @@ func newGatewayConfig(ctx context.Context, config *keserv.ServerConfig, tlsConfi
 		}
 	}
 
+	rConfig.APIConfig = make(map[string]api.Config, len(config.API.Paths))
+	for k, v := range config.API.Paths {
+		k = strings.TrimSpace(k) // Ensure that the API path starts with a '/'
+		if !strings.HasPrefix(k, "/") {
+			k = "/" + k
+		}
+
+		if _, ok := rConfig.APIConfig[k]; ok {
+			return nil, fmt.Errorf("ambiguous API configuration for '%s'", k)
+		}
+		rConfig.APIConfig[k] = api.Config{
+			Timeout:          v.Timeout.Value,
+			InsecureSkipAuth: v.InsecureSkipAuth.Value,
+		}
+	}
+
 	var err error
 	rConfig.Policies, err = policySetFromConfig(config)
 	if err != nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,12 +16,32 @@ import (
 	"github.com/minio/kes/internal/sys"
 )
 
+// Config is a structure for configuring
+// a KES server API.
+type Config struct {
+	// Timeout is the duration after which a request
+	// times out. If Timeout <= 0 the API default
+	// is used.
+	Timeout time.Duration
+
+	// InsecureSkipAuth controls whether the API verifies
+	// client identities. If InsecureSkipAuth is true,
+	// the API accepts requests from arbitrary identities.
+	// In this mode, the API can be used by anyone who can
+	// communicate to the KES server over HTTPS.
+	// This should only be set for testing or in certain
+	// cases for APIs that don't expose sensitive information,
+	// like metrics.
+	InsecureSkipAuth bool
+}
+
 // API describes a KES server API.
 type API struct {
 	Method  string        // The HTTP method
 	Path    string        // The URI API path
 	MaxBody int64         // The max. body size the API accepts
 	Timeout time.Duration // The duration after which an API request times out. 0 means no timeout
+	Verify  bool          // Whether the API verifies the client identity
 
 	// Handler implements the API.
 	//
@@ -32,6 +52,8 @@ type API struct {
 	//  - the request body being limited to the API's MaxBody size.
 	//  - the request timing out after the duration specified for the API.
 	Handler http.Handler
+
+	_ [0]int
 }
 
 // ServerHTTP takes an HTTP Request and ResponseWriter and executes the

--- a/internal/api/enclave.go
+++ b/internal/api/enclave.go
@@ -22,6 +22,7 @@ func createEnclave(config *RouterConfig) API {
 		APIPath = "/v1/enclave/create/"
 		MaxBody = int64(1 * mem.MiB)
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	type Request struct {
 		Admin kes.Identity `json:"admin"`
@@ -70,6 +71,7 @@ func createEnclave(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -80,6 +82,7 @@ func describeEnclave(config *RouterConfig) API {
 		APIPath     = "/v1/enclave/describe/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Response struct {
@@ -121,6 +124,7 @@ func describeEnclave(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -131,6 +135,7 @@ func deleteEnclave(config *RouterConfig) API {
 		APIPath = "/v1/enclave/delete/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
@@ -159,6 +164,7 @@ func deleteEnclave(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -21,6 +21,7 @@ func describeIdentity(config *RouterConfig) API {
 		APIPath     = "/v1/identity/describe/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Response struct {
@@ -66,18 +67,25 @@ func describeIdentity(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeDescribeIdentity(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/identity/describe/"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		IsAdmin   bool         `json:"admin,omitempty"`
 		Policy    string       `json:"policy"`
@@ -113,6 +121,7 @@ func edgeDescribeIdentity(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -123,6 +132,7 @@ func selfDescribeIdentity(config *RouterConfig) API {
 		APIPath     = "/v1/identity/self/describe"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = false
 		ContentType = "application/json"
 	)
 	type InlinePolicy struct {
@@ -188,18 +198,25 @@ func selfDescribeIdentity(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeSelfDescribeIdentity(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/identity/self/describe"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = false
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type InlinePolicy struct {
 		Allow     []string     `json:"allow,omitempty"`
 		Deny      []string     `json:"deny,omitempty"`
@@ -251,6 +268,7 @@ func edgeSelfDescribeIdentity(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -261,6 +279,7 @@ func deleteIdentity(config *RouterConfig) API {
 		APIPath = "/v1/identity/delete/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
@@ -300,6 +319,7 @@ func deleteIdentity(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -310,6 +330,7 @@ func listIdentity(config *RouterConfig) API {
 		APIPath     = "/v1/identity/list/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
 	type Response struct {
@@ -389,18 +410,25 @@ func listIdentity(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeListIdentity(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/identity/list/"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		Identity  kes.Identity `json:"identity"`
 		IsAdmin   bool         `json:"admin"`
@@ -472,6 +500,7 @@ func edgeListIdentity(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }

--- a/internal/api/key.go
+++ b/internal/api/key.go
@@ -26,6 +26,7 @@ func createKey(config *RouterConfig) API {
 		APIPath = "/v1/key/create/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
@@ -66,17 +67,24 @@ func createKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeCreateKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method  = http.MethodPost
 		APIPath = "/v1/key/create/"
-		MaxBody = 0
+		MaxBody int64
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
 		if err != nil {
@@ -109,6 +117,7 @@ func edgeCreateKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -119,6 +128,7 @@ func importKey(config *RouterConfig) API {
 		APIPath = "/v1/key/import/"
 		MaxBody = int64(1 * mem.MiB)
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	type Request struct {
 		Bytes     []byte           `json:"bytes"`
@@ -163,17 +173,24 @@ func importKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeImportKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method  = http.MethodPost
 		APIPath = "/v1/key/import/"
 		MaxBody = 1 * mem.MiB
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Request struct {
 		Bytes     []byte           `json:"bytes"`
 		Algorithm kes.KeyAlgorithm `json:"algorithm"`
@@ -210,6 +227,7 @@ func edgeImportKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: int64(MaxBody),
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -220,6 +238,7 @@ func describeKey(config *RouterConfig) API {
 		APIPath     = "/v1/key/describe/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Response struct {
@@ -266,17 +285,24 @@ func describeKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeDescribeKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method  = http.MethodGet
 		APIPath = "/v1/key/describe/"
-		MaxBody = 0
+		MaxBody int64
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		Name      string           `json:"name"`
 		ID        string           `json:"id,omitempty"`
@@ -313,6 +339,7 @@ func edgeDescribeKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -323,6 +350,7 @@ func deleteKey(config *RouterConfig) API {
 		APIPath = "/v1/key/delete/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
@@ -352,17 +380,24 @@ func deleteKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeDeleteKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method  = http.MethodDelete
 		APIPath = "/v1/key/delete/"
-		MaxBody = 0
+		MaxBody int64
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
 		if err != nil {
@@ -383,6 +418,7 @@ func edgeDeleteKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -393,6 +429,7 @@ func generateKey(config *RouterConfig) API {
 		APIPath     = "/v1/key/generate/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Request struct {
@@ -450,18 +487,25 @@ func generateKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeGenerateKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/generate/"
 		MaxBody     = 1 * mem.MiB
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Request struct {
 		Context []byte `json:"context"` // optional
 	}
@@ -508,6 +552,7 @@ func edgeGenerateKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: int64(MaxBody),
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -518,6 +563,7 @@ func encryptKey(config *RouterConfig) API {
 		APIPath     = "/v1/key/encrypt/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Request struct {
@@ -570,18 +616,25 @@ func encryptKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeEncryptKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/encrypt/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Request struct {
 		Plaintext []byte `json:"plaintext"`
 		Context   []byte `json:"context"` // optional
@@ -623,6 +676,7 @@ func edgeEncryptKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -633,6 +687,7 @@ func decryptKey(config *RouterConfig) API {
 		APIPath     = "/v1/key/decrypt/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Request struct {
@@ -684,18 +739,25 @@ func decryptKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeDecryptKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/decrypt/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Request struct {
 		Ciphertext []byte `json:"ciphertext"`
 		Context    []byte `json:"context"` // optional
@@ -737,6 +799,7 @@ func edgeDecryptKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -747,6 +810,7 @@ func bulkDecryptKey(config *RouterConfig) API {
 		APIPath     = "/v1/key/bulk/decrypt/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 		MaxRequests = 1000 // For now, we limit the number of decryption requests in a single API call to 1000.
 	)
@@ -810,19 +874,26 @@ func bulkDecryptKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeBulkDecryptKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodPost
 		APIPath     = "/v1/key/bulk/decrypt/"
 		MaxBody     = int64(1 * mem.MiB)
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 		MaxRequests = 1000 // For now, we limit the number of decryption requests in a single API call to 1000.
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Request struct {
 		Ciphertext []byte `json:"ciphertext"`
 		Context    []byte `json:"context"` // optional
@@ -874,6 +945,7 @@ func edgeBulkDecryptKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -884,6 +956,7 @@ func listKey(config *RouterConfig) API {
 		APIPath     = "/v1/key/list/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
 	type Response struct {
@@ -964,18 +1037,25 @@ func listKey(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeListKey(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/key/list/"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		Name string `json:"name,omitempty"`
 		Err  string `json:"error,omitempty"`
@@ -1031,6 +1111,7 @@ func edgeListKey(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }

--- a/internal/api/log.go
+++ b/internal/api/log.go
@@ -19,6 +19,7 @@ func errorLog(config *RouterConfig) API {
 		APIPath     = "/v1/log/error"
 		MaxBody     = 0
 		Timeout     = 0 * time.Second // No timeout
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
 
@@ -48,18 +49,25 @@ func errorLog(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(handler)),
 	}
 }
 
 func edgeErrorLog(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/log/error"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 0 * time.Second // No timeout
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
 			Fail(w, err)
@@ -81,6 +89,7 @@ func edgeErrorLog(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(handler)),
 	}
 }
@@ -91,6 +100,7 @@ func auditLog(config *RouterConfig) API {
 		APIPath     = "/v1/log/audit"
 		MaxBody     = 0
 		Timeout     = 0 * time.Second // No timeout
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
 
@@ -120,19 +130,25 @@ func auditLog(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(handler)),
 	}
 }
 
 func edgeAuditLog(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/log/audit"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 0 * time.Second // No timeout
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
-
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
 			Fail(w, err)
@@ -153,6 +169,7 @@ func edgeAuditLog(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(handler)),
 	}
 }

--- a/internal/api/metric.go
+++ b/internal/api/metric.go
@@ -18,6 +18,7 @@ func metrics(config *RouterConfig) API {
 		APIPath = "/v1/metrics"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		if err := Sync(config.Vault.RLocker(), func() error {
@@ -43,19 +44,27 @@ func metrics(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: handler,
 	}
 }
 
 func edgeMetrics(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method  = http.MethodGet
 		APIPath = "/v1/metrics"
-		MaxBody = 0
+		MaxBody int64
+		Verify  = true
 		Timeout = 15 * time.Second
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+		Verify = !c.InsecureSkipAuth
+	}
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
-		if err := auth.VerifyRequest(r, config.Policies, config.Identities); err != nil {
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); Verify && err != nil {
 			Fail(w, err)
 			return
 		}
@@ -71,6 +80,7 @@ func edgeMetrics(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: handler,
 	}
 }

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -22,6 +22,7 @@ func assignPolicy(config *RouterConfig) API {
 		APIPath = "/v1/policy/assign/"
 		MaxBody = int64(1 * mem.KiB)
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	type Request struct {
 		Identity kes.Identity `json:"identity"`
@@ -76,6 +77,7 @@ func assignPolicy(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -86,6 +88,7 @@ func describePolicy(config *RouterConfig) API {
 		APIPath     = "/v1/policy/describe/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Response struct {
@@ -127,18 +130,25 @@ func describePolicy(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeDescribePolicy(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/policy/describe/"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		CreatedAt time.Time    `json:"created_at,omitempty"`
 		CreatedBy kes.Identity `json:"created_by,omitempty"`
@@ -170,6 +180,7 @@ func edgeDescribePolicy(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -180,6 +191,7 @@ func readPolicy(config *RouterConfig) API {
 		APIPath     = "/v1/policy/read/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Response struct {
@@ -225,18 +237,25 @@ func readPolicy(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeReadPolicy(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/policy/read/"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		Allow     []string     `json:"allow,omitempty"`
 		Deny      []string     `json:"deny,omitempty"`
@@ -272,6 +291,7 @@ func edgeReadPolicy(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -282,6 +302,7 @@ func writePolicy(config *RouterConfig) API {
 		APIPath = "/v1/policy/write/"
 		MaxBody = int64(1 * mem.MiB)
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	type Request struct {
 		Allow []string `json:"allow,omitempty"`
@@ -326,6 +347,7 @@ func writePolicy(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -336,6 +358,7 @@ func deletePolicy(config *RouterConfig) API {
 		APIPath = "/v1/policy/delete/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
@@ -366,6 +389,7 @@ func deletePolicy(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -376,6 +400,7 @@ func listPolicy(config *RouterConfig) API {
 		APIPath     = "/v1/policy/list/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
 	type Response struct {
@@ -451,18 +476,25 @@ func listPolicy(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
 
 func edgeListPolicy(config *EdgeRouterConfig) API {
-	const (
+	var (
 		Method      = http.MethodGet
 		APIPath     = "/v1/policy/list/"
-		MaxBody     = 0
+		MaxBody     int64
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+	}
 	type Response struct {
 		Name      string       `json:"name"`
 		CreatedAt time.Time    `json:"created_at,omitempty"`
@@ -528,6 +560,7 @@ func edgeListPolicy(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -18,7 +18,7 @@ import (
 )
 
 // RouterConfig is a structure containing the
-// API configuration a KES server.
+// API configuration for a KES server.
 type RouterConfig struct {
 	Vault *sys.Vault
 
@@ -43,6 +43,8 @@ type EdgeRouterConfig struct {
 	Metrics *metric.Metrics
 
 	Proxy *auth.TLSProxy
+
+	APIConfig map[string]Config
 
 	AuditLog *log.Logger
 

--- a/internal/api/secret.go
+++ b/internal/api/secret.go
@@ -23,6 +23,7 @@ func createSecret(config *RouterConfig) API {
 		APIPath = "/v1/secret/create/"
 		MaxBody = int64(1 * mem.MiB)
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	type Request struct {
 		Type  kes.SecretType `json:"type"`
@@ -66,6 +67,7 @@ func createSecret(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -76,6 +78,7 @@ func describeSecret(config *RouterConfig) API {
 		APIPath     = "/v1/secret/describe/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/json"
 	)
 	type Response struct {
@@ -121,6 +124,7 @@ func describeSecret(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -131,6 +135,7 @@ func readSecret(config *RouterConfig) API {
 		APIPath = "/v1/secret/read/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	type Response struct {
 		Bytes     []byte         `json:"bytes"`
@@ -177,6 +182,7 @@ func readSecret(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -187,6 +193,7 @@ func deleteSecret(config *RouterConfig) API {
 		APIPath = "/v1/secret/delete/"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = true
 	)
 	var handler HandlerFunc = func(w http.ResponseWriter, r *http.Request) error {
 		name, err := nameFromRequest(r, APIPath)
@@ -217,6 +224,7 @@ func deleteSecret(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -227,6 +235,7 @@ func listSecret(config *RouterConfig) API {
 		APIPath     = "/v1/secret/list/"
 		MaxBody     = 0
 		Timeout     = 15 * time.Second
+		Verify      = true
 		ContentType = "application/x-ndjson"
 	)
 	type Response struct {
@@ -307,6 +316,7 @@ func listSecret(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }

--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -19,6 +19,7 @@ func version(config *RouterConfig) API {
 		APIPath = "/version"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = false
 	)
 	type Response struct {
 		Version string `json:"version"`
@@ -35,6 +36,7 @@ func version(config *RouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }
@@ -45,6 +47,7 @@ func edgeVersion(config *EdgeRouterConfig) API {
 		APIPath = "/version"
 		MaxBody = 0
 		Timeout = 15 * time.Second
+		Verify  = false
 	)
 	type Response struct {
 		Version string `json:"version"`
@@ -61,6 +64,7 @@ func edgeVersion(config *EdgeRouterConfig) API {
 		Path:    APIPath,
 		MaxBody: MaxBody,
 		Timeout: Timeout,
+		Verify:  Verify,
 		Handler: config.Metrics.Count(config.Metrics.Latency(audit.Log(config.AuditLog, handler))),
 	}
 }

--- a/keserv/config.go
+++ b/keserv/config.go
@@ -146,6 +146,9 @@ type ServerConfig struct {
 	// TLS holds the KES server TLS configuration.
 	TLS TLSConfig
 
+	// API holds the KES server API configuration.
+	API APIConfig
+
 	// Cache holds the KES server cache configuration.
 	Cache CacheConfig
 
@@ -199,6 +202,37 @@ type TLSConfig struct {
 	// TLS / HTTPS proxy to forward the actual client certificate
 	// to KES.
 	ForwardCertHeader Env[string]
+
+	_ [0]int
+}
+
+// APIConfig is a structure that holds the API configuration
+// for a (stateless) KES server.
+type APIConfig struct {
+	// Paths contains a set of API paths and there
+	// API configuration.
+	Paths map[string]APIPathConfig
+
+	_ [0]int
+}
+
+// APIPathConfig is a structure that holds the API configuration
+// for one particular KES API.
+type APIPathConfig struct {
+	// Timeout is the duration after which the API response with
+	// a HTTP timeout error response.
+	// If Timeout <= 0 the API default is used.
+	Timeout Env[time.Duration]
+
+	// InsecureSkipAuth controls whether the API verifies
+	// client identities. If InsecureSkipAuth is true,
+	// the API accepts requests from arbitrary identities.
+	// In this mode, the API can be used by anyone who can
+	// communicate to the KES server over HTTPS.
+	// This should only be set for testing or in certain
+	// cases for APIs that don't expose sensitive information,
+	// like metrics.
+	InsecureSkipAuth Env[bool]
 
 	_ [0]int
 }

--- a/keserv/example_test.go
+++ b/keserv/example_test.go
@@ -5,22 +5,23 @@
 package keserv
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+
+	"gopkg.in/yaml.v3"
 )
 
 func ExampleEnv() {
-	const Text = `{"addr":"${SERVER_ADDR}"}`
+	const Text = `addr: ${SERVER_ADDR}`
 
 	os.Setenv("SERVER_ADDR", "127.0.0.1:7373")
 
 	type Config struct {
-		Addr Env[string] `json:"addr"`
+		Addr Env[string] `yaml:"addr"`
 	}
 	var config Config
-	if err := json.Unmarshal([]byte(Text), &config); err != nil {
+	if err := yaml.Unmarshal([]byte(Text), &config); err != nil {
 		log.Fatalln(err)
 	}
 	fmt.Println(config.Addr.Name, "=", config.Addr.Value)

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -51,6 +51,36 @@ tls:
       # certificate of the kes client forwarded by the TLS proxy.
       cert: X-Tls-Client-Cert
 
+# The API configuration. The APIs exposed by the KES server can
+# be adjusted here. Each API is identified by its API path.
+#
+# In general, the KES server uses sane defaults for all APIs.
+# Only customize the APIs if there is a real need.
+# 
+# Disabling authentication for an API must be carefully evaluated.
+# One example, when authentication may be justified monitoring via
+# the /v1/metrics API. It is possible that providing identities
+# to auto-scaling monitoring instances may not be feasable in certain
+# environments. However, in general it is better to use API keys or
+# TLS client certificates if possible.
+#
+# When authentication is disabled, the particular API can be
+# accessed by any client that can send HTTPS requests to the
+# KES server.
+# Currently, authentication can only be disabled for the
+# following APIs:
+#   - /v1/status
+#   - /v1/metrics
+#   - /v1/api
+#
+api:
+  /v1/metrics:
+    skip_auth: false
+    timeout:   15s
+  /v1/status:
+    skip_auth: false
+    timeout:   15s
+    
 # The (pre-defined) policy definitions.
 #
 # A policy must have an unique name (e.g my-app) and specifies which


### PR DESCRIPTION
This commit adds the ability to customize the
KES server API.

Now the KES server config file contains an `api`
section:
```
api:
  <api-path>:
    skip_auth: bool
    timeout:   time.Duration
```

The KES server uses sane defaults for all APIs.
Further, all APIs except `/version` and
`/v1/identity/self/describe` require authentication
by default.

In general, authentication should not be disabled.
Under certain circumstances, disabling authentication
may be an option to simplify the integration of e.g.
monitoring.

At the moment, authentication can only be turned
of for the following APIs:
 - `/v1/metrics`
 - `/v1/status`
 - `/v1/api`

Now, all APIs returned by the `/v1/api` API also
report whether authentication is enabled or disabled.