### PR TITLE
cmd/kes: add support for migrating keys to minkms

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.22.2
+        go-version: 1.22.4
         check-latest: true
       id: go
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build and Lint
       env:
         GO111MODULE: on
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Set up Go"
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
         id: go
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          args: --config ./.golangci.yml --timeout=2m
+          args: --config ./.golangci.yml --timeout=5m
   test:
     name: Test ${{ matrix.os }}
     needs: Lint
@@ -52,13 +52,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.22.2
+        go-version: 1.22.4
         check-latest: true
       id: go
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Test
       env:
         GO111MODULE: on
@@ -70,14 +70,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.9, 1.22.3]
+        go-version: [1.21.11, 1.22.4]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -30,4 +30,4 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --skip-publish --skip-sign --clean --snapshot --skip-before
+          args: release --skip=publish,sign,before --clean --snapshot

--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -71,7 +71,7 @@ func main() {
 		"status": statusCmd,
 		"metric": metricCmd,
 
-		"migrate": migrateCmd,
+		"migrate": migrate,
 		"update":  updateCmd,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0
 	github.com/aws/aws-sdk-go v1.52.1
 	github.com/charmbracelet/lipgloss v0.10.0
-	github.com/fatih/color v1.16.0
 	github.com/hashicorp/vault/api v1.13.0
 	github.com/minio/kms-go/kes v0.3.1-0.20240226133855-0dfed1a72132
+	github.com/minio/kms-go/kms v0.4.0
 	github.com/minio/selfupdate v0.6.0
 	github.com/muesli/termenv v0.15.2
 	github.com/prometheus/client_golang v1.19.0
@@ -64,7 +64,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,7 +145,6 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -153,6 +152,8 @@ github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZ
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/minio/kms-go/kes v0.3.1-0.20240226133855-0dfed1a72132 h1:0J9XIk73q+EaZ7hR0XC6ZZ4hXLeqlvwGrZjQbrN1k4o=
 github.com/minio/kms-go/kes v0.3.1-0.20240226133855-0dfed1a72132/go.mod h1:w6DeVT878qEOU3nUrYVy1WOT5H1Ig9hbDIh698NYJKY=
+github.com/minio/kms-go/kms v0.4.0 h1:cLPZceEp+05xHotVBaeFJrgL7JcXM4lBy6PU0idkE7I=
+github.com/minio/kms-go/kms v0.4.0/go.mod h1:q12CehiIy2qgBnDKq6Q7wmPi2PHSyRVug5DKp0HAVeE=
 github.com/minio/selfupdate v0.6.0 h1:i76PgT0K5xO9+hjzKcacQtO7+MjJ4JKA8Ak8XQ9DDwU=
 github.com/minio/selfupdate v0.6.0/go.mod h1:bO02GTIPCMQFTEvE5h4DjYB58bCoZ35XLeBf0buTDdM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -258,7 +259,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=

--- a/internal/cli/exit.go
+++ b/internal/cli/exit.go
@@ -28,3 +28,17 @@ func Exitf(format string, args ...any) {
 	fmt.Fprintln(os.Stderr, s+fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
+
+// Assert calls Exit if the statement is false.
+func Assert(statement bool, args ...any) {
+	if !statement {
+		Exit(args...)
+	}
+}
+
+// Assertf calls Exitf if the statement is false.
+func Assertf(statement bool, format string, args ...any) {
+	if !statement {
+		Exitf(format, args...)
+	}
+}

--- a/internal/crypto/key.go
+++ b/internal/crypto/key.go
@@ -249,6 +249,12 @@ func (s SecretKey) Type() SecretKeyType { return s.cipher }
 // and its ciphertext.
 func (s SecretKey) Overhead() int { return randSize + 16 }
 
+// Bytes returns the raw key bytes.
+func (s SecretKey) Bytes() []byte {
+	b := make([]byte, 0, len(s.key))
+	return append(b, s.key[:]...)
+}
+
 // Encrypt encrypts and authenticates the plaintext and
 // authenticates the associatedData.
 //


### PR DESCRIPTION
This commit adds support for migrating keys to minkms via the `kes migrate` command. Migrating all keys
of a KES backend to a MinKMS server can be done as following:
```
kes migrate --from src-config.yml --server 127.0.0.1:7373 --enclave minio --api-key k1:...
```

Currently, this implementation has the following limitations:
 - The HMAC key is not migrated. This requires support from MinKMS. However, HMAC keys are not used for S3 object encryption and have been added to KES recently.
 - Ciphertexts produced by KES cannot be decrypted auto. because they lack the key version prefix (e.g. 'v1:'). Future KES servers may use ciphertexts with key versions and MinKMS may accept a ciphertext without one.