### PR TITLE
vault: add support for transit-encrypted K/V

### DIFF
--- a/edge/server-config-yml.go
+++ b/edge/server-config-yml.go
@@ -89,6 +89,11 @@ type yml struct {
 			Namespace  env[string] `yaml:"namespace"`
 			Prefix     env[string] `yaml:"prefix"`
 
+			Transit *struct {
+				Engine  env[string] `yaml:"engine"`
+				KeyName env[string] `yaml:"key"`
+			}
+
 			AppRole *struct {
 				Engine env[string] `yaml:"engine"`
 				ID     env[string] `yaml:"id"`
@@ -448,6 +453,12 @@ func ymlToKeyStore(y *yml) (KeyStore, error) {
 				y.KeyStore.Vault.Kubernetes.JWT.Value = string(b)
 			}
 		}
+		if y.KeyStore.Vault.Transit != nil {
+			if y.KeyStore.Vault.Transit.KeyName.Value == "" {
+				return nil, errors.New("edge: invalid vault keystore: invalid transit config: no key name specified")
+			}
+		}
+
 		if y.KeyStore.Vault.TLS.PrivateKey.Value != "" && y.KeyStore.Vault.TLS.Certificate.Value == "" {
 			return nil, errors.New("edge: invalid vault keystore: invalid tls config: no TLS certificate provided")
 		}
@@ -477,6 +488,12 @@ func ymlToKeyStore(y *yml) (KeyStore, error) {
 				Engine: y.KeyStore.Vault.Kubernetes.Engine.Value,
 				JWT:    y.KeyStore.Vault.Kubernetes.JWT.Value,
 				Role:   y.KeyStore.Vault.Kubernetes.Role.Value,
+			}
+		}
+		if y.KeyStore.Vault.Transit != nil {
+			s.Transit = &VaultTransit{
+				Engine:  y.KeyStore.Vault.Transit.Engine.Value,
+				KeyName: y.KeyStore.Vault.Transit.KeyName.Value,
 			}
 		}
 		keystore = s

--- a/internal/keystore/vault/client.go
+++ b/internal/keystore/vault/client.go
@@ -69,7 +69,7 @@ func (c *client) CheckStatus(ctx context.Context, delay time.Duration) {
 // from the vault server by using the login AppRole credentials.
 //
 // To renew the auth. token see: client.RenewToken(...).
-func (c *client) AuthenticateWithAppRole(login AppRole) authFunc {
+func (c *client) AuthenticateWithAppRole(login *AppRole) authFunc {
 	return func() (token string, ttl time.Duration, err error) {
 		secret, err := c.Logical().Write(path.Join("auth", login.Engine, "login"), map[string]interface{}{
 			"role_id":   login.ID,
@@ -99,7 +99,7 @@ func (c *client) AuthenticateWithAppRole(login AppRole) authFunc {
 	}
 }
 
-func (c *client) AuthenticateWithK8S(login Kubernetes) authFunc {
+func (c *client) AuthenticateWithK8S(login *Kubernetes) authFunc {
 	return func() (token string, ttl time.Duration, err error) {
 		secret, err := c.Logical().Write(path.Join("auth", login.Engine, "login"), map[string]interface{}{
 			"role": login.Role,

--- a/internal/keystore/vault/config_test.go
+++ b/internal/keystore/vault/config_test.go
@@ -5,13 +5,14 @@
 package vault
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
 
 func TestCloneConfig(t *testing.T) {
 	for i, a := range cloneConfigTests {
-		if b := a.Clone(); *a != *b {
+		if b := a.Clone(); !reflect.DeepEqual(a, b) {
 			t.Fatalf("Test %d: cloned config does not match original", i)
 		}
 	}
@@ -34,6 +35,10 @@ var cloneConfigTests = []*Config{
 			Engine: "auth",
 			Role:   "kes",
 			JWT:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+		},
+		Transit: &Transit{
+			Engine:  "transit",
+			KeyName: "my-key",
 		},
 		StatusPingAfter: 15 * time.Second,
 		PrivateKey:      "/tmp/kes/vault.key",

--- a/internal/keystore/vault/config_test.go
+++ b/internal/keystore/vault/config_test.go
@@ -24,13 +24,13 @@ var cloneConfigTests = []*Config{
 		APIVersion: APIv2,
 		Namespace:  "ns-1",
 		Prefix:     "my-prefix",
-		AppRole: AppRole{
+		AppRole: &AppRole{
 			Engine: "auth",
 			ID:     "be7f3c83-9733-4d65-adaa-7eeb6e14e922",
 			Secret: "ba8d68af-23c4-4199-a516-e37cebdaab48",
 			Retry:  30 * time.Second,
 		},
-		K8S: Kubernetes{
+		K8S: &Kubernetes{
 			Engine: "auth",
 			Role:   "kes",
 			JWT:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",

--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -83,7 +83,7 @@ func Connect(ctx context.Context, c *Config) (*Store, error) {
 			return nil, errors.New("vault: no authentication method specified")
 		}
 		if (c.AppRole.ID != "" || c.AppRole.Secret != "") && (c.K8S.JWT != "" || c.K8S.Role != "") {
-			return nil, errors.New("vault: ambigious authentication: approle and kubernetes method specified")
+			return nil, errors.New("vault: more than one authentication method specified: approle and kubernetes configuration is present")
 		}
 	}
 	if c.Transit != nil {

--- a/server-config.yaml
+++ b/server-config.yaml
@@ -260,6 +260,9 @@ keystore:
     version: ""   # The K/V engine version - either "v1" or "v2". The "v1" engine is recommended.
     namespace: "" # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
     prefix: ""    # An optional K/V prefix. The server will store keys under this prefix.
+    transit:      # Optionally encrypt keys stored on the K/V engine with a Vault-managed key.
+      engine: ""  # The path of the transit engine - e.g. "my-transit". If empty, defaults to: transit (Vault default)
+      key: ""     # The key name that should be used to encrypt entries stored on the K/V engine.
     approle:    # AppRole credentials. See: https://www.vaultproject.io/docs/auth/approle.html
       engine: ""  # The path of the AppRole engine - e.g. authenticate. If empty, defaults to: approle. (Vault default)
       id: ""      # Your AppRole Role ID


### PR DESCRIPTION
This commit adds support for encrypting K/V entries with a specific transit engine key.

**Transit Engine**

The transit engine is Hashicorp Vault's en/decryption engine. Among others, it allows to send a plaintext to an encrypt API endpoint and receive a ciphertext and vice versa.
Ref: https://developer.hashicorp.com/vault/api-docs/secret/transit

Now, users can specify a transit key name in the KES config file. KES will use this key to en/decrypt its key values before storing them on the K/V backend.
However, this does, in general, not improve security since Vault encrypts all data stored on the K/V engine with internally managed keys. Users may specify a transit key if the want/have to control which key is used to encrypt the K/V data.