### PR TITLE
add git tag check to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --skip-publish --skip-sign --rm-dist --snapshot
+          args: release --skip-publish --skip-sign --clean --snapshot --skip-before

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ before:
   hooks:
     - go mod tidy
     - sh -c 'git diff --quiet || (echo "Repo contains modified files. Run git checkout" && exit 1)'
+    - sh -c "[[ {{ .Tag }} ==  {{ replace .CommitDate ":" "-" }} ]] || (echo Invalid release tag. Run git tag -a {{ replace .CommitDate ":" "-" }} && exit 1)"
 
 builds:
   -


### PR DESCRIPTION
This commit adds a check to the release process
to ensure that the git tag matches the commit
timestamp.

This ensures that the releases aren't tagged
incorrectly.