### PR TITLE
edge: handle Vault K8S auht JWTs more strictly

### DIFF
--- a/edge/server-config-yml.go
+++ b/edge/server-config-yml.go
@@ -423,9 +423,10 @@ func ymlToKeyStore(y *yml) (KeyStore, error) {
 				return nil, errors.New("edge: invalid vault keystore: invalid kubernetes config: no JWT specified")
 			}
 
-			// We check whether the JWT looks like a JWT (<header>.<payload>.<signature>). If not, we assume it's
-			// a path to a file containing the JWT and try to read the JWT from that file.
-			if s := strings.Split(y.KeyStore.Vault.Kubernetes.JWT.Value, "."); len(s) != 3 && strings.Contains(y.KeyStore.Vault.Kubernetes.JWT.Value, "/") {
+			// If the passed JWT value contains a path separator we assume it's a file.
+			// We always check for '/' and the OS-specific one make cover cases where
+			// a path is specified using '/' but the underlying OS is e.g. windows.
+			if jwt := y.KeyStore.Vault.Kubernetes.JWT.Value; strings.ContainsRune(jwt, '/') || strings.ContainsRune(jwt, os.PathSeparator) {
 				b, err := os.ReadFile(y.KeyStore.Vault.Kubernetes.JWT.Value)
 				if err != nil {
 					return nil, fmt.Errorf("edge: failed to read vault kubernetes JWT from '%s': %v", y.KeyStore.Vault.Kubernetes.JWT.Value, err)


### PR DESCRIPTION
This commit enforces that a JWT passed to the
K8S Vault engine does not require contain '/' (or
other OS path seperator).

If the JWT value contains a OS path separator we
treat it as file and read it from disk.

As a sideeffect, we require that a path to a JWT
is absolute. A relative path - e.g. `token` will
not be treated as filepath. Instead, it must be
specified as e.g. `/var/run/secrets/kubernetes.io/serviceaccount/token`.

Fixes #361