### PR TITLE
edge: use random secret key names and delete at end of each test

### DIFF
--- a/edge/aws_test.go
+++ b/edge/aws_test.go
@@ -41,8 +41,8 @@ func TestAWS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/azure_test.go
+++ b/edge/azure_test.go
@@ -40,8 +40,8 @@ func TestAzure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/edge_test.go
+++ b/edge/edge_test.go
@@ -186,9 +186,6 @@ func clean(ctx context.Context, store kv.Store[string, []byte], t *testing.T, se
 			}
 		}
 	}
-	if err = iter.Close(); err != nil {
-		t.Errorf("Cleanup: failed to close iter: %v", err)
-	}
 }
 
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/edge/fortanix_test.go
+++ b/edge/fortanix_test.go
@@ -41,8 +41,8 @@ func TestFortanix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/fs_test.go
+++ b/edge/fs_test.go
@@ -29,8 +29,8 @@ func TestFS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/gcp_test.go
+++ b/edge/gcp_test.go
@@ -41,8 +41,8 @@ func TestGCP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/gemalto_test.go
+++ b/edge/gemalto_test.go
@@ -41,8 +41,8 @@ func TestGemalto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/mem_test.go
+++ b/edge/mem_test.go
@@ -15,8 +15,9 @@ func TestInMem(t *testing.T) {
 	defer cancel()
 
 	store := &mem.Store{}
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }

--- a/edge/vault_test.go
+++ b/edge/vault_test.go
@@ -29,7 +29,7 @@ func TestVault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, ok := config.KeyStore.(*edge.KeySecureKeyStore); !ok {
+	if _, ok := config.KeyStore.(*edge.VaultKeyStore); !ok {
 		t.Fatalf("Invalid Keystore: want %T - got %T", config.KeyStore, &edge.VaultKeyStore{})
 	}
 
@@ -41,8 +41,8 @@ func TestVault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t) })
-	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t) })
-	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t) })
+	t.Run("Create", func(t *testing.T) { testCreate(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Set", func(t *testing.T) { testSet(ctx, store, t, RandString(ranStringLength)) })
+	t.Run("Get", func(t *testing.T) { testGet(ctx, store, t, RandString(ranStringLength)) })
 	t.Run("Status", func(t *testing.T) { testStatus(ctx, store, t) })
 }


### PR DESCRIPTION
Use random secret key names in tests in the form `prefix-seed-counter`. This way keys become randomized yet predictable tests.
Also fixed an issue with vault test where type of store config was wrong.