### PR TITLE
gcp: use default GCP endpoint for status checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.2
+        go-version: 1.20.3
         check-latest: true
       id: go
     - name: Check out code
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.2
+          go-version: 1.20.3
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.2
+        go-version: 1.20.3
         check-latest: true
       id: go
     - name: Check out code
@@ -74,7 +74,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.20.2
+        go-version: 1.20.3
         check-latest: true
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.2
+          go-version: 1.20.3
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/internal/keystore/gcp/secret-manager.go
+++ b/internal/keystore/gcp/secret-manager.go
@@ -41,6 +41,9 @@ func Connect(ctx context.Context, c *Config) (*Conn, error) {
 	var options []option.ClientOption
 	if c.Endpoint != "" {
 		options = append(options, option.WithEndpoint(c.Endpoint))
+	} else {
+		const DefaultEndpoint = "https://secretmanager.googleapis.com" // From the GCP SDK
+		c.Endpoint = DefaultEndpoint
 	}
 	// We only pass credentials to the GCP client if they
 	// are not empty. When running inside GCP, e.g. on app engine,


### PR DESCRIPTION
This commit fixes a bug in the GCP SecretsManager
status check implementation.

Commit 64f37b1 changed the status check for a general TCP status check to a keystore specific HTTP status check.
As part of this change, the GCP implementation
only considered the SecretsManager endpoint
provided in the config file - which is usually
not set - and did not fallback to the GCP default: `secretmanager.googleapis.com:443`

This commit fixes this such that it is no longer
required to set the GCP endpoint to successfully
query the SecretsManager liveness.