### PR TITLE
Remove 'rm' from list

### DIFF
--- a/cmd/kes/policy.go
+++ b/cmd/kes/policy.go
@@ -27,7 +27,6 @@ const policyCmdUsage = `Usage:
 Commands:
     info                     Get information about a policy.
     ls                       List policies.
-    rm                       Remove a policy.
     show                     Display a policy.
 
 Options:


### PR DESCRIPTION
Remove the non-existing `rm` subcommand from the `policy` command.