### PR TITLE
Vault client ignore errors on return

### DIFF
--- a/internal/keystore/vault/client.go
+++ b/internal/keystore/vault/client.go
@@ -83,7 +83,7 @@ func (c *client) AuthenticateWithAppRole(login *AppRole) authFunc {
 			"role_id":   login.ID,
 			"secret_id": login.Secret,
 		})
-		if secret == nil {
+		if secret == nil && err == nil {
 			// The Vault SDK eventually returns no error but also no
 			// secret. In this case have to return a (not very helpful)
 			// error to signal that the authentication failed - for some
@@ -108,7 +108,7 @@ func (c *client) AuthenticateWithK8S(login *Kubernetes) authFunc {
 			"role": login.Role,
 			"jwt":  login.JWT,
 		})
-		if secret == nil {
+		if secret == nil && err == nil {
 			// The Vault SDK eventually returns no error but also no
 			// secret. In this case have to return a (not very helpful)
 			// error to signal that the authentication failed - for some


### PR DESCRIPTION
It looks like vault client overrides error in case if it is returned, and return unhelpful message instead.

This PR adds check if `err` is in fact `nil` before returning custom error.