### PR TITLE
Parse address from config if not provided with '--addr'

### DIFF
--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -139,6 +139,13 @@ func startServer(addrFlag, configFlag string) error {
 		return err
 	}
 
+	rawConfig, err := kesconf.ReadFile(configFlag)
+	if err != nil {
+		return err
+	}
+	if addrFlag == "" {
+		addrFlag = rawConfig.Addr
+	}
 	host, port, err := net.SplitHostPort(addrFlag)
 	if err != nil {
 		return err
@@ -157,13 +164,6 @@ func startServer(addrFlag, configFlag string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	rawConfig, err := kesconf.ReadFile(configFlag)
-	if err != nil {
-		return err
-	}
-	if addrFlag == "" {
-		addrFlag = rawConfig.Addr
-	}
 	conf, err := rawConfig.Config(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes a bug where kes would try to split and evaluate the listen address, before the config file was read. This caused kes to fail if no `--addr` value was provided.

With this change, the config file is parsed before we try to determine the listen address. If the `--addr` parameter is provided, we override the value from the config as expected.

This fixes #418 .