### PR TITLE
add `version` field to crypto requests/responses

### DIFF
--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -14,20 +14,24 @@ type ImportKeyRequest struct {
 type EncryptKeyRequest struct {
 	Plaintext []byte `json:"plaintext"`
 	Context   []byte `json:"context"` // optional
+	Version   string `json:"version"` // optional
 }
 
 // GenerateKeyRequest is the request sent by clients when calling the GenerateKey API.
 type GenerateKeyRequest struct {
 	Context []byte `json:"context"` // optional
+	Version string `json:"version"` // optional
 }
 
 // DecryptKeyRequest is the request sent by clients when calling the DecryptKey API.
 type DecryptKeyRequest struct {
 	Ciphertext []byte `json:"ciphertext"`
 	Context    []byte `json:"context"` // optional
+	Version    string `json:"version"` // optional
 }
 
 // HMACRequest is the request sent by clients when calling the HMAC API.
 type HMACRequest struct {
 	Message []byte `json:"message"`
+	Version string `json:"version"` // optional
 }

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -58,12 +58,14 @@ type ListKeysResponse struct {
 // EncryptKeyResponse is the response sent to clients by the EncryptKey API.
 type EncryptKeyResponse struct {
 	Ciphertext []byte `json:"ciphertext"`
+	Version    string `json:"version,omitempty"`
 }
 
 // GenerateKeyResponse is the response sent to clients by the GenerateKey API.
 type GenerateKeyResponse struct {
 	Plaintext  []byte `json:"plaintext"`
 	Ciphertext []byte `json:"ciphertext"`
+	Version    string `json:"version,omitempty"`
 }
 
 // DecryptKeyResponse is the response sent to clients by the DecryptKey API.
@@ -73,7 +75,8 @@ type DecryptKeyResponse struct {
 
 // HMACResponse is the response sent to clients by the HMAC API.
 type HMACResponse struct {
-	Sum []byte `json:"hmac"`
+	Sum     []byte `json:"hmac"`
+	Version string `json:"version,omitempty"`
 }
 
 // ReadPolicyResponse is the response sent to clients by the ReadPolicy API.


### PR DESCRIPTION
This commit adds a `Version` field to various request and response types that identifies a particular key version in a set of master keys.