### PR TITLE
fix: set client CAs for mTLS auth

### DIFF
--- a/kesconf/file.go
+++ b/kesconf/file.go
@@ -150,6 +150,7 @@ func (f *File) TLSConfig() (*tls.Config, error) {
 		Certificates: []tls.Certificate{certificate},
 		NextProtos:   []string{"h2", "http/1.1"},
 		RootCAs:      rootCAs,
+		ClientCAs:    rootCAs,
 	}, nil
 }
 


### PR DESCRIPTION
The new TLS config introduced in #414 does not set client CAs. So when enabling mTLS authentication, client requests fail with `tls: failed to verify certificate: x509: certificate signed by unknown authority`.
This PR fixes this by using the root CAs also for authenticating mTLS clients, like before:
https://github.com/minio/kes/blob/9d1b5ad6dbdd963beabfbc91eb1ca0d330d5cd3d/cmd/kes/gateway.go#L526