### PR TITLE
vault: implement authentication token renewal

### DIFF
--- a/internal/keystore/vault/config.go
+++ b/internal/keystore/vault/config.go
@@ -54,11 +54,6 @@ type AppRole struct {
 
 	// Secret is the AppRole authentication secret.
 	Secret string
-
-	// Retry is the duration after which another
-	// authentication attempt is performed once
-	// an authentication attempt failed.
-	Retry time.Duration
 }
 
 // Clone returns a copy of the AppRole auth.
@@ -70,7 +65,6 @@ func (a *AppRole) Clone() *AppRole {
 		Engine: a.Engine,
 		ID:     a.ID,
 		Secret: a.Secret,
-		Retry:  a.Retry,
 	}
 }
 
@@ -92,11 +86,6 @@ type Kubernetes struct {
 
 	// JWT is the issued authentication token.
 	JWT string
-
-	// Retry is the duration after which another
-	// authentication attempt is performed once
-	// an authentication attempt failed.
-	Retry time.Duration
 }
 
 // Clone returns a copy of the Kubernetes auth.
@@ -108,7 +97,6 @@ func (k *Kubernetes) Clone() *Kubernetes {
 		Engine: k.Engine,
 		Role:   k.Role,
 		JWT:    k.JWT,
-		Retry:  k.Retry,
 	}
 }
 

--- a/internal/keystore/vault/config_test.go
+++ b/internal/keystore/vault/config_test.go
@@ -29,7 +29,6 @@ var cloneConfigTests = []*Config{
 			Engine: "auth",
 			ID:     "be7f3c83-9733-4d65-adaa-7eeb6e14e922",
 			Secret: "ba8d68af-23c4-4199-a516-e37cebdaab48",
-			Retry:  30 * time.Second,
 		},
 		K8S: &Kubernetes{
 			Engine: "auth",


### PR DESCRIPTION
This commit re-implements token renewal after it
got removed by 13cee22.

Now, the token renewal process works as following:
 - If the token is about to expire (max. 10s before expiry) we try to renew the token if renewable.
 - If the renewal fails, or the token is not renewable, KES tries to re-authenticate with the configured auth method.
 - If re-authenticating also fails, we retry after 3s.