### PR TITLE
vault: renew token earlier

### DIFF
--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -131,7 +131,7 @@ func Connect(ctx context.Context, c *Config) (*Store, error) {
 		authenticate = client.AuthenticateWithK8S(c.K8S)
 	}
 
-	auth, err := authenticate()
+	auth, err := authenticate(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit changes the Vault token renewal logic to renew a token earlier than 10s before it expires. Now, if the token has a TTL > than 1m (or 30s) the token is renewed 1m (or 30s) before it expires.

This commit also adds a `context.Context` to the Vault authentication function.