### PR TITLE
add HMAC API test

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -11,8 +11,8 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/api"
+	"github.com/minio/kms-go/kes"
 )
 
 // AuditRecord describes an audit event logged by a KES server.

--- a/auth.go
+++ b/auth.go
@@ -13,8 +13,8 @@ import (
 	"net/http"
 	"sync/atomic"
 
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/api"
+	"github.com/minio/kms-go/kes"
 )
 
 // verifyIdentity authenticates client requests by verifying that

--- a/cmd/kes/log.go
+++ b/cmd/kes/log.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	tui "github.com/charmbracelet/lipgloss"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cli"
+	"github.com/minio/kms-go/kes"
 
 	flag "github.com/spf13/pflag"
 )

--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	tui "github.com/charmbracelet/lipgloss"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cli"
 	"github.com/minio/kes/internal/https"
 	"github.com/minio/kes/internal/sys"
+	"github.com/minio/kms-go/kes"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/term"
 )
@@ -225,14 +225,6 @@ func newClient(insecureSkipVerify bool) *kes.Client {
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: insecureSkipVerify,
 	})
-}
-
-func newEnclave(name string, insecureSkipVerify bool) *kes.Enclave {
-	client := newClient(insecureSkipVerify)
-	if name == "" {
-		name = os.Getenv("KES_ENCLAVE")
-	}
-	return client.Enclave(name)
 }
 
 func isTerm(f *os.File) bool { return term.IsTerminal(int(f.Fd())) }

--- a/cmd/kes/metric.go
+++ b/cmd/kes/metric.go
@@ -17,8 +17,8 @@ import (
 
 	"aead.dev/mem"
 	tui "github.com/charmbracelet/lipgloss"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cli"
+	"github.com/minio/kms-go/kes"
 	flag "github.com/spf13/pflag"
 )
 

--- a/cmd/kes/migrate.go
+++ b/cmd/kes/migrate.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cli"
 	"github.com/minio/kes/kesconf"
+	"github.com/minio/kms-go/kes"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/term"
 )

--- a/cmd/kes/server.go
+++ b/cmd/kes/server.go
@@ -29,10 +29,10 @@ import (
 
 	tui "github.com/charmbracelet/lipgloss"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cli"
 	"github.com/minio/kes/internal/sys"
 	"github.com/minio/kes/kesconf"
+	kesdk "github.com/minio/kms-go/kes"
 	flag "github.com/spf13/pflag"
 )
 

--- a/cmd/kes/status.go
+++ b/cmd/kes/status.go
@@ -18,8 +18,8 @@ import (
 
 	"aead.dev/mem"
 	tui "github.com/charmbracelet/lipgloss"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cli"
+	"github.com/minio/kms-go/kes"
 	flag "github.com/spf13/pflag"
 )
 

--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/minio/kes-go"
+	"github.com/minio/kms-go/kes"
 )
 
 // Config is a structure that holds configuration for a KES server.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/fatih/color v1.16.0
 	github.com/hashicorp/vault/api v1.10.0
-	github.com/minio/kes-go v0.2.1
+	github.com/minio/kms-go/kes v0.3.0
 	github.com/minio/selfupdate v0.6.0
 	github.com/muesli/termenv v0.15.2
 	github.com/prometheus/client_golang v1.18.0
@@ -24,6 +24,7 @@ require (
 	golang.org/x/term v0.16.0
 	google.golang.org/api v0.155.0
 	google.golang.org/grpc v1.60.1
+	google.golang.org/protobuf v1.32.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -92,5 +93,4 @@ require (
 	google.golang.org/genproto v0.0.0-20240108191215-35c7eff3a6b1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240108191215-35c7eff3a6b1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240108191215-35c7eff3a6b1 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZ
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/minio/kes-go v0.2.1 h1:KnqS+p6xoSFJZbQhmJaz/PbxeA6nQyRqT/ywrn5lU2o=
-github.com/minio/kes-go v0.2.1/go.mod h1:76xf7l41Wrh+IifisABXK2S8uZWYgWV1IGBKC3GdOJk=
+github.com/minio/kms-go/kes v0.3.0 h1:SU8VGVM/Hk9w1OiSby3OatkcojooUqIdDHl6dtM6NkY=
+github.com/minio/kms-go/kes v0.3.0/go.mod h1:w6DeVT878qEOU3nUrYVy1WOT5H1Ig9hbDIh698NYJKY=
 github.com/minio/selfupdate v0.6.0 h1:i76PgT0K5xO9+hjzKcacQtO7+MjJ4JKA8Ak8XQ9DDwU=
 github.com/minio/selfupdate v0.6.0/go.mod h1:bO02GTIPCMQFTEvE5h4DjYB58bCoZ35XLeBf0buTDdM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"aead.dev/mem"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/headers"
+	"github.com/minio/kms-go/kes"
 )
 
 // API paths exposed by KES servers.

--- a/internal/crypto/ciphertext.go
+++ b/internal/crypto/ciphertext.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"slices"
 
-	"github.com/minio/kes-go"
+	"github.com/minio/kms-go/kes"
 	"github.com/tinylib/msgp/msgp"
 )
 

--- a/internal/crypto/key.go
+++ b/internal/crypto/key.go
@@ -20,9 +20,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/fips"
 	pb "github.com/minio/kes/internal/protobuf"
+	"github.com/minio/kms-go/kes"
 	"golang.org/x/crypto/chacha20"
 	"golang.org/x/crypto/chacha20poly1305"
 )

--- a/internal/https/proxy.go
+++ b/internal/https/proxy.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/minio/kes-go"
+	"github.com/minio/kms-go/kes"
 )
 
 // A TLSProxy handles HTTP requests sent by a client through

--- a/internal/https/proxy_test.go
+++ b/internal/https/proxy_test.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/minio/kes-go"
+	"github.com/minio/kms-go/kes"
 )
 
 var tlsProxyAddTests = []struct {

--- a/internal/keystore/aws/secrets-manager.go
+++ b/internal/keystore/aws/secrets-manager.go
@@ -17,8 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // Credentials represents static AWS credentials:

--- a/internal/keystore/azure/key-vault.go
+++ b/internal/keystore/azure/key-vault.go
@@ -15,8 +15,8 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // Credentials are Azure client credentials to authenticate an application

--- a/internal/keystore/entrust/keycontrol.go
+++ b/internal/keystore/entrust/keycontrol.go
@@ -22,9 +22,9 @@ import (
 
 	"aead.dev/mem"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	xhttp "github.com/minio/kes/internal/http"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // Config is a structure containing the Entrust KeyControl configuration.

--- a/internal/keystore/fortanix/keystore.go
+++ b/internal/keystore/fortanix/keystore.go
@@ -24,9 +24,9 @@ import (
 
 	"aead.dev/mem"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	xhttp "github.com/minio/kes/internal/http"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // APIKey is a Fortanix API key for authenticating to

--- a/internal/keystore/fs/fs.go
+++ b/internal/keystore/fs/fs.go
@@ -19,8 +19,8 @@ import (
 
 	"aead.dev/mem"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // NewStore returns a new Store that reads

--- a/internal/keystore/gcp/secret-manager.go
+++ b/internal/keystore/gcp/secret-manager.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 	gcpiterator "google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"

--- a/internal/keystore/gemalto/key-secure.go
+++ b/internal/keystore/gemalto/key-secure.go
@@ -24,9 +24,9 @@ import (
 
 	"aead.dev/mem"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	xhttp "github.com/minio/kes/internal/http"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // Credentials represents a Gemalto KeySecure

--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -26,8 +26,8 @@ import (
 	"aead.dev/mem"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/keystore"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 // Store is a Hashicorp Vault secret store.

--- a/kesconf/config.go
+++ b/kesconf/config.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/minio/kes-go"
+	"github.com/minio/kms-go/kes"
 	"gopkg.in/yaml.v3"
 )
 

--- a/kesconf/edge_test.go
+++ b/kesconf/edge_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
+	kesdk "github.com/minio/kms-go/kes"
 )
 
 type SetupFunc func(context.Context, kes.KeyStore, string) error

--- a/kesconf/file.go
+++ b/kesconf/file.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/minio/kes"
-	kesdk "github.com/minio/kes-go"
 	"github.com/minio/kes/internal/https"
 	"github.com/minio/kes/internal/keystore/aws"
 	"github.com/minio/kes/internal/keystore/azure"
@@ -27,6 +26,7 @@ import (
 	"github.com/minio/kes/internal/keystore/gcp"
 	"github.com/minio/kes/internal/keystore/gemalto"
 	"github.com/minio/kes/internal/keystore/vault"
+	kesdk "github.com/minio/kms-go/kes"
 	yaml "gopkg.in/yaml.v3"
 )
 

--- a/keystore.go
+++ b/keystore.go
@@ -13,10 +13,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/cache"
 	"github.com/minio/kes/internal/crypto"
 	"github.com/minio/kes/internal/keystore"
+	"github.com/minio/kms-go/kes"
 )
 
 // A KeyStore stores key-value pairs. It provides durable storage for a

--- a/server.go
+++ b/server.go
@@ -22,7 +22,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/api"
 	"github.com/minio/kes/internal/cpu"
 	"github.com/minio/kes/internal/crypto"
@@ -32,6 +31,7 @@ import (
 	"github.com/minio/kes/internal/keystore"
 	"github.com/minio/kes/internal/metric"
 	"github.com/minio/kes/internal/sys"
+	"github.com/minio/kms-go/kes"
 	"github.com/prometheus/common/expfmt"
 )
 
@@ -924,8 +924,8 @@ func (s *Server) hmacKey(resp *api.Response, req *api.Request) {
 		return
 	}
 
-	api.ReplyWith(resp, http.StatusOK, api.DecryptKeyResponse{
-		Plaintext: key.HMACKey.Sum(body.Message),
+	api.ReplyWith(resp, http.StatusOK, api.HMACResponse{
+		Sum: key.HMACKey.Sum(body.Message),
 	})
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/minio/kes-go"
+	"github.com/minio/kms-go/kes"
 )
 
 // Self-signed, valid from Oct. 10 2023 until Oct 10 2050

--- a/state.go
+++ b/state.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"aead.dev/mem"
-	"github.com/minio/kes-go"
 	"github.com/minio/kes/internal/api"
 	"github.com/minio/kes/internal/metric"
+	"github.com/minio/kms-go/kes"
 )
 
 type serverState struct {


### PR DESCRIPTION
This commit adds tests for the HMAC server API.
It also removes enclave code that is no longer used nor supported.

Requires minio/kms-go#9