### PR TITLE
Refactored `kestest` integration tests

### DIFF
--- a/kestest/gateway_aws_test.go
+++ b/kestest/gateway_aws_test.go
@@ -26,20 +26,23 @@ func TestGatewayAWS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	store, err := srvrConfig.KeyStore.Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Run("metrics", TestMetrics)
-	t.Run("apis", TestAPIs)
-	t.Run("createkey", TestCreateKey)
-	t.Run("importkey", TestImportKey)
-	t.Run("generatekey", TestGenerateKey)
-	t.Run("encryptket", TestEncryptKey)
-	t.Run("decryptkey", TestDecryptKey)
-	t.Run("decryptkeyall", TestDecryptKeyAll)
-	t.Run("describepolicy", TestDescribePolicy)
-	t.Run("getpolicy", TestGetPolicy)
-	t.Run("selfdescribe", TestSelfDescribe)
+	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
+	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })
+	t.Run("CreateKey", func(t *testing.T) { testCreateKey(ctx, store, t) })
+	t.Run("ImportKey", func(t *testing.T) { testImportKey(ctx, store, t) })
+	t.Run("GenerateKey", func(t *testing.T) { testGenerateKey(ctx, store, t) })
+	t.Run("EncryptKey", func(t *testing.T) { testEncryptKey(ctx, store, t) })
+	t.Run("DecryptKey", func(t *testing.T) { testDecryptKey(ctx, store, t) })
+	t.Run("DecryptKeyAll", func(t *testing.T) { testDecryptKeyAll(ctx, store, t) })
+	t.Run("DescribePolicy", func(t *testing.T) { testDescribePolicy(ctx, store, t) })
+	t.Run("GetPolicy", func(t *testing.T) { testGetPolicy(ctx, store, t) })
+	t.Run("SelfDescribe", func(t *testing.T) { testSelfDescribe(ctx, store, t) })
 }

--- a/kestest/gateway_azure_test.go
+++ b/kestest/gateway_azure_test.go
@@ -25,20 +25,23 @@ func TestGatewayAzure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	store, err := srvrConfig.KeyStore.Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Run("metrics", TestMetrics)
-	t.Run("apis", TestAPIs)
-	t.Run("createkey", TestCreateKey)
-	t.Run("importkey", TestImportKey)
-	t.Run("generatekey", TestGenerateKey)
-	t.Run("encryptket", TestEncryptKey)
-	t.Run("decryptkey", TestDecryptKey)
-	t.Run("decryptkeyall", TestDecryptKeyAll)
-	t.Run("describepolicy", TestDescribePolicy)
-	t.Run("getpolicy", TestGetPolicy)
-	t.Run("selfdescribe", TestSelfDescribe)
+	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
+	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })
+	t.Run("CreateKey", func(t *testing.T) { testCreateKey(ctx, store, t) })
+	t.Run("ImportKey", func(t *testing.T) { testImportKey(ctx, store, t) })
+	t.Run("GenerateKey", func(t *testing.T) { testGenerateKey(ctx, store, t) })
+	t.Run("EncryptKey", func(t *testing.T) { testEncryptKey(ctx, store, t) })
+	t.Run("DecryptKey", func(t *testing.T) { testDecryptKey(ctx, store, t) })
+	t.Run("DecryptKeyAll", func(t *testing.T) { testDecryptKeyAll(ctx, store, t) })
+	t.Run("DescribePolicy", func(t *testing.T) { testDescribePolicy(ctx, store, t) })
+	t.Run("GetPolicy", func(t *testing.T) { testGetPolicy(ctx, store, t) })
+	t.Run("SelfDescribe", func(t *testing.T) { testSelfDescribe(ctx, store, t) })
 }

--- a/kestest/gateway_fortanix_test.go
+++ b/kestest/gateway_fortanix_test.go
@@ -25,20 +25,23 @@ func TestGatewayFortanix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	store, err := srvrConfig.KeyStore.Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Run("metrics", TestMetrics)
-	t.Run("apis", TestAPIs)
-	t.Run("createkey", TestCreateKey)
-	t.Run("importkey", TestImportKey)
-	t.Run("generatekey", TestGenerateKey)
-	t.Run("encryptket", TestEncryptKey)
-	t.Run("decryptkey", TestDecryptKey)
-	t.Run("decryptkeyall", TestDecryptKeyAll)
-	t.Run("describepolicy", TestDescribePolicy)
-	t.Run("getpolicy", TestGetPolicy)
-	t.Run("selfdescribe", TestSelfDescribe)
+	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
+	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })
+	t.Run("CreateKey", func(t *testing.T) { testCreateKey(ctx, store, t) })
+	t.Run("ImportKey", func(t *testing.T) { testImportKey(ctx, store, t) })
+	t.Run("GenerateKey", func(t *testing.T) { testGenerateKey(ctx, store, t) })
+	t.Run("EncryptKey", func(t *testing.T) { testEncryptKey(ctx, store, t) })
+	t.Run("DecryptKey", func(t *testing.T) { testDecryptKey(ctx, store, t) })
+	t.Run("DecryptKeyAll", func(t *testing.T) { testDecryptKeyAll(ctx, store, t) })
+	t.Run("DescribePolicy", func(t *testing.T) { testDescribePolicy(ctx, store, t) })
+	t.Run("GetPolicy", func(t *testing.T) { testGetPolicy(ctx, store, t) })
+	t.Run("SelfDescribe", func(t *testing.T) { testSelfDescribe(ctx, store, t) })
 }

--- a/kestest/gateway_gcp_test.go
+++ b/kestest/gateway_gcp_test.go
@@ -26,20 +26,23 @@ func TestGatewayGCP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	store, err := srvrConfig.KeyStore.Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Run("metrics", TestMetrics)
-	t.Run("apis", TestAPIs)
-	t.Run("createkey", TestCreateKey)
-	t.Run("importkey", TestImportKey)
-	t.Run("generatekey", TestGenerateKey)
-	t.Run("encryptket", TestEncryptKey)
-	t.Run("decryptkey", TestDecryptKey)
-	t.Run("decryptkeyall", TestDecryptKeyAll)
-	t.Run("describepolicy", TestDescribePolicy)
-	t.Run("getpolicy", TestGetPolicy)
-	t.Run("selfdescribe", TestSelfDescribe)
+	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
+	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })
+	t.Run("CreateKey", func(t *testing.T) { testCreateKey(ctx, store, t) })
+	t.Run("ImportKey", func(t *testing.T) { testImportKey(ctx, store, t) })
+	t.Run("GenerateKey", func(t *testing.T) { testGenerateKey(ctx, store, t) })
+	t.Run("EncryptKey", func(t *testing.T) { testEncryptKey(ctx, store, t) })
+	t.Run("DecryptKey", func(t *testing.T) { testDecryptKey(ctx, store, t) })
+	t.Run("DecryptKeyAll", func(t *testing.T) { testDecryptKeyAll(ctx, store, t) })
+	t.Run("DescribePolicy", func(t *testing.T) { testDescribePolicy(ctx, store, t) })
+	t.Run("GetPolicy", func(t *testing.T) { testGetPolicy(ctx, store, t) })
+	t.Run("SelfDescribe", func(t *testing.T) { testSelfDescribe(ctx, store, t) })
 }

--- a/kestest/gateway_gemalto_test.go
+++ b/kestest/gateway_gemalto_test.go
@@ -25,20 +25,23 @@ func TestGatewayGemalto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err = srvrConfig.KeyStore.Connect(context.Background())
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	store, err := srvrConfig.KeyStore.Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Run("metrics", TestMetrics)
-	t.Run("apis", TestAPIs)
-	t.Run("createkey", TestCreateKey)
-	t.Run("importkey", TestImportKey)
-	t.Run("generatekey", TestGenerateKey)
-	t.Run("encryptket", TestEncryptKey)
-	t.Run("decryptkey", TestDecryptKey)
-	t.Run("decryptkeyall", TestDecryptKeyAll)
-	t.Run("describepolicy", TestDescribePolicy)
-	t.Run("getpolicy", TestGetPolicy)
-	t.Run("selfdescribe", TestSelfDescribe)
+	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
+	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })
+	t.Run("CreateKey", func(t *testing.T) { testCreateKey(ctx, store, t) })
+	t.Run("ImportKey", func(t *testing.T) { testImportKey(ctx, store, t) })
+	t.Run("GenerateKey", func(t *testing.T) { testGenerateKey(ctx, store, t) })
+	t.Run("EncryptKey", func(t *testing.T) { testEncryptKey(ctx, store, t) })
+	t.Run("DecryptKey", func(t *testing.T) { testDecryptKey(ctx, store, t) })
+	t.Run("DecryptKeyAll", func(t *testing.T) { testDecryptKeyAll(ctx, store, t) })
+	t.Run("DescribePolicy", func(t *testing.T) { testDescribePolicy(ctx, store, t) })
+	t.Run("GetPolicy", func(t *testing.T) { testGetPolicy(ctx, store, t) })
+	t.Run("SelfDescribe", func(t *testing.T) { testSelfDescribe(ctx, store, t) })
 }

--- a/kestest/gateway_mem_test.go
+++ b/kestest/gateway_mem_test.go
@@ -1,26 +1,17 @@
 package kestest_test
 
 import (
-	"flag"
 	"testing"
 
-	"github.com/minio/kes/internal/keystore/fs"
+	"github.com/minio/kes/internal/keystore/mem"
+	"github.com/minio/kes/kv"
 )
 
-var fsPath = flag.String("fs.path", "", "FS Path")
-
-func TestGatewayFS(t *testing.T) {
-	if *fsPath == "" {
-		t.Skip("FS tests disabled. Use -fs.path=<path> to enable them.")
-	}
-	var err error
-	store, err := fs.NewStore(*fsPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func TestGatewayMem(t *testing.T) {
 	ctx, cancel := testingContext(t)
 	defer cancel()
+
+	store := kv.Store[string, []byte](&mem.Store{})
 
 	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
 	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })

--- a/kestest/gateway_test.go
+++ b/kestest/gateway_test.go
@@ -18,12 +18,9 @@ import (
 	"time"
 
 	"github.com/minio/kes-go"
-	"github.com/minio/kes/internal/keystore/mem"
 	"github.com/minio/kes/kestest"
 	"github.com/minio/kes/kv"
 )
-
-var store = kv.Store[string, []byte](&mem.Store{})
 
 var gatewayAPIs = map[string]struct {
 	Method  string
@@ -58,13 +55,9 @@ var gatewayAPIs = map[string]struct {
 	"/v1/log/audit": {Method: http.MethodGet, MaxBody: 0, Timeout: 0},
 }
 
-func TestMetrics(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testMetrics(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
 
 	metric, err := client.Metrics(ctx)
@@ -88,13 +81,9 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func TestAPIs(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testAPIs(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
 
 	apis, err := client.APIs(ctx)
@@ -126,18 +115,23 @@ var createKeyTests = []struct {
 	ShouldFail bool
 	Err        error
 }{
-	{Name: "my-key"},
-	{Name: "my-key", ShouldFail: true, Err: kes.ErrKeyExists},
+	{ // 0
+		Name: "my-key",
+	},
+	{ // 1
+		Name:       "my-key",
+		ShouldFail: true,
+		Err:        kes.ErrKeyExists,
+	},
 }
 
-func TestCreateKey(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testCreateKey(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
+
+	defer clean(ctx, client, "my-key*", t)
+
 	for i, test := range createKeyTests {
 		err := client.CreateKey(ctx, test.Name)
 		if err == nil && test.ShouldFail {
@@ -158,21 +152,36 @@ var importKeyTests = []struct {
 	ShouldFail bool
 	Err        error
 }{
-	{Name: "my-key1", Key: make([]byte, 32)},
-	{Name: "my-key1", Key: make([]byte, 32), ShouldFail: true, Err: kes.ErrKeyExists},
+	{ // 0
+		Name: "my-key",
+		Key:  make([]byte, 32),
+	},
+	{ // 1
+		Name:       "my-key",
+		Key:        make([]byte, 32),
+		ShouldFail: true,
+		Err:        kes.ErrKeyExists,
+	},
 
-	{Name: "fail-key", Key: make([]byte, 0), ShouldFail: true},
-	{Name: "fail-key2", Key: make([]byte, 1<<20), ShouldFail: true},
+	{ // 2
+		Name:       "fail-key",
+		Key:        make([]byte, 0),
+		ShouldFail: true,
+	},
+	{ // 3
+		Name:       "fail-key2",
+		Key:        make([]byte, 1<<20),
+		ShouldFail: true,
+	},
 }
 
-func TestImportKey(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testImportKey(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
+
+	defer clean(ctx, client, "my-key*", t)
+
 	for i, test := range importKeyTests {
 		err := client.ImportKey(ctx, test.Name, test.Key)
 		if err == nil && test.ShouldFail {
@@ -197,16 +206,15 @@ var generateKeyTests = []struct {
 	{Context: make([]byte, 1<<20), ShouldFail: true},
 }
 
-func TestGenerateKey(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
+func testGenerateKey(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
+	const KeyName = "my-key"
 
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
 
-	const KeyName = "my-key2"
+	defer clean(ctx, client, "my-key*", t)
+
 	if err := client.CreateKey(ctx, KeyName); err != nil {
 		t.Fatalf("Failed to create %q: %v", KeyName, err)
 	}
@@ -248,16 +256,14 @@ var encryptKeyTests = []struct {
 	{Plaintext: make([]byte, 512*1024), Context: make([]byte, 512*1024), ShouldFail: true},
 }
 
-func TestEncryptKey(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testEncryptKey(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
+	const KeyName = "my-key"
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
 
-	const KeyName = "my-key3"
+	defer clean(ctx, client, "my-key*", t)
+
 	if err := client.CreateKey(ctx, KeyName); err != nil {
 		t.Fatalf("Failed to create %q: %v", KeyName, err)
 	}
@@ -308,16 +314,14 @@ var decryptKeyTests = []struct {
 	},
 }
 
-func TestDecryptKey(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testDecryptKey(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
+	const KeyName = "my-key"
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
 
-	const KeyName = "my-key4"
+	defer clean(ctx, client, "my-key*", t)
+
 	const KeyValue = "pQLPe6/f87AMSItvZzEbrxYdRUzmM81ziXF95HOFE4Y="
 	if err := client.ImportKey(ctx, KeyName, mustDecodeB64(KeyValue)); err != nil {
 		t.Fatalf("Failed to create %q: %v", KeyName, err)
@@ -383,16 +387,14 @@ var decryptAllKeyTests = []struct {
 	},
 }
 
-func TestDecryptKeyAll(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testDecryptKeyAll(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
+	const KeyName = "my-key"
 	server := kestest.NewGateway(store)
 	defer server.Close()
-
 	client := server.Client()
 
-	const KeyName = "my-key5"
+	defer clean(ctx, client, "my-key*", t)
+
 	const KeyValue = "pQLPe6/f87AMSItvZzEbrxYdRUzmM81ziXF95HOFE4Y="
 	if err := client.ImportKey(ctx, KeyName, mustDecodeB64(KeyValue)); err != nil {
 		t.Fatalf("Failed to create %q: %v", KeyName, err)
@@ -443,10 +445,7 @@ var getPolicyTests = []struct {
 	},
 }
 
-func TestDescribePolicy(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testDescribePolicy(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	for i, test := range getPolicyTests {
 		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
 			server := kestest.NewGateway(store)
@@ -472,10 +471,7 @@ func TestDescribePolicy(t *testing.T) {
 	}
 }
 
-func TestGetPolicy(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testGetPolicy(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	for i, test := range getPolicyTests {
 		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
 			server := kestest.NewGateway(store)
@@ -549,10 +545,7 @@ var selfDescribeTests = []struct {
 	},
 }
 
-func TestSelfDescribe(t *testing.T) {
-	ctx, cancel := testingContext(t)
-	defer cancel()
-
+func testSelfDescribe(ctx context.Context, store kv.Store[string, []byte], t *testing.T) {
 	server := kestest.NewGateway(store)
 	defer server.Close()
 
@@ -632,4 +625,29 @@ func mustDecodeB64(s string) []byte {
 		panic(err)
 	}
 	return b
+}
+
+func clean(ctx context.Context, client *kes.Client, pattern string, t *testing.T) {
+	iter, err := client.ListKeys(ctx, pattern)
+	if err != nil {
+		t.Fatalf("Cleanup: failed to list keys: %v", err)
+	}
+	defer iter.Close()
+
+	names := []string{}
+	keysInfo, err := iter.Values(-1)
+	if err != nil {
+		t.Fatalf("Cleanup: failed to iterate keys")
+	}
+	for _, keyInfo := range keysInfo {
+		names = append(names, keyInfo.Name)
+	}
+	for _, name := range names {
+		if err = client.DeleteKey(ctx, name); err != nil {
+			t.Errorf("Cleanup: failed to delete '%s': %v", name, err)
+		}
+	}
+	if err = iter.Close(); err != nil {
+		t.Errorf("Cleanup: failed to close iter: %v", err)
+	}
 }

--- a/kestest/gateway_vault_test.go
+++ b/kestest/gateway_vault_test.go
@@ -24,20 +24,24 @@ func TestGatewayVault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store, err = srvrConfig.KeyStore.Connect(context.Background())
+
+	ctx, cancel := testingContext(t)
+	defer cancel()
+
+	store, err := srvrConfig.KeyStore.Connect(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Run("metrics", TestMetrics)
-	t.Run("apis", TestAPIs)
-	t.Run("createkey", TestCreateKey)
-	t.Run("importkey", TestImportKey)
-	t.Run("generatekey", TestGenerateKey)
-	t.Run("encryptket", TestEncryptKey)
-	t.Run("decryptkey", TestDecryptKey)
-	t.Run("decryptkeyall", TestDecryptKeyAll)
-	t.Run("describepolicy", TestDescribePolicy)
-	t.Run("getpolicy", TestGetPolicy)
-	t.Run("selfdescribe", TestSelfDescribe)
+	t.Run("Metrics", func(t *testing.T) { testMetrics(ctx, store, t) })
+	t.Run("APIs", func(t *testing.T) { testAPIs(ctx, store, t) })
+	t.Run("CreateKey", func(t *testing.T) { testCreateKey(ctx, store, t) })
+	t.Run("ImportKey", func(t *testing.T) { testImportKey(ctx, store, t) })
+	t.Run("GenerateKey", func(t *testing.T) { testGenerateKey(ctx, store, t) })
+	t.Run("EncryptKey", func(t *testing.T) { testEncryptKey(ctx, store, t) })
+	t.Run("DecryptKey", func(t *testing.T) { testDecryptKey(ctx, store, t) })
+	t.Run("DecryptKeyAll", func(t *testing.T) { testDecryptKeyAll(ctx, store, t) })
+	t.Run("DescribePolicy", func(t *testing.T) { testDescribePolicy(ctx, store, t) })
+	t.Run("GetPolicy", func(t *testing.T) { testGetPolicy(ctx, store, t) })
+	t.Run("SelfDescribe", func(t *testing.T) { testSelfDescribe(ctx, store, t) })
 }


### PR DESCRIPTION
This PR adds a cleanup method to make sure each test works in its entirety and there are no left outs.
Also all tests use the same common functions for scenarios like `create`, `import`, `generate`, `encrypt` and `decrypt` etc.

Different kind of tests can be executed using `go test -v -run="<test>"` command.
e.g. `go test -v -run="TestGatewayMem"` or `go test -v -fs.path=./keys -run="TestGatewayFS"`