### PR TITLE
keystore: fix conn leak in {AWS,GCP,Fortanx,Gemalto} backend

### DIFF
--- a/internal/keystore/aws/secrets-manager.go
+++ b/internal/keystore/aws/secrets-manager.go
@@ -112,9 +112,12 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	if _, err = http.DefaultClient.Do(req); err != nil {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
+	defer resp.Body.Close()
+
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil

--- a/internal/keystore/azure/key-vault.go
+++ b/internal/keystore/azure/key-vault.go
@@ -57,7 +57,8 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil

--- a/internal/keystore/fortanix/keystore.go
+++ b/internal/keystore/fortanix/keystore.go
@@ -189,9 +189,12 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	if _, err = http.DefaultClient.Do(req); err != nil {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
+	defer resp.Body.Close()
+
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil

--- a/internal/keystore/gcp/secret-manager.go
+++ b/internal/keystore/gcp/secret-manager.go
@@ -112,9 +112,12 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	if _, err = http.DefaultClient.Do(req); err != nil {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
+	defer resp.Body.Close()
+
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil

--- a/internal/keystore/gemalto/key-secure.go
+++ b/internal/keystore/gemalto/key-secure.go
@@ -122,9 +122,12 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	if _, err = http.DefaultClient.Do(req); err != nil {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}
+	defer resp.Body.Close()
+
 	return kes.KeyStoreState{
 		Latency: time.Since(start),
 	}, nil


### PR DESCRIPTION
This commit fixes a TCP conn leak in the AWS, GCP, Fortanix and Gemalto KMS backend. Due to a missing `http.Response.Body.Close` call, the status check in these backends accumulated TCP connections that are not closed by the runtime.

This resource leak can cause OOM issues.

Fixes #445