### PR TITLE
vault: improve Vault API interaction

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.9
+        go-version: 1.22.2
         check-latest: true
       id: go
     - name: Check out code
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.9
+          go-version: 1.22.2
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.9
+        go-version: 1.22.2
         check-latest: true
       id: go
     - name: Check out code
@@ -74,7 +74,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.21.9
+        go-version: 1.22.2
         check-latest: true
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.9
+          go-version: 1.22.2
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
This commit improves the Vault API interaction by
using the `vaultapi.KVv1` and `vaultapi.KVv2` types where possible. This simplifies the `List`, `Delete` and `Get` APIs.

Further, this commit changes the `List` API implementation by using HTTP GET instead of LIST. This is a workaround that prevents listing errors caused by some middleware/firewalls. Such systems may reject API calls with "non-standard" HTTP methods.