### PR TITLE
honor offline caching in `/v1/status` API

### DIFF
--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -26,7 +26,6 @@ type StatusResponse struct {
 	StackAlloc uint64 `json:"mem_stack_used"`
 
 	KeyStoreLatency     int64 `json:"keystore_latency,omitempty"` // In microseconds
-	KeyStoreUnavailable bool  `json:"keystore_unavailable,omitempty"`
 	KeyStoreUnreachable bool  `json:"keystore_unreachable,omitempty"`
 }
 

--- a/keystore.go
+++ b/keystore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cache"
 	"github.com/minio/kes/internal/key"
+	"github.com/minio/kes/kv"
 )
 
 // A KeyStore stores key-value pairs. It provides durable storage for a
@@ -238,7 +239,13 @@ type cacheEntry struct {
 }
 
 // Status returns the current state of the underlying KeyStore.
+//
+// It immediately returns an error if the backend keystore is not
+// reachable and offline caching is enabled.
 func (c *keyCache) Status(ctx context.Context) (KeyStoreState, error) {
+	if c.offline.Load() {
+		return KeyStoreState{}, &kv.Unreachable{Err: errors.New("keystore is offline")}
+	}
 	return c.store.Status(ctx)
 }
 


### PR DESCRIPTION
Now, the `/v1/status` API will not try fetch the backend keystore status if:
 - offline caching is enabled.
 - the keystore is considered offline.

The idea here is that if the cache considered the backend keystore as offline then it is unlikely that a `Status` suceeds. Instead, we can directly return unreachable.

Once, the keystore becomes available again, the cache will detect it eventually (on its next health check cycle).

Among other things, this improves pod availability when `/v1/status` is used as (part of) readiness probes. (i.e. MinIO) Such probes are now less likely to time out since `/v1/status` returns immediately.
However, if the backend keystore becomes unavailable and a `/v1/status` request arrives BEFORE the cache detects that the keystore is offline then these requests may time out. Hence, it is recommended to use readiness probes with a retry threshold > 1.