### PR TITLE
fix:  AWS status check within KES

### DIFF
--- a/internal/keystore/aws/secrets-manager.go
+++ b/internal/keystore/aws/secrets-manager.go
@@ -112,9 +112,12 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	if _, err = http.DefaultClient.Do(req); err != nil {
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
+	defer res.Body.Close()
+	
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil


### PR DESCRIPTION
the returned response body is not closed casued the file descriptor exceed the system limit