### PR TITLE
add readiness API

### DIFF
--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -482,8 +482,24 @@ func newTLSConfig(config *edge.ServerConfig, auth string) (*tls.Config, error) {
 	switch strings.ToLower(auth) {
 	case "", "on":
 		clientAuth = tls.RequireAndVerifyClientCert
+		if config.API != nil {
+			for _, api := range config.API.Paths {
+				if api.InsecureSkipAuth {
+					clientAuth = tls.VerifyClientCertIfGiven
+					break
+				}
+			}
+		}
 	case "off":
 		clientAuth = tls.RequireAnyClientCert
+		if config.API != nil {
+			for _, api := range config.API.Paths {
+				if api.InsecureSkipAuth {
+					clientAuth = tls.RequestClientCert
+					break
+				}
+			}
+		}
 	default:
 		return nil, fmt.Errorf("invalid option for --auth: %s", auth)
 	}

--- a/edge/server-config-yml.go
+++ b/edge/server-config-yml.go
@@ -304,7 +304,7 @@ func ymlToServerConfig(y *yml) (*ServerConfig, error) {
 		},
 		Log: &LogConfig{
 			Error: strings.TrimSpace(strings.ToLower(y.Log.Error.Value)) != "off", // default is "on" behavior
-			Audit: strings.TrimSpace(strings.ToLower(y.Log.Audit.Value)) != "on",  // default is "off" behavior
+			Audit: strings.TrimSpace(strings.ToLower(y.Log.Audit.Value)) == "on",  // default is "off" behavior
 		},
 		KeyStore: keystore,
 	}

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -1,0 +1,55 @@
+// Copyright 2023 - MinIO, Inc. All rights reserved.
+// Use of this source code is governed by the AGPLv3
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/minio/kes-go"
+	"github.com/minio/kes/internal/auth"
+	"github.com/minio/kes/kv"
+)
+
+func edgeReady(config *EdgeRouterConfig) API {
+	var (
+		Method  = http.MethodGet
+		APIPath = "/v1/ready"
+		MaxBody int64
+		Timeout = 15 * time.Second
+		Verify  = true
+	)
+	if c, ok := config.APIConfig[APIPath]; ok {
+		if c.Timeout > 0 {
+			Timeout = c.Timeout
+		}
+		Verify = !c.InsecureSkipAuth
+	}
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		if err := auth.VerifyRequest(r, config.Policies, config.Identities); Verify && err != nil {
+			Fail(w, err)
+			return
+		}
+
+		_, err := config.Keys.Status(r.Context())
+		if _, ok := kv.IsUnreachable(err); ok {
+			Fail(w, kes.NewError(http.StatusGatewayTimeout, err.Error()))
+			return
+		}
+		if err != nil {
+			Fail(w, kes.NewError(http.StatusBadGateway, err.Error()))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	return API{
+		Method:  Method,
+		Path:    APIPath,
+		MaxBody: MaxBody,
+		Verify:  Verify,
+		Timeout: Timeout,
+		Handler: handler,
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -116,6 +116,7 @@ func NewEdgeRouter(config *EdgeRouterConfig) *Router {
 	}
 
 	r.api = append(r.api, edgeVersion(config))
+	r.api = append(r.api, edgeReady(config))
 	r.api = append(r.api, edgeStatus(config))
 	r.api = append(r.api, edgeMetrics(config))
 	r.api = append(r.api, edgeListAPI(r, config))

--- a/kestest/gateway_test.go
+++ b/kestest/gateway_test.go
@@ -27,6 +27,7 @@ var gatewayAPIs = map[string]struct {
 	Timeout time.Duration
 }{
 	"/version":    {Method: http.MethodGet, MaxBody: 0, Timeout: 15 * time.Second},
+	"/v1/ready":   {Method: http.MethodGet, MaxBody: 0, Timeout: 15 * time.Second},
 	"/v1/status":  {Method: http.MethodGet, MaxBody: 0, Timeout: 15 * time.Second},
 	"/v1/metrics": {Method: http.MethodGet, MaxBody: 0, Timeout: 15 * time.Second},
 	"/v1/api":     {Method: http.MethodGet, MaxBody: 0, Timeout: 15 * time.Second},

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -58,26 +58,41 @@ tls:
 # Only customize the APIs if there is a real need.
 # 
 # Disabling authentication for an API must be carefully evaluated.
-# One example, when authentication may be justified monitoring via
-# the /v1/metrics API. It is possible that providing identities
-# to auto-scaling monitoring instances may not be feasable in certain
-# environments. However, in general it is better to use API keys or
-# TLS client certificates if possible.
+# One example, when disabling authentication may be justified, would
+# be the liveness and readiness probes in a Kubernetes environment.
 #
 # When authentication is disabled, the particular API can be
 # accessed by any client that can send HTTPS requests to the
 # KES server.
+#
+# When disabling authentication for any API, the KES server will
+# change its TLS handshake behavior. By default, KES requires that
+# a client sends a client certificate during the handshake or KES
+# aborts the handshake. This means that a client can only send an
+# HTTP request to KES when it provides a certificate during the
+# handshake. This is no longer the case when authentication is 
+# disabled for at least one API. Clients should be able to call
+# the API even without a certificate. Hence, KES can no longer
+# require a certificate during the TLS handshake but instead has
+# to check the certificate when executing the API handler. 
+# 
+# Now, these two behaviors have slightly different semantics:
+# By default, KES does not accept connections from clients without
+# a TLS certificate. When disabling authentication for one API, KES
+# has to accept connections from any client for all APIs. However,
+# the API handlers that still require authentication will reject
+# requests from clients without a certificate. Instead of a TLS
+# error these clients will receive an HTTP error.
+#
 # Currently, authentication can only be disabled for the
 # following APIs:
+#   - /v1/ready
 #   - /v1/status
 #   - /v1/metrics
 #   - /v1/api
 #
 api:
-  /v1/metrics:
-    skip_auth: false
-    timeout:   15s
-  /v1/status:
+  /v1/ready:
     skip_auth: false
     timeout:   15s
     


### PR DESCRIPTION
This commit adds a new API to check the readiness
of a KES edge server.

In general, liveness and readiness may be checked
by a system like Kubernetes to determine whether
a system (i.e. pod) is available and ready to serve
requests.

In general, the liveness probe should report
whether a system is not in a deadlock state.
In particular, it does not indicate whether
a system is "alive".

In contrast, the readiness probe should report
whether a system is ready to handle requests.
For example, if KES cannot reach its backend
keystore its readiness probe should fail since
it will not be able to process (some) requests.

For KES the liveness probe makes no sense at
the moment since it is not a distributed systems
where deadlocks can occur. Hence, it is not
implemented.

To make readiness really useful we have to change
the KES TLS behavior in a subtle way.

By default, KES doesn't not accept a TLS connection
attempt from a client without a TLS certificate
(or API key that translates to a certificate).
Hence, only clients with an API key or certificate
can check the KES liveness or readiness.

However, some systems (e.g. K8S) do not support
client certificates for liveness and readiness
probes. Hence, we allow the disabling authentication
for these two APIs in the `api` section in the
KES config file.

To make this actually work, we also have to tell
the Go TLS stack to allow TLS handshakes without
a certificate. Therefore, whenever at least one
API has a `skip_auth` config set to true, we also
set:
- `tls.RequestClientCert` instead of `tls.RequireAnyClientCert`
- `tls.VerifyClientCertIfGiven` instead of `tlsRequireAndVerifyClientCert`

Ref to: https://pkg.go.dev/crypto/tls#ClientAuthType

Now, the subtle behavior change is the following:
If the config file disables authentication for any
API, clients are no longer forced to send a client
certificate whenever they try to perform an API call.
Instead, the TLS handshake will always succeed.
However, for all APIs that require authentication
the HTTP API handler will reject the request with
the following error:
```
no client certificate is present
```
The difference is the protocol layer that is responsible
for rejecting clients without certificates. Before,
and also today in the default config, it's the Gop TLS
stack rejecting such connection attempts. However,
when authentication is disabled for at least one API,
the TLS stack will allow requests without a client
certificate and its no the HTTP / API layer that
has to enforce that the client sends a client certificate
when the API requires authentication.

This however, does not change the security model.
APIs that required authentication still require
authentication.

Fixes #353