### PR TITLE
fix goroutine leak when reloading server config

### DIFF
--- a/keystore.go
+++ b/keystore.go
@@ -348,7 +348,7 @@ func (c *keyCache) List(ctx context.Context, prefix string, n int) ([]string, st
 // releases associated resources.
 func (c *keyCache) Close() error {
 	c.stop()
-	return nil
+	return c.store.Close()
 }
 
 // gc executes f periodically until the ctx.Done() channel returns.


### PR DESCRIPTION
This commit fixes a goroutine leak that occurs when reloading the server configuration.

During a config reload, the server establishes a 2nd connection to the backend keystore and replaces the existing connection with the newly opened one. The switch is performed atomically (without locking) to not block or abort ongoing requests.

Once the server has replaced the keystore connection, it closes it. Before this commit, the server stopped the in-memory key cache and its GC goroutines. However, it did not close any resources (goroutines/file descriptors) allocated by the replaced keystore. This commit fixes this.

The resource leak can only be observed when reloading the KES server config - i.e. using SIGHUP signals