### PR TITLE
kes: add support for API key authentication

### DIFF
--- a/keserv/yml.go
+++ b/keserv/yml.go
@@ -69,6 +69,7 @@ type serverConfigYAML struct {
 		KES struct {
 			Endpoint []Env[string] `yaml:"endpoint,omitempty"`
 			Enclave  Env[string]   `yaml:"enclave,omitempty"`
+			APIKey   Env[string]   `yaml:"api_key,omitempty"`
 			TLS      struct {
 				Certificate Env[string] `yaml:"cert,omitempty"`
 				PrivateKey  Env[string] `yaml:"key,omitempty"`

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -234,6 +234,7 @@ keystore:
     endpoint: 
     - ""           # The endpoint (or list of endpoints) to the KES server(s)
     enclave: ""    # An optional enclave name. If empty, the default enclave will be used
+    api_key: ""    # The KES API key to authenticate to KES server
     tls:           # The KES mTLS authentication credentials - i.e. client certificate.
       cert: ""     # Path to the TLS client certificate for mTLS authentication
       key: ""      # Path to the TLS client private key for mTLS authentication


### PR DESCRIPTION
This commit adds support for KES<->KES authentication via API keys. Now, a KES edge server can authenticate to a KES server (stateful) via API keys - not just via TLS private key / certificate files.