### PR TITLE
docker: bump base image to ubi-micro:9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3 as build
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 as build
 
 RUN microdnf update -y --nodocs && microdnf install ca-certificates --nodocs
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.3
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5
 
 ARG TAG
 


### PR DESCRIPTION
The current base image was released in March 2024, and contains some vulnerabilities. This pull-request bumps the version in the `Dockerfile` from 9.3 to 9.5.

Overview of vulnerabilities in 9.3: https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58?image=65e0ac6949fc66cfe14185b4&architecture=amd64&container-tabs=security

Current 9.5 image: https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58?image=677fd3a0d6e3ce480e3c5e57&architecture=amd64