### PR TITLE
keystore: use pre-configured client for {Gemalto,Fortanix} status check

### DIFF
--- a/internal/keystore/fortanix/keystore.go
+++ b/internal/keystore/fortanix/keystore.go
@@ -189,7 +189,7 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}

--- a/internal/keystore/gemalto/key-secure.go
+++ b/internal/keystore/gemalto/key-secure.go
@@ -122,7 +122,7 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	}
 
 	start := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return kes.KeyStoreState{}, &keystore.ErrUnreachable{Err: err}
 	}


### PR DESCRIPTION
This commit fixes an issue on the Gemalto and Fortanix status checks. Before, the status check for both backends used the `http.DefaultClient`. This can cause TLS verification issues when the backend uses certificate not issued by one of the server's root CAs - e.g. with a custom root CA.

Now, the status check uses the HTTP client used for other API calls, like creating a key, with a TLS configuration provided to the server.