### PR TITLE
close keystore when reloading config

### DIFF
--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.0
+        go-version: 1.21.1
         check-latest: true
       id: go
     - name: Check out code
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.0
+        go-version: 1.21.1
         check-latest: true
       id: go
     - name: Check out code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.0
+        go-version: 1.21.1
         check-latest: true
       id: go
     - name: Check out code
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.0
+          go-version: 1.21.1
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.0
+        go-version: 1.21.1
         check-latest: true
       id: go
     - name: Check out code
@@ -74,7 +74,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.21.0
+        go-version: 1.21.1
         check-latest: true
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.0
+          go-version: 1.21.1
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/cmd/kes/gateway.go
+++ b/cmd/kes/gateway.go
@@ -119,6 +119,7 @@ func startGateway(cliConfig gatewayConfig) {
 					Addr:      config.Addr,
 					Handler:   api.NewEdgeRouter(gwConfig),
 					TLSConfig: tlsConfig,
+					Cancel:    func() { gwConfig.Keys.Close() },
 				})
 				if err != nil {
 					log.Printf("failed to update server configuration: %v", err)

--- a/internal/keystore/aws/secrets-manager.go
+++ b/internal/keystore/aws/secrets-manager.go
@@ -247,6 +247,9 @@ func (s *Store) List(ctx context.Context) (kv.Iter[string], error) {
 	}, nil
 }
 
+// Close closes the Store.
+func (s *Store) Close() error { return nil }
+
 type iter struct {
 	ch  <-chan string
 	ctx context.Context

--- a/internal/keystore/azure/key-vault.go
+++ b/internal/keystore/azure/key-vault.go
@@ -339,6 +339,9 @@ func (s *Store) List(ctx context.Context) (kv.Iter[string], error) {
 	}, nil
 }
 
+// Close closes the Store.
+func (s *Store) Close() error { return nil }
+
 // ConnectWithCredentials tries to establish a connection to a Azure KeyVault
 // instance using Azure client credentials.
 func ConnectWithCredentials(_ context.Context, endpoint string, creds Credentials) (*Store, error) {

--- a/internal/keystore/cache.go
+++ b/internal/keystore/cache.go
@@ -231,6 +231,13 @@ func (c *Cache) Get(ctx context.Context, name string) (key.Key, error) {
 	return k, nil
 }
 
+// Close stops the Cache's GCs, if started, and closes the
+// underlying keystore.
+func (c *Cache) Close() error {
+	c.Stop()
+	return c.store.Close()
+}
+
 // gc executes f periodically until the ctx.Done() channel returns.
 func (c *Cache) gc(ctx context.Context, interval time.Duration, f func()) {
 	if interval <= 0 {

--- a/internal/keystore/fortanix/keystore.go
+++ b/internal/keystore/fortanix/keystore.go
@@ -466,6 +466,9 @@ func (s *Store) List(ctx context.Context) (kv.Iter[string], error) {
 	}, nil
 }
 
+// Close closes the Store.
+func (s *Store) Close() error { return nil }
+
 type iterator struct {
 	ch     <-chan string
 	ctx    context.Context

--- a/internal/keystore/fs/fs.go
+++ b/internal/keystore/fs/fs.go
@@ -160,6 +160,9 @@ func (s *Store) List(ctx context.Context) (kv.Iter[string], error) {
 	return NewIter(ctx, dir), nil
 }
 
+// Close closes the Store.
+func (s *Store) Close() error { return nil }
+
 func (s *Store) create(filename string, value []byte) error {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {

--- a/internal/keystore/gcp/secret-manager.go
+++ b/internal/keystore/gcp/secret-manager.go
@@ -224,3 +224,6 @@ func (s *Store) List(ctx context.Context) (kv.Iter[string], error) {
 		}),
 	}, nil
 }
+
+// Close closes the Store.
+func (s *Store) Close() error { return nil }

--- a/internal/keystore/kes/kes.go
+++ b/internal/keystore/kes/kes.go
@@ -162,6 +162,9 @@ func (s *Store) List(ctx context.Context) (kv.Iter[string], error) {
 	return &iter{i}, nil
 }
 
+// Close closes the Store.
+func (s *Store) Close() error { return nil }
+
 type iter struct {
 	*kes.SecretIter
 }

--- a/internal/keystore/mem/mem.go
+++ b/internal/keystore/mem/mem.go
@@ -88,6 +88,9 @@ func (s *Store) List(context.Context) (kv.Iter[string], error) {
 	}, nil
 }
 
+// Close closes the Store.
+func (s *Store) Close() error { return nil }
+
 type iterator struct {
 	values []string
 }

--- a/kv/store.go
+++ b/kv/store.go
@@ -9,6 +9,7 @@ package kv
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 )
 
@@ -75,6 +76,8 @@ type Store[K comparable, V any] interface {
 	// List returns an Iter enumerating the stored
 	// entries.
 	List(context.Context) (Iter[K], error)
+
+	io.Closer
 }
 
 // State describes the state of a Store.


### PR DESCRIPTION
This commit ensures that the cache and keystore
get closed and any background token renewal processes are stopped when the server updates its config.

This fixes a resource leak for keystores that perform background tasks, like Vault, Gemalto, and Entrust.