### PR TITLE
fix obsolete vault kubernetes jwt file read

### DIFF
--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -115,13 +115,6 @@ func Connect(ctx context.Context, c *Config) (*Store, error) {
 	case c.AppRole.ID != "" || c.AppRole.Secret != "":
 		authenticate, retry = client.AuthenticateWithAppRole(c.AppRole), c.AppRole.Retry
 	case c.K8S.Role != "" || c.K8S.JWT != "":
-		jwt, err := os.ReadFile(c.K8S.JWT) // The JWT may be a file path containing the actaul token
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
-		if err == nil {
-			c.K8S.JWT = string(jwt)
-		}
 		authenticate, retry = client.AuthenticateWithK8S(c.K8S), c.K8S.Retry
 	}
 


### PR DESCRIPTION
The Vault Kubernetes JWT token is already checked and read [here](https://github.com/minio/kes/blob/master/edge/server-config-yml.go#L429). Doing it again in `vault.go` results in an error, because the JWT token is used as file path.