### PR TITLE
fix: set GOPROXY for self hosted runner

### DIFF
--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Test
       env:
         GO111MODULE: on
+        GOPROXY: "https://proxy.golang.org,direct"
+        GOPATH: ${{ github.workspace }}
       run: |
          go test ./edge -v -aws.config=/etc/kes/config-aws.yml -run="TestAWS"
   azure-edge-test:
@@ -38,5 +40,7 @@ jobs:
     - name: Test
       env:
         GO111MODULE: on
+        GOPROXY: "https://proxy.golang.org,direct"
+        GOPATH: ${{ github.workspace }}
       run: |
          go test ./edge -v -azure.config=/etc/kes/config-azure.yml -run="TestAzure"


### PR DESCRIPTION
This fixes the workflow failures while edge test