### PR TITLE
vault: do not reuse TCP connections

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.5
+        go-version: 1.22.7
         check-latest: true
       id: go
     - name: Check out code
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.22.7
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.5
+        go-version: 1.22.7
         check-latest: true
       id: go
     - name: Check out code
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.12, 1.22.5]
+        go-version: [1.22.7, 1.23.1]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.22.7
           check-latest: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -108,6 +108,10 @@ func Connect(ctx context.Context, c *Config) (*Store, error) {
 	config.CloneTLSConfig = true // Required for status checks
 	config.CloneToken = true     // Required for status checks
 	config.ConfigureTLS(tlsConfig)
+	if tr, ok := config.HttpClient.Transport.(*http.Transport); ok {
+		tr.DisableKeepAlives = true
+		tr.MaxIdleConnsPerHost = -1
+	}
 	vaultClient, err := vaultapi.NewClient(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit disables TCP connection reuse for Vault. Apparently, TCP connections to Vault might hang if Vault gets shutdown forcefully.

The downside of this commit is that KES has to re-open a new TCP connection for every interaction with Vault. However, KES should not reach out to Vault most of the time. Hence, this change seems acceptable.