### PR TITLE
azure: Close http response body

### DIFF
--- a/internal/keystore/azure/client.go
+++ b/internal/keystore/azure/client.go
@@ -73,6 +73,7 @@ func (c *client) CreateSecret(ctx context.Context, name, value string) (status, 
 	if err != nil {
 		return status{}, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
 		return status{
 			StatusCode: http.StatusOK,
@@ -133,6 +134,7 @@ func (c *client) GetSecret(ctx context.Context, name, version string) (string, s
 	if err != nil {
 		return "", status{}, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		response, err := parseErrorResponse(resp)
 		if err != nil {
@@ -207,6 +209,7 @@ func (c *client) DeleteSecret(ctx context.Context, name string) (status, error) 
 	if err != nil {
 		return status{}, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode != http.StatusOK {
 			response, err := parseErrorResponse(resp)
@@ -245,6 +248,7 @@ func (c *client) PurgeSecret(ctx context.Context, name string) (status, error) {
 	if err != nil {
 		return status{}, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		response, err := parseErrorResponse(resp)
 		if err != nil {
@@ -296,6 +300,7 @@ func (c *client) GetFirstVersion(ctx context.Context, name string) (string, stat
 	if err != nil {
 		return "", status{}, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		response, err := parseErrorResponse(resp)
 		if err != nil {
@@ -379,6 +384,7 @@ func (c *client) ListSecrets(ctx context.Context, nextLink string) ([]string, st
 	if err != nil {
 		return nil, "", status{}, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		response, err := parseErrorResponse(resp)
 		if err != nil {

--- a/internal/keystore/azure/key-vault.go
+++ b/internal/keystore/azure/key-vault.go
@@ -53,9 +53,11 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	if _, err = http.DefaultClient.Do(req); err != nil {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
+	resp.Body.Close()
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil


### PR DESCRIPTION
Closing the http response body seems to be forgotten in the Azure KeyVault 
KMS backend. This commit fixes it.