### PR TITLE
Make endpoint config optional in AWS secrets-manager keystore config

### DIFF
--- a/kesconf/config.go
+++ b/kesconf/config.go
@@ -571,9 +571,6 @@ func ymlToKeyStore(y *ymlFile) (KeyStore, error) {
 		if keystore != nil {
 			return nil, errors.New("kesconf: invalid keystore config: more than once keystore specified")
 		}
-		if y.KeyStore.AWS.SecretsManager.Endpoint.Value == "" {
-			return nil, errors.New("kesconf: invalid AWS secretsmanager keystore: no endpoint specified")
-		}
 		if y.KeyStore.AWS.SecretsManager.Region.Value == "" {
 			return nil, errors.New("kesconf: invalid AWS secretsmanager keystore: no region specified")
 		}

--- a/kesconf/config_test.go
+++ b/kesconf/config_test.go
@@ -285,3 +285,44 @@ func TestReadServerConfigYAML_AWS_NoCredentials(t *testing.T) {
 		t.Fatalf("Invalid secret key: got '%s' - want '%s'", aws.SessionToken, SessionToken)
 	}
 }
+
+func TestReadServerConfigYAML_AWS_NoEndpoint(t *testing.T) {
+	// The AWS SDK will use the pre-configured endpoints
+	// when no endpoint is specified in the config.
+
+	const (
+		Filename = "./testdata/aws-no-endpoint.yml"
+
+		Endpoint     = ""
+		Region       = "us-east-2"
+		AccessKey    = "AKIAIOSFODNN7EXAMPLE"
+		Secretkey    = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		SessionToken = ""
+	)
+
+	config, err := ReadFile(Filename)
+	if err != nil {
+		t.Fatalf("Failed to read file '%s': %v", Filename, err)
+	}
+
+	aws, ok := config.KeyStore.(*AWSSecretsManagerKeyStore)
+	if !ok {
+		var want *AWSSecretsManagerKeyStore
+		t.Fatalf("Invalid keystore: got type '%T' - want type '%T'", config.KeyStore, want)
+	}
+	if aws.Endpoint != Endpoint {
+		t.Fatalf("Invalid endpoint: got '%s' - want '%s'", aws.Endpoint, Endpoint)
+	}
+	if aws.Region != Region {
+		t.Fatalf("Invalid region: got '%s' - want '%s'", aws.Region, Region)
+	}
+	if aws.AccessKey != AccessKey {
+		t.Fatalf("Invalid access key: got '%s' - want '%s'", aws.AccessKey, AccessKey)
+	}
+	if aws.SecretKey != Secretkey {
+		t.Fatalf("Invalid secret key: got '%s' - want '%s'", aws.SecretKey, Secretkey)
+	}
+	if aws.SessionToken != SessionToken {
+		t.Fatalf("Invalid secret key: got '%s' - want '%s'", aws.SessionToken, SessionToken)
+	}
+}

--- a/kesconf/testdata/aws-no-endpoint.yml
+++ b/kesconf/testdata/aws-no-endpoint.yml
@@ -1,0 +1,18 @@
+version: v1
+
+address: 0.0.0.0:7373 
+
+admin:
+  identity: c84cc9b91ae2399b043da7eca616048d4b4200edf2ff418d8af3835911db945d
+
+tls:
+  key:      ./server.key  
+  cert:     ./server.cert  
+
+keystore:
+  aws:
+    secretsmanager:
+      region: us-east-2
+      credentials:
+        accesskey: AKIAIOSFODNN7EXAMPLE
+        secretkey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY


### PR DESCRIPTION
The AWS SDK contains a set of pre-configured endpoints. Make the endpoint config optional, and let the SDK decide what endpoint should be used. This fixes #495. See #495 about more details.

Maybe we should make the region optional too. Both can be autoconfigured by the SDK.