### PR TITLE
Use `GetClientCertificate` to ensure client certificate is sent

### DIFF
--- a/cmd/kes/main.go
+++ b/cmd/kes/main.go
@@ -238,7 +238,9 @@ func newClient(conf config) *kes.Client {
 	}
 
 	client := kes.NewClientWithConfig("", &tls.Config{
-		Certificates:       []tls.Certificate{cert},
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &cert, nil
+		},
 		InsecureSkipVerify: conf.InsecureSkipVerify,
 	})
 	client.Endpoints = endpoints


### PR DESCRIPTION
It looks like `tls.Config.Certificates` will not always send the client certificate.

The Go TLS code contains the following:
```go
func (c *Conn) getClientCertificate(cri *CertificateRequestInfo) (*Certificate, error) {
	if c.config.GetClientCertificate != nil {
		return c.config.GetClientCertificate(cri)
	}

	for _, chain := range c.config.Certificates {
		if err := cri.SupportsCertificate(&chain); err != nil {
			continue
		}
		return &chain, nil
	}

	// No acceptable certificate found. Don't send a certificate.
	return new(Certificate), nil
}
```
So if the certificate doesn't match the conditions in `cri.SupportsCertificate`, then it won't be sent.