### PR TITLE
Enabled for other backend stores

### DIFF
--- a/kestest/example_test.go
+++ b/kestest/example_test.go
@@ -11,11 +11,12 @@ import (
 	"log"
 
 	"github.com/minio/kes-go"
+	"github.com/minio/kes/internal/keystore/mem"
 	"github.com/minio/kes/kestest"
 )
 
 func ExampleGateway() {
-	server := kestest.NewGateway()
+	server := kestest.NewGateway(&mem.Store{})
 	defer server.Close()
 
 	version, err := server.Client().Version(context.Background())
@@ -29,7 +30,7 @@ func ExampleGateway() {
 }
 
 func ExampleGateway_IssueClientCertificate() {
-	server := kestest.NewGateway()
+	server := kestest.NewGateway(&mem.Store{})
 	defer server.Close()
 
 	server.Policy().Allow("test-policy",

--- a/kestest/gateway.go
+++ b/kestest/gateway.go
@@ -26,17 +26,17 @@ import (
 	"github.com/minio/kes/internal/api"
 	"github.com/minio/kes/internal/auth"
 	"github.com/minio/kes/internal/keystore"
-	"github.com/minio/kes/internal/keystore/mem"
 	"github.com/minio/kes/internal/log"
 	"github.com/minio/kes/internal/metric"
+	"github.com/minio/kes/kv"
 )
 
 // NewGateway starts and returns a new Gateway.
 // The caller should call Close when finished,
 // to shut it down.
-func NewGateway() *Gateway {
+func NewGateway(store kv.Store[string, []byte]) *Gateway {
 	g := &Gateway{}
-	g.start()
+	g.start(store)
 	return g
 }
 
@@ -92,7 +92,7 @@ func (g *Gateway) CAs() *x509.CertPool {
 	return certpool
 }
 
-func (g *Gateway) start() {
+func (g *Gateway) start(kmsStore kv.Store[string, []byte]) {
 	var (
 		rootCAs   = g.CAs()
 		auditLog  = log.New(io.Discard, "", 0)
@@ -108,7 +108,7 @@ func (g *Gateway) start() {
 
 	auditLog.Add(metrics.AuditEventCounter())
 	errorLog.Add(metrics.ErrorEventCounter())
-	store := keystore.NewCache(context.Background(), &mem.Store{}, &keystore.CacheConfig{
+	store := keystore.NewCache(context.Background(), kmsStore, &keystore.CacheConfig{
 		Expiry:       30 * time.Second,
 		ExpiryUnused: 5 * time.Second,
 	})

--- a/kestest/gateway_aws_test.go
+++ b/kestest/gateway_aws_test.go
@@ -1,0 +1,45 @@
+package kestest_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var awsConfigFile = flag.String("aws.config", "", "Path to a KES config file with AWS SecretsManager config")
+
+func TestGatewayAWS(t *testing.T) {
+	if *awsConfigFile == "" {
+		t.Skip("AWS tests disabled. Use -aws.config=<config file with AWS SecretManager config> to enable them")
+	}
+
+	file, err := os.Open(*awsConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}

--- a/kestest/gateway_azure_test.go
+++ b/kestest/gateway_azure_test.go
@@ -1,0 +1,44 @@
+package kestest_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var azureConfigFile = flag.String("azure.config", "", "Path to a KES config file with Azure SecretsManager config")
+
+func TestGatewayAzure(t *testing.T) {
+	if *azureConfigFile == "" {
+		t.Skip("Azure tests disabled. Use -azure.config=<config file with Azure SecretManager config> to enable them")
+	}
+	file, err := os.Open(*azureConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}

--- a/kestest/gateway_fortanix_test.go
+++ b/kestest/gateway_fortanix_test.go
@@ -1,0 +1,44 @@
+package kestest_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var fortanixConfigFile = flag.String("fortanix.config", "", "Path to a KES config file with Fortanix SecretsManager config")
+
+func TestGatewayFortanix(t *testing.T) {
+	if *fortanixConfigFile == "" {
+		t.Skip("Fortanix tests disabled. Use -fortanix.config=<config file with Fortanix SecretManager config> to enable them")
+	}
+	file, err := os.Open(*fortanixConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}

--- a/kestest/gateway_fs_test.go
+++ b/kestest/gateway_fs_test.go
@@ -1,0 +1,33 @@
+package kestest_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/minio/kes/internal/keystore/fs"
+)
+
+var fsPath = flag.String("fs.path", "", "FS Path")
+
+func TestGatewayFS(t *testing.T) {
+	if *fsPath == "" {
+		t.Skip("FS tests disabled. Use -fs.path=<path> to enable them.")
+	}
+	var err error
+	store, err = fs.NewStore(*fsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}

--- a/kestest/gateway_gcp_test.go
+++ b/kestest/gateway_gcp_test.go
@@ -1,0 +1,45 @@
+package kestest_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var gcpConfigFile = flag.String("gcp.config", "", "Path to a KES config file with GCP SecretsManager config")
+
+func TestGatewayGCP(t *testing.T) {
+	if *gcpConfigFile == "" {
+		t.Skip("GCP tests disabled. Use -gcp.config=<config file with GCP SecretManager config> to enable them")
+	}
+
+	file, err := os.Open(*gcpConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}

--- a/kestest/gateway_gemalto_test.go
+++ b/kestest/gateway_gemalto_test.go
@@ -1,0 +1,44 @@
+package kestest_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var gemaltoConfigFile = flag.String("gemalto.config", "", "Path to a KES config file with Gemalto SecretsManager config")
+
+func TestGatewayGemalto(t *testing.T) {
+	if *gemaltoConfigFile == "" {
+		t.Skip("Gemalto tests disabled. Use -gemalto.config=<config file with Gemalto SecretManager config> to enable them")
+	}
+	file, err := os.Open(*gemaltoConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}

--- a/kestest/gateway_vault_test.go
+++ b/kestest/gateway_vault_test.go
@@ -1,0 +1,43 @@
+package kestest_test
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/minio/kes/edge"
+)
+
+var vaultConfigFile = flag.String("vault.config", "", "Path to a KES config file with Vault SecretsManager config")
+
+func TestGatewayVault(t *testing.T) {
+	if *vaultConfigFile == "" {
+		t.Skip("Vault tests disabled. Use -vault.config=<config file with Vault SecretManager config> to enable them")
+	}
+	file, err := os.Open(*vaultConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	srvrConfig, err := edge.ReadServerConfigYAML(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("metrics", TestMetrics)
+	t.Run("apis", TestAPIs)
+	t.Run("createkey", TestCreateKey)
+	t.Run("importkey", TestImportKey)
+	t.Run("generatekey", TestGenerateKey)
+	t.Run("encryptket", TestEncryptKey)
+	t.Run("decryptkey", TestDecryptKey)
+	t.Run("decryptkeyall", TestDecryptKeyAll)
+	t.Run("describepolicy", TestDescribePolicy)
+	t.Run("getpolicy", TestGetPolicy)
+	t.Run("selfdescribe", TestSelfDescribe)
+}


### PR DESCRIPTION
This change enables integration tests with various backend ketystores.
It uses command line flags like `aws.config`, `azure.config` and `vault.config` to provide keystore connection configurations.