### PR TITLE
ci: update to Go 1.20.6

### DIFF
--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.5
+        go-version: 1.20.6
         check-latest: true
       id: go
     - name: Check out code
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.5
+        go-version: 1.20.6
         check-latest: true
       id: go
     - name: Check out code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.5
+        go-version: 1.20.6
         check-latest: true
       id: go
     - name: Check out code
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.20.6
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.5
+        go-version: 1.20.6
         check-latest: true
       id: go
     - name: Check out code
@@ -74,7 +74,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.20.5
+        go-version: 1.20.6
         check-latest: true
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.5
+          go-version: 1.20.6
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
This commit updates the CI and release config to Go 1.20.6