### PR TITLE
vault: clone client TLS config and headers for status checks

### DIFF
--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -105,6 +105,8 @@ func Connect(ctx context.Context, c *Config) (*Store, error) {
 
 	config := vaultapi.DefaultConfig()
 	config.Address = c.Endpoint
+	config.CloneTLSConfig = true // Required for status checks
+	config.CloneToken = true     // Required for status checks
 	config.ConfigureTLS(tlsConfig)
 	vaultClient, err := vaultapi.NewClient(config)
 	if err != nil {
@@ -160,7 +162,7 @@ func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	// The Vault SDK should not set the X-Vault-Namespace header
 	// for root-only API paths.
 	// Otherwise, Vault may respond with: 404 - unsupported path
-	client, err := s.client.Clone()
+	client, err := s.client.CloneWithHeaders()
 	if err != nil {
 		return kes.KeyStoreState{}, err
 	}


### PR DESCRIPTION
This commit improves the Vault status check logic. KES has to clone the Vault client since it has to clear the namespace header for status checks.

However, KES should use the same TLS client config and token configured on the client when performing such status checks. KES has to opt-in to this behavior since the Vault SDK doesn't do this by default.