### PR TITLE
use HTTP instead of TCP KeyStore status check

### DIFF
--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -530,19 +530,21 @@ func newGatewayConfig(ctx context.Context, config *edge.ServerConfig, tlsConfig 
 		}
 	}
 
-	rConfig.APIConfig = make(map[string]api.Config, len(config.API.Paths))
-	for k, v := range config.API.Paths {
-		k = strings.TrimSpace(k) // Ensure that the API path starts with a '/'
-		if !strings.HasPrefix(k, "/") {
-			k = "/" + k
-		}
+	if config.API != nil && len(config.API.Paths) > 0 {
+		rConfig.APIConfig = make(map[string]api.Config, len(config.API.Paths))
+		for k, v := range config.API.Paths {
+			k = strings.TrimSpace(k) // Ensure that the API path starts with a '/'
+			if !strings.HasPrefix(k, "/") {
+				k = "/" + k
+			}
 
-		if _, ok := rConfig.APIConfig[k]; ok {
-			return nil, fmt.Errorf("ambiguous API configuration for '%s'", k)
-		}
-		rConfig.APIConfig[k] = api.Config{
-			Timeout:          v.Timeout,
-			InsecureSkipAuth: v.InsecureSkipAuth,
+			if _, ok := rConfig.APIConfig[k]; ok {
+				return nil, fmt.Errorf("ambiguous API configuration for '%s'", k)
+			}
+			rConfig.APIConfig[k] = api.Config{
+				Timeout:          v.Timeout,
+				InsecureSkipAuth: v.InsecureSkipAuth,
+			}
 		}
 	}
 

--- a/internal/keystore/azure/key-vault.go
+++ b/internal/keystore/azure/key-vault.go
@@ -47,7 +47,18 @@ var _ kms.Conn = (*Conn)(nil)
 // Status returns the current state of the Azure KeyVault instance.
 // In particular, whether it is reachable and the network latency.
 func (c *Conn) Status(ctx context.Context) (kms.State, error) {
-	return kms.Dial(ctx, c.endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.client.Endpoint, nil)
+	if err != nil {
+		return kms.State{}, err
+	}
+
+	start := time.Now()
+	if _, err = http.DefaultClient.Do(req); err != nil {
+		return kms.State{}, &kms.Unreachable{Err: err}
+	}
+	return kms.State{
+		Latency: time.Since(start),
+	}, nil
 }
 
 // Create creates the given key-value pair as KeyVault secret.

--- a/internal/keystore/fortanix/keystore.go
+++ b/internal/keystore/fortanix/keystore.go
@@ -186,12 +186,17 @@ func Connect(ctx context.Context, config *Config) (*Conn, error) {
 // Status returns the current state of the Fortanix SDKMS instance.
 // In particular, whether it is reachable and the network latency.
 func (c *Conn) Status(ctx context.Context) (kms.State, error) {
-	state, err := kms.Dial(ctx, c.config.Endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.config.Endpoint, nil)
 	if err != nil {
+		return kms.State{}, err
+	}
+
+	start := time.Now()
+	if _, err = http.DefaultClient.Do(req); err != nil {
 		return kms.State{}, &kms.Unreachable{Err: err}
 	}
 	return kms.State{
-		Latency: state.Latency,
+		Latency: time.Since(start),
 	}, nil
 }
 

--- a/internal/keystore/gemalto/key-secure.go
+++ b/internal/keystore/gemalto/key-secure.go
@@ -113,7 +113,18 @@ func Connect(ctx context.Context, config *Config) (c *Conn, err error) {
 // Status returns the current state of the Gemalto KeySecure instance.
 // In particular, whether it is reachable and the network latency.
 func (c *Conn) Status(ctx context.Context) (kms.State, error) {
-	return kms.Dial(ctx, c.config.Endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.config.Endpoint, nil)
+	if err != nil {
+		return kms.State{}, err
+	}
+
+	start := time.Now()
+	if _, err = http.DefaultClient.Do(req); err != nil {
+		return kms.State{}, &kms.Unreachable{Err: err}
+	}
+	return kms.State{
+		Latency: time.Since(start),
+	}, nil
 }
 
 // Create creates the given key-value pair at Gemalto if and only

--- a/internal/keystore/generic/client.go
+++ b/internal/keystore/generic/client.go
@@ -62,13 +62,9 @@ type Conn struct {
 
 // Connect connects to the KMS plugin using the
 // given configuration.
-func Connect(ctx context.Context, config *Config) (*Conn, error) {
+func Connect(_ context.Context, config *Config) (*Conn, error) {
 	if config == nil || config.Endpoint == "" {
 		return nil, errors.New("generic: endpoint is empty")
-	}
-	_, err := kms.Dial(ctx, config.Endpoint)
-	if err != nil {
-		return nil, err
 	}
 
 	tlsConfig := &tls.Config{
@@ -115,9 +111,7 @@ var _ kms.Conn = (*Conn)(nil)
 
 // Status returns the current state of the generic KeyStore instance.
 // In particular, whether it is reachable and the network latency.
-func (c *Conn) Status(ctx context.Context) (kms.State, error) {
-	return kms.Dial(ctx, c.config.Endpoint)
-}
+func (c *Conn) Status(context.Context) (kms.State, error) { return kms.State{}, nil }
 
 // Create creates the given key-value pair at the generic KeyStore if
 // and only if the given key does not exist. If such an entry already

--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -175,7 +175,15 @@ func (s *Conn) Status(ctx context.Context) (kms.State, error) {
 	if errors.Is(err, context.Canceled) && errors.Is(err, context.DeadlineExceeded) {
 		return kms.State{}, &kms.Unreachable{Err: err}
 	}
-	return kms.Dial(ctx, s.config.Endpoint)
+
+	start = time.Now()
+	req := s.client.Client.NewRequest(http.MethodGet, "")
+	if _, err = s.client.Client.RawRequestWithContext(ctx, req); err != nil {
+		return kms.State{}, &kms.Unreachable{Err: err}
+	}
+	return kms.State{
+		Latency: time.Since(start),
+	}, nil
 }
 
 // Create creates the given key-value pair at Vault if and only


### PR DESCRIPTION
This commit removes the generic TCP status check
in favour of a HTTP status check specific for
each KeyStore backend.

One major problem for TCP status checks are HTTP
proxies. If a KeyStore is only reachable by via
an HTTP proxy (air-gap env.) then any TCP status
check fails.

Hence, this commit switches to a HTTP-based status check that accounts for HTTP proxies.