### PR TITLE
read config file before looking up net interfaces

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -139,6 +139,18 @@ func startServer(addrFlag, configFlag string) error {
 		return err
 	}
 
+	// Read the config file before looking up the
+	// local network interfaces. We may not know the
+	// server addr yet since a user may not specified
+	// one on the command line.
+	rawConfig, err := kesconf.ReadFile(configFlag)
+	if err != nil {
+		return err
+	}
+	if addrFlag == "" {
+		addrFlag = rawConfig.Addr
+	}
+
 	host, port, err := net.SplitHostPort(addrFlag)
 	if err != nil {
 		return err
@@ -157,13 +169,6 @@ func startServer(addrFlag, configFlag string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	rawConfig, err := kesconf.ReadFile(configFlag)
-	if err != nil {
-		return err
-	}
-	if addrFlag == "" {
-		addrFlag = rawConfig.Addr
-	}
 	conf, err := rawConfig.Config(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit fixes a bug in the KES server command. The server must read its config file before looking up the net addrs it listens on because the addr may not come from the command line but from the config file.