### PR TITLE
ci: add staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,16 @@ linters-settings:
   misspell:
     locale: US
 
+  staticcheck:
+    checks: ["all", "-SA1019"]
+
 linters:
   disable-all: true
   enable:
     - typecheck
     - goimports
     - misspell
+    - staticcheck
     - govet
     - revive
     - ineffassign

--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -603,13 +603,12 @@ func gatewayMessage(config *edge.ServerConfig, tlsConfig *tls.Config, mlock bool
 		return nil, err
 	}
 
-	var faint, item, green, red, yellow tui.Style
+	var faint, item, green, red tui.Style
 	if isTerm(os.Stdout) {
 		faint = faint.Faint(true)
 		item = item.Foreground(tui.Color("#2e42d1")).Bold(true)
 		green = green.Foreground(tui.Color("#00a700"))
 		red = red.Foreground(tui.Color("#a70000"))
-		yellow = yellow.Foreground(tui.Color("#fede00"))
 	}
 
 	buffer := new(cli.Buffer)

--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -345,7 +345,7 @@ Examples:
 
 func infoIdentityCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, infoIdentityCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, infoIdentityCmdUsage) }
 
 	var (
 		jsonFlag           bool

--- a/cmd/kes/key.go
+++ b/cmd/kes/key.go
@@ -465,7 +465,7 @@ Examples:
 
 func encryptKeyCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, encryptKeyCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, encryptKeyCmdUsage) }
 
 	var (
 		insecureSkipVerify bool
@@ -527,7 +527,7 @@ Examples:
 
 func decryptKeyCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, decryptKeyCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, decryptKeyCmdUsage) }
 
 	var (
 		insecureSkipVerify bool

--- a/cmd/kes/log.go
+++ b/cmd/kes/log.go
@@ -39,7 +39,7 @@ Examples:
 
 func logCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, logCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, logCmdUsage) }
 
 	var (
 		auditFlag          bool

--- a/cmd/kes/policy.go
+++ b/cmd/kes/policy.go
@@ -38,7 +38,7 @@ Options:
 
 func policyCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, policyCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, policyCmdUsage) }
 
 	subCmds := commands{
 		"create": createPolicyCmd,
@@ -84,7 +84,7 @@ Examples:
 
 func createPolicyCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, createPolicyCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, createPolicyCmdUsage) }
 
 	var (
 		insecureSkipVerify bool
@@ -147,7 +147,7 @@ Examples:
 
 func assignPolicyCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, assignPolicyCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, assignPolicyCmdUsage) }
 
 	var (
 		insecureSkipVerify bool
@@ -207,7 +207,7 @@ Examples:
 
 func lsPolicyCmd(args []string) {
 	cmd := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	cmd.Usage = func() { fmt.Fprintf(os.Stderr, lsPolicyCmdUsage) }
+	cmd.Usage = func() { fmt.Fprint(os.Stderr, lsPolicyCmdUsage) }
 
 	var (
 		jsonFlag           bool

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -263,13 +263,12 @@ func startServer(path string, sConfig serverConfig) {
 		cli.Fatal("failed to listen on network interfaces")
 	}
 
-	var faint, item, green, red, yellow tui.Style
+	var faint, item, green, red tui.Style
 	if isTerm(os.Stdout) {
 		faint = faint.Faint(true)
 		item = item.Foreground(tui.Color("#2e42d1")).Bold(true)
 		green = green.Foreground(tui.Color("#00a700"))
 		red = red.Foreground(tui.Color("#a70000"))
-		yellow = yellow.Foreground(tui.Color("#fede00"))
 	}
 
 	var buffer cli.Buffer

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	golang.org/x/sys v0.5.0
 	golang.org/x/term v0.5.0
 	google.golang.org/api v0.102.0
-	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 	google.golang.org/grpc v1.50.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -96,6 +95,7 @@ require (
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )

--- a/internal/http/retry.go
+++ b/internal/http/retry.go
@@ -247,7 +247,7 @@ func isTemporary(err error) bool {
 		return false
 	}
 	if netErr, ok := err.(net.Error); ok { // *url.Error implements net.Error
-		if netErr.Timeout() || netErr.Temporary() {
+		if netErr.Timeout() {
 			return true
 		}
 

--- a/internal/https/flush.go
+++ b/internal/https/flush.go
@@ -39,7 +39,7 @@ func (fw *flushWriter) WriteHeader(status int) { fw.w.WriteHeader(status) }
 func (fw *flushWriter) Header() http.Header { return fw.w.Header() }
 
 func (fw *flushWriter) Write(p []byte) (int, error) {
-	n, err := fw.Write(p)
+	n, err := fw.w.Write(p)
 	if fw.f != nil && err == nil {
 		fw.f.Flush()
 	}

--- a/internal/keystore/azure/key-vault.go
+++ b/internal/keystore/azure/key-vault.go
@@ -228,9 +228,8 @@ func (c *Conn) Delete(ctx context.Context, name string) error {
 		case stat.StatusCode == http.StatusConflict && stat.ErrorCode == "ObjectIsBeingDeleted":
 			time.Sleep(Delay + time.Duration(rand.Int63n(Jitter.Milliseconds()))*time.Millisecond)
 			continue
-		default:
-			break
 		}
+		break
 	}
 	if stat.StatusCode == http.StatusConflict && stat.ErrorCode == "ObjectIsBeingDeleted" {
 		return nil
@@ -308,7 +307,7 @@ func (c *Conn) List(ctx context.Context) (kms.Iter, error) {
 						err = context.Canceled
 					}
 					iterator.SetErr(err)
-					break
+					return
 				}
 			}
 			if nextLink == "" {

--- a/internal/keystore/gcp/secret-manager.go
+++ b/internal/keystore/gcp/secret-manager.go
@@ -15,11 +15,11 @@ import (
 	"github.com/minio/kes-go"
 	"github.com/minio/kes/kms"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 )
 
 // Conn is a connection to a GCP SecretManager.
@@ -141,7 +141,7 @@ func (c *Conn) Create(ctx context.Context, name string, value []byte) error {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
-		if grpc.Code(err) == codes.AlreadyExists {
+		if status.Code(err) == codes.AlreadyExists {
 			return kes.ErrKeyExists
 		}
 		return fmt.Errorf("gcp: failed to create '%s': %v", name, err)
@@ -171,7 +171,7 @@ func (c *Conn) Get(ctx context.Context, name string) ([]byte, error) {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
-		if grpc.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			return nil, kes.ErrKeyNotFound
 		}
 		return nil, fmt.Errorf("gcp: failed to read '%s': %v", name, err)
@@ -195,7 +195,7 @@ func (c *Conn) Delete(ctx context.Context, name string) error {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
-		if grpc.Code(err) == codes.NotFound {
+		if status.Code(err) == codes.NotFound {
 			return kes.ErrKeyNotFound
 		}
 		return fmt.Errorf("gcp: failed to delete '%s': %v", name, err)


### PR DESCRIPTION
This commit adds the staticcheck linter and fixes
the reported staticcheck linter warnings.

The deprecated lint warning (SA1019) is disabled
since we support some legacy features like
`x509.EncryptPEMBlock`.