### PR TITLE
Added unit tests for various key stores

### DIFF
--- a/edge_test/aws_test.go
+++ b/edge_test/aws_test.go
@@ -1,0 +1,40 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var awsConfigFile = flag.String("aws.config", "", "Path to a KES config file with AWS SecretsManager config")
+
+func TestAWS(t *testing.T) {
+	if *awsConfigFile == "" {
+		t.Skip("AWS tests disabled. Use -aws.config=<config file with AWS SecretManager config> to enable them")
+	}
+
+	file, err := os.Open(*awsConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}

--- a/edge_test/azure_test.go
+++ b/edge_test/azure_test.go
@@ -1,0 +1,39 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var azureConfigFile = flag.String("azure.config", "", "Path to a KES config file with Azure SecretsManager config")
+
+func TestAzure(t *testing.T) {
+	if *azureConfigFile == "" {
+		t.Skip("Azure tests disabled. Use -azure.config=<config file with Azure SecretManager config> to enable them")
+	}
+	file, err := os.Open(*azureConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}

--- a/edge_test/edge_test.go
+++ b/edge_test/edge_test.go
@@ -1,0 +1,119 @@
+package edge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/minio/kes/internal/keystore/mem"
+	"github.com/minio/kes/kv"
+)
+
+var store = kv.Store[string, []byte](&mem.Store{})
+
+func TestCreate(t *testing.T) {
+	if err := store.Create(context.Background(), "testkey", []byte("testvalue")); err != nil {
+		t.Fatalf("Failed to create key: %v", err)
+	}
+
+	value, err := store.Get(context.Background(), "testkey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(value) != "testvalue" {
+		t.Fatal("The key vaule not matching")
+	}
+	_ = store.Delete(context.Background(), "testkey")
+}
+
+func TestSet(t *testing.T) {
+	if err := store.Set(context.Background(), "testkey1", []byte("testvalue1")); err != nil {
+		t.Fatalf("Failed to set key: %v", err)
+	}
+	value, err := store.Get(context.Background(), "testkey1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(value) != "testvalue1" {
+		t.Fatal("The key vaule not matching")
+	}
+	_ = store.Delete(context.Background(), "testkey1")
+}
+
+func TestGet(t *testing.T) {
+	if err := store.Create(context.Background(), "testkey", []byte("testvalue")); err != nil {
+		t.Fatalf("Failed to create key: %v", err)
+	}
+
+	value, err := store.Get(context.Background(), "testkey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(value) != "testvalue" {
+		t.Fatal("The key vaule not matching")
+	}
+	_ = store.Delete(context.Background(), "testkey")
+}
+
+func TestList(t *testing.T) {
+	if err := store.Create(context.Background(), "testkey", []byte("testvalue")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Create(context.Background(), "testkey1", []byte("testvalue1")); err != nil {
+		t.Fatal(err)
+	}
+	iter, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	for {
+		key, ok := iter.Next()
+		if ok {
+			keys = append(keys, key)
+		} else {
+			break
+		}
+	}
+	if len(keys) != 2 {
+		t.Fatal("Incorrect no of keys found")
+	}
+	_ = store.Delete(context.Background(), "testkey")
+	_ = store.Delete(context.Background(), "testkey1")
+}
+
+func TestDelete(t *testing.T) {
+	if err := store.Create(context.Background(), "testkey", []byte("testvalue")); err != nil {
+		t.Fatal(err)
+	}
+
+	iter, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	for {
+		key, ok := iter.Next()
+		if ok {
+			keys = append(keys, key)
+		} else {
+			break
+		}
+	}
+	if len(keys) != 1 {
+		t.Fatal("Incorrect no of keys found")
+	}
+
+	if err := store.Delete(context.Background(), "testkey"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(context.Background(), "testkey"); err != nil {
+		t.Log("Key not present anymore")
+	}
+}
+
+func TestStatus(t *testing.T) {
+	_, err := store.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/edge_test/fortanix_test.go
+++ b/edge_test/fortanix_test.go
@@ -1,0 +1,39 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var fortanixConfigFile = flag.String("fortanix.config", "", "Path to a KES config file with Fortanix SecretsManager config")
+
+func TestFortanix(t *testing.T) {
+	if *fortanixConfigFile == "" {
+		t.Skip("Fortanix tests disabled. Use -fortanix.config=<config file with Fortanix SecretManager config> to enable them")
+	}
+	file, err := os.Open(*fortanixConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}

--- a/edge_test/fs_test.go
+++ b/edge_test/fs_test.go
@@ -1,0 +1,33 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var FSPath = flag.String("fs.path", "", "Path used for FS tests")
+
+func TestFS(t *testing.T) {
+	if *FSPath == "" {
+		t.Skip("FS tests disabled. Use -fs.path=<path> to enable them")
+	}
+	config := edge.FSKeyStore{
+		Path: *FSPath,
+	}
+
+	var err error
+	store, err = config.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}

--- a/edge_test/gcp_test.go
+++ b/edge_test/gcp_test.go
@@ -1,0 +1,39 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var gcpConfigFile = flag.String("gcp.config", "", "Path to a KES config file with GCP SecretsManager config")
+
+func TestGCP(t *testing.T) {
+	if *gcpConfigFile == "" {
+		t.Skip("GCP tests disabled. Use -gcp.config=<config file with GCP SecretManager config> to enable them")
+	}
+	file, err := os.Open(*gcpConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}

--- a/edge_test/gemalto_test.go
+++ b/edge_test/gemalto_test.go
@@ -1,0 +1,39 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var gemaltoConfigFile = flag.String("gemalto.config", "", "Path to a KES config file with Gemalto SecretsManager config")
+
+func TestGemalto(t *testing.T) {
+	if *gemaltoConfigFile == "" {
+		t.Skip("Gemalto tests disabled. Use -gemalto.config=<config file with Gemalto SecretManager config> to enable them")
+	}
+	file, err := os.Open(*gemaltoConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}

--- a/edge_test/vault_test.go
+++ b/edge_test/vault_test.go
@@ -1,0 +1,39 @@
+package edge_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var vaultConfigFile = flag.String("vault.config", "", "Path to a KES config file with Vault SecretsManager config")
+
+func TestVault(t *testing.T) {
+	if *vaultConfigFile == "" {
+		t.Skip("Vault tests disabled. Use -vault.config=<config file with Vault SecretManager config> to enable them")
+	}
+	file, err := os.Open(*vaultConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("create", TestCreate)
+	t.Run("set", TestSet)
+	t.Run("get", TestGet)
+	t.Run("list", TestList)
+	t.Run("delete", TestDelete)
+	t.Run("status", TestStatus)
+}


### PR DESCRIPTION
Purpose of this change is to enable testing of various backend key stores like Azure, GCP, HashiCorp Vault etc. The tests use command like flags e.g. `aws.config`, `azure.config` to get details to connect to the key store. This is done to make the changes generic and so code remains agnostic to addition of new keystores.

Also this way we are making sure all backend key store integrations work just fine and later when integrated with KES server and client making calls throughKES server, there wont be any surprises.
