### PR TITLE
Bugfix: clear namespace for healthcheck request in CheckStatus

### DIFF
--- a/internal/keystore/vault/client.go
+++ b/internal/keystore/vault/client.go
@@ -54,9 +54,14 @@ func (c *client) CheckStatus(ctx context.Context, delay time.Duration) {
 	defer ticker.Stop()
 
 	for {
-		status, err := c.Sys().Health()
-		if err == nil {
-			c.sealed.Store(status.Sealed)
+		client, _ := c.CloneWithHeaders()
+		if client != nil {
+			// See vault.Store.Status() for more info on namespace handling.
+			client.ClearNamespace()
+			status, err := client.Sys().HealthWithContext(ctx)
+			if err == nil {
+				c.sealed.Store(status.Sealed)
+			}
 		}
 
 		select {

--- a/internal/keystore/vault/vault.go
+++ b/internal/keystore/vault/vault.go
@@ -164,7 +164,7 @@ func (s *Store) String() string { return "Hashicorp Vault: " + s.config.Endpoint
 func (s *Store) Status(ctx context.Context) (kes.KeyStoreState, error) {
 	// This is a workaround for https://github.com/hashicorp/vault/issues/14934
 	// The Vault SDK should not set the X-Vault-Namespace header
-	// for root-only API paths.
+	// for root-only API paths. Health is also checked in client.CheckStatus.
 	// Otherwise, Vault may respond with: 404 - unsupported path
 	client, err := s.client.CloneWithHeaders()
 	if err != nil {


### PR DESCRIPTION
The namespace was not cleared in this location, meaning errors are logged in Enterprise vault when a namespace is used. We are doing this healthcheck request twice: once in client.CheckStatus and again in Store.Status, maybe we can consolidate these? The Store.Status function was already fixed to clear namespace in a previous change.

