### PR TITLE
Fix `identity new --ip` example

### DIFF
--- a/cmd/kes/identity.go
+++ b/cmd/kes/identity.go
@@ -200,7 +200,7 @@ Options:
 
 Examples:
     $ kes identity new
-    $ kes identity new --ip "192.168.0.182" --ip "10.0.0.92" localhost
+    $ kes identity new --ip "192.168.0.182" --ip "10.0.0.92" --key private.key --cert public.crt localhost
     $ kes identity new --key server.key --cert server.crt --encrypt --expiry 8760h kes-server.local
 `
 


### PR DESCRIPTION
Fix the `kes identity new --ip` example so it includes the `--key` and `--cert` options (required).