### PR TITLE
 fix: Load Azure KeyVault tenant-id correctly from the config file

### DIFF
--- a/edge/server-config.go
+++ b/edge/server-config.go
@@ -624,7 +624,7 @@ func (s *AzureKeyVaultKeyStore) Connect(ctx context.Context) (kv.Store[string, [
 	switch {
 	case s.TenantID != "" || s.ClientID != "" || s.ClientSecret != "":
 		creds := azure.Credentials{
-			TenantID: s.Endpoint,
+			TenantID: s.TenantID,
 			ClientID: s.ClientID,
 			Secret:   s.ClientSecret,
 		}


### PR DESCRIPTION
A typo was found to not load the tenant-id correctly from the config file.

The apparent issue is 404 status code with a HTML page

This commit fixes the behavior.