### PR TITLE
vault: reset token TTL to 0 when renewing token

### DIFF
--- a/internal/keystore/vault/client.go
+++ b/internal/keystore/vault/client.go
@@ -196,6 +196,7 @@ func (c *client) RenewToken(ctx context.Context, authenticate authFunc, secret *
 		}
 
 		renewIn := 80 * (ttl / 100) // Renew token after 80% of its TTL has passed
+		ttl = 0                     // Set TTL to zero to trigger an immediate re-authentication in case of auth failure
 		select {
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
This commit resets the token TTL to zero once we start another re-authentication attempt. The reason is that if we fail to re-authenticate, we should not wait again for 80% of the prev. token TTL but instead re-authenticate right away.